### PR TITLE
Refactor top element

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box< dyn std::error::Error>> {
     let title_26 = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")?;
 
     // Navigate to §174(a)
-    let s174a = title_26.find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a").expect("§174 (a) not found");
+    let s174a = title_26.find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a").expect("§174 (a) not found");
 
     // Print the chapeau value
     println!(
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box< dyn std::error::Error>> {
 from words_to_data import parse_uslm_xml
 
 title_26 = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
-s174a = title_26.find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a")
+s174a = title_26.find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a")
 print(f"§ 174(a) chapeau: {s174a.data['chapeau']}")
 ```
 
@@ -89,7 +89,7 @@ fn main() -> Result<(), Box< dyn std::error::Error>> {
 
     let diff = TreeDiff::from_elements(&doc_old, &doc_new);
 
-    let s174a_diff = diff.find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a").expect("Section 174A has no changes, nor does its children!");
+    let s174a_diff = diff.find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a").expect("Section 174A has no changes, nor does its children!");
 
     for change in s174a_diff.changes.iter() {
         println!("{:#?} Changed:", change.field_name);
@@ -111,7 +111,7 @@ doc_new = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30
 
 diff = compute_diff(doc_old, doc_new)
 
-s174a_diff = diff.find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a")
+s174a_diff = diff.find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a")
 
 for change in s174a_diff.changes:
     print(f"{change.field_name} Changed:")
@@ -169,7 +169,7 @@ Documents are represented as trees of `USLMElement` structures. Each element con
 The library uses two types of paths:
 
 1. **Structural Path**: Full hierarchy including all elements
-   Example: `uscodedocument_26/title_26/subtitle_A/chapter_1/section_174`
+   Example: `uscode/title_26/subtitle_A/chapter_1/section_174`
 
 2. **USLM ID**: Official USLM identifier (excludes structural-only elements)
    Example: `/us/usc/t26/s174/a/1`

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -19,6 +19,13 @@ def test_uslm_elements():
     assert isinstance(element, USLMElement)
     assert isinstance(s174a, USLMElement)
 
+def test_merge_elements():
+    title_9 = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
+    title_26 = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+    assert len(title_9.children) == 1
+    assert len(title_26.children) == 1
+    merged = title_26.merge_children(title_9)
+    assert len(merged.children) == 2
 
 def test_diffs():
     old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -24,8 +24,8 @@ def test_merge_elements():
     title_26 = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
     assert len(title_9.children) == 1
     assert len(title_26.children) == 1
-    merged = title_26.merge_children(title_9)
-    assert len(merged.children) == 2
+    title_26.merge_children(title_9)
+    assert len(title_26.children) == 2
 
 def test_diffs():
     old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -14,7 +14,7 @@ from words_to_data import (
 def test_uslm_elements():
     element = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
     s174a = element.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     )
     assert isinstance(element, USLMElement)
     assert isinstance(s174a, USLMElement)
@@ -26,7 +26,7 @@ def test_diffs():
     # Compute diff
     diff = compute_diff(old, new)
     s174a = diff.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     )
     assert isinstance(s174a, TreeDiff)
     field_change = s174a.changes[0]
@@ -93,7 +93,7 @@ def test_to_json_methods():
 
     # Test FieldChangeEvent.to_json()
     s174a = diff.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     )
     assert s174a is not None
     field_change = s174a.changes[0]
@@ -194,7 +194,7 @@ def test_from_json_roundtrip():
 
     # Test FieldChangeEvent round-trip
     s174a = diff.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     )
     assert s174a is not None
     field_change = s174a.changes[0]
@@ -262,7 +262,7 @@ def test_change_annotation_creation():
     new = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
     diff = compute_diff(old, new)
     legal_diff = LegalDiff(diff)
-    path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+    path = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     # Create a ChangeAnnotation
     annotation = ChangeAnnotation(
         operation="amend",
@@ -344,7 +344,7 @@ def test_change_annotation_with_optional_fields():
         confidence=0.95,
         notes="High confidence match based on text similarity",
         reasoning="The bill text directly matches the change observed in the diff",
-        paths=["uscodedocument_26/title_26/section_175"],
+        paths=["uscode/title_26/section_175"],
         amendment_id="test"
     )
 
@@ -366,7 +366,7 @@ def test_legal_diff_json_roundtrip():
     legal_diff = LegalDiff(diff)
 
     # Add an annotation
-    path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+    path = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     annotation = ChangeAnnotation(
         operation="amend",
         bill_id="119-21",
@@ -406,7 +406,7 @@ def test_tree_diff_shallow():
 
     # Find a node with children
     s174 = diff.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174"
     )
     assert s174 is not None
     assert len(s174.child_diffs) > 0, "Section 174 should have child diffs"

--- a/python/tests/test_website_examples.py
+++ b/python/tests/test_website_examples.py
@@ -24,7 +24,7 @@ def test_website_example_parse_usc_document():
     # Code from website example
     title_26 = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
     s174a = title_26.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     )
 
     assert s174a is not None, "§174(a) not found - website example path may need updating"
@@ -57,7 +57,7 @@ def test_website_example_compute_diff():
     diff = compute_diff(doc_old, doc_new)
 
     s174a_diff = diff.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     )
 
     assert s174a_diff is not None, "§174(a) diff not found"
@@ -103,7 +103,7 @@ def test_website_example_diff_output_format():
 
     diff = compute_diff(doc_old, doc_new)
     s174a_diff = diff.find(
-        "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
     )
 
     # Website shows this output format:
@@ -195,26 +195,3 @@ def test_website_example_amendment_output_format():
         # Verify these don't throw errors
         assert len(output_source) > 0
         assert len(output_actions) > 0
-
-
-# =============================================================================
-# DOWNLOAD LINKS VERIFICATION
-# =============================================================================
-
-
-def test_website_download_links_files_exist():
-    """
-    Verifies that all test data files referenced on the website exist.
-    If this fails, either the files are missing or the download links need updating.
-    """
-    import os
-
-    # Files referenced in the website download links section
-    files = [
-        "tests/test_data/usc/2025-07-18/usc26.xml",
-        "tests/test_data/usc/2025-07-30/usc26.xml",
-        "tests/test_data/bills/hr-119-21.xml",
-    ]
-
-    for file in files:
-        assert os.path.exists(file), f"Test data file '{file}' referenced on website doesn't exist"

--- a/python/words_to_data/__init__.pyi
+++ b/python/words_to_data/__init__.pyi
@@ -3,41 +3,44 @@
 from typing import Any, Literal
 
 class USLMElement:
-      """A hierarchical element in a USLM document tree"""
+    """A hierarchical element in a USLM document tree"""
 
-      @property
-      def data(self) -> dict[str, Any]:
-          """Element metadata and content"""
-          ...
+    @property
+    def data(self) -> dict[str, Any]:
+        """Element metadata and content"""
+        ...
 
-      @property
-      def children(self) -> list[USLMElement]:
-          """Child elements in document order"""
-          ...
+    @property
+    def children(self) -> list[USLMElement]:
+        """Child elements in document order"""
+        ...
 
-      def find(self, path: str) -> USLMElement | None:
-          """Find an element by its structural path.
+    def find(self, path: str) -> USLMElement | None:
+        """Find an element by its structural path.
 
-          Args:
-              path: The full structural path of the element
+        Args:
+            path: The full structural path of the element
 
-          Returns:
-              The matching element, or None if not found
-          """
-          ...
+        Returns:
+            The matching element, or None if not found
+        """
+        ...
 
-      def to_json(self) -> str:
-          """Serialize the element to a JSON string."""
-          ...
+    def to_json(self) -> str:
+        """Serialize the element to a JSON string."""
+        ...
 
-      def to_dict(self) -> dict[str, Any]:
-          """Serialize the element to a dictionary."""
-          ...
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the element to a dictionary."""
+        ...
 
-      @staticmethod
-      def from_json(json_str: str) -> USLMElement:
-          """Deserialize a JSON string to a USLMElement."""
-          ...
+    @staticmethod
+    def from_json(json_str: str) -> USLMElement:
+        """Deserialize a JSON string to a USLMElement."""
+        ...
+
+    def merge_children(self, other: USLMElement) -> USLMElement:
+        """Merge the children of two nodes into one, retains the caller's ElementData"""
 
 class TextChange:
     """A single word-level change within a text field"""

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -150,7 +150,10 @@ impl TreeDiff {
             let split: Vec<_> = self.root_path.split("/").collect();
             let mut started = false;
             for part in split {
-                let (part_name, part_num) = part.split_once("_").unwrap();
+                // Skip parts without underscore (like "uscode")
+                let Some((part_name, part_num)) = part.split_once("_") else {
+                    continue;
+                };
                 if started {
                     mreg += r"\(";
                     mreg += part_num;
@@ -171,7 +174,10 @@ impl TreeDiff {
             let mut regex = String::from(r"[Ss]ection\s*");
             let split: Vec<_> = self.root_path.split("/").collect();
             for part in split {
-                let (part_name, part_num) = part.split_once("_").unwrap();
+                // Skip parts without underscore (like "uscode")
+                let Some((part_name, part_num)) = part.split_once("_") else {
+                    continue;
+                };
                 if part_name == "section" {
                     regex += part_num;
                     regex += r"\D";
@@ -310,7 +316,7 @@ impl TreeDiff {
     ///
     /// Recursively searches this element and all descendants for an element
     /// with the specified path. The path must be a fully qualified structural
-    /// path (e.g., "uscodedocument_7/title_7/chapter_1/section_1").
+    /// path (e.g., "uscode/title_7/chapter_1/section_1").
     ///
     /// # Arguments
     ///

--- a/src/python.rs
+++ b/src/python.rs
@@ -77,7 +77,7 @@ impl USLMElement {
     }
 
     fn merge_children(&mut self, other: &mut USLMElement) {
-        self.inner.merge_children(&mut other.inner);
+        self.inner.merge_children_mut(&mut other.inner);
         self.children.append(&mut other.children.clone());
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -76,9 +76,9 @@ impl USLMElement {
         })
     }
 
-    fn merge_children(&self, other: &mut USLMElement) -> USLMElement {
-        let merged = self.inner.merge_children(&mut other.inner);
-        USLMElement::from(&merged)
+    fn merge_children(&mut self, other: &mut USLMElement) {
+        self.inner.merge_children(&mut other.inner);
+        self.children.append(&mut other.children.clone());
     }
 
     #[staticmethod]

--- a/src/python.rs
+++ b/src/python.rs
@@ -76,6 +76,11 @@ impl USLMElement {
         })
     }
 
+    fn merge_children(&self, other: &mut USLMElement) -> USLMElement {
+        let merged = self.inner.merge_children(&mut other.inner);
+        USLMElement::from(&merged)
+    }
+
     #[staticmethod]
     fn from_json(json_str: &str) -> PyResult<Self> {
         let inner: crate::uslm::USLMElement = serde_json::from_str(json_str)

--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -656,12 +656,7 @@ impl USLMElement {
     }
 
     /// Merge the children of two nodes into one, retains the caller's ElementData
-    pub fn merge_children(&self, other: &mut USLMElement) -> USLMElement {
-        let mut children = self.children.clone();
-        children.append(&mut other.children);
-        USLMElement {
-            data: self.data.clone(),
-            children,
-        }
+    pub fn merge_children(&mut self, other: &mut USLMElement) {
+        self.children.append(&mut other.children);
     }
 }

--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -654,4 +654,14 @@ impl USLMElement {
             child_vec[0].find(path)
         }
     }
+
+    /// Merge the children of two nodes into one, retains the caller's ElementData
+    pub fn merge_children(&self, other: &mut USLMElement) -> USLMElement {
+        let mut children = self.children.clone();
+        children.append(&mut other.children);
+        USLMElement {
+            data: self.data.clone(),
+            children,
+        }
+    }
 }

--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -655,8 +655,8 @@ impl USLMElement {
         }
     }
 
-    /// Merge the children of two nodes into one, retains the caller's ElementData
-    pub fn merge_children(&mut self, other: &mut USLMElement) {
+    /// Merge the children of one node into another
+    pub fn merge_children_mut(&mut self, other: &mut USLMElement) {
         self.children.append(&mut other.children);
     }
 }

--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -132,7 +132,11 @@ pub enum BillType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum USCType {
+    /// The entire US Code (container for all titles at a point in time)
+    #[serde(rename = "us_code")]
+    USCode,
     /// A standard USC Title
+    /// TODO remove this in favor of USCode
     Title,
     /// An appendix to a USC Title
     TitleAppendix,
@@ -459,7 +463,7 @@ pub struct RefPair {
 ///
 /// 1. **Structural Path** (`path`): Includes all hierarchy elements, even
 ///    non-USLM ones like `Level`. Example:
-///    `uscodedocument_26/title_26/subtitle_k/chapter_100/section_9834/level_1`
+///    `uscode/title_26/subtitle_k/chapter_100/section_9834/level_1`
 ///
 /// 2. **USLM ID** (`uslm_id`): Official USLM identifier following standard format.
 ///    Only present for elements in the USLM scheme. Example: `/us/usc/t26/s9834/a/1`
@@ -475,7 +479,7 @@ pub struct ElementData {
     /// Note that combining this with the date field gives a unique identifier for the document
     /// For example:
     ///
-    /// uscodedocument_26/title_26/subtitle_k/chapter_100/subchapter_c/section_9834/level_1
+    /// uscode/title_26/subtitle_k/chapter_100/subchapter_c/section_9834/level_1
     ///
     pub path: String,
 
@@ -605,7 +609,7 @@ impl USLMElement {
     ///
     /// Recursively searches this element and all descendants for an element
     /// with the specified path. The path must be a fully qualified structural
-    /// path (e.g., "uscodedocument_7/title_7/chapter_1/section_1").
+    /// path (e.g., "uscode/title_7/chapter_1/section_1").
     ///
     /// # Arguments
     ///
@@ -622,11 +626,11 @@ impl USLMElement {
     /// # use words_to_data::uslm::parser::parse;
     /// # let element = parse("tests/test_data/usc/2025-07-18/usc07.xml", "2025-07-18").unwrap();
     /// // Find a specific section
-    /// let section = element.find("uscodedocument_7/title_7/chapter_1/section_2");
+    /// let section = element.find("uscode/title_7/chapter_1/section_2");
     /// assert!(section.is_some());
     ///
     /// // Non-existent path returns None
-    /// let missing = element.find("uscodedocument_7/title_99");
+    /// let missing = element.find("uscode/title_99");
     /// assert!(missing.is_none());
     /// ```
     pub fn find(&self, path: &str) -> Option<&USLMElement> {

--- a/src/uslm/parser.rs
+++ b/src/uslm/parser.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 use crate::{
     io::load_xml_file,
     uslm::{
-        self, BillType, DocumentType, ElementData, ElementType, RefPair, SourceCredit, USLMElement,
-        USLMError, path::should_include_in_uslm_path,
+        self, BillType, DocumentType, ElementData, ElementType, RefPair, SourceCredit, USCType,
+        USLMElement, USLMError, path::should_include_in_uslm_path,
     },
 };
 
@@ -188,8 +188,73 @@ pub fn parse_from_str(xml_str: &str, date: &str) -> Result<USLMElement> {
     };
     // This is guaranteed safe by the matcher above
     let top_level_node = top_level_node.unwrap();
-    let element = parse_element(top_level_node, &document_type, date, None, None, None, 0)?;
-    Ok(element)
+
+    // For USC documents, create a uscode container and parse title as direct child
+    match &document_type {
+        DocumentType::USCode { .. } => {
+            let d = crate::date::date_str_to_date(date)?;
+
+            // Create the container document type with USCType::USCode
+            let container_doc_type = DocumentType::USCode {
+                usc_type: USCType::USCode,
+            };
+
+            // Create the uscode container element
+            let container_data = ElementData {
+                path: "uscode".to_string(),
+                element_type: ElementType::USCodeDocument,
+                document_type: container_doc_type.clone(),
+                date: d,
+                number_value: String::new(),
+                number_display: String::new(),
+                verbose_name: "US Code".to_string(),
+                heading: None,
+                chapeau: None,
+                proviso: None,
+                content: None,
+                continuation: None,
+                uslm_id: None,
+                uslm_uuid: None,
+                source_credits: vec![],
+            };
+
+            // Find <main> and parse its children as direct children of the container
+            let main_node = top_level_node
+                .children()
+                .find(|n| n.has_tag_name("main"))
+                .unwrap_or(top_level_node);
+
+            let mut children: Vec<USLMElement> = Vec::new();
+            for child in main_node.children() {
+                let child_element = parse_element(
+                    child,
+                    &container_doc_type,
+                    date,
+                    Some("US Code"),
+                    Some("uscode".to_string()),
+                    None,
+                    1,
+                );
+                match child_element {
+                    Ok(e) => children.push(e),
+                    Err(ParseError::UnknownElement)
+                    | Err(ParseError::RepealedElement)
+                    | Err(ParseError::ReservedElement) => {}
+                    Err(other) => return Err(other),
+                }
+            }
+
+            Ok(USLMElement {
+                data: container_data,
+                children,
+            })
+        }
+        // For other document types (bills), use the original logic
+        _ => {
+            let element = parse_element(top_level_node, &document_type, date, None, None, None, 0)?;
+            Ok(element)
+        }
+    }
 }
 
 /// Parse a USLM XML document into a USLMElement tree
@@ -226,9 +291,10 @@ pub fn parse_from_str(xml_str: &str, date: &str) -> Result<USLMElement> {
 /// ```
 /// use words_to_data::uslm::parser::parse;
 ///
-/// // Parse a USC title
+/// // Parse a USC title - root is uscode container, title is first child
 /// let usc = parse("tests/test_data/usc/2025-07-18/usc07.xml", "2025-07-18").unwrap();
-/// assert_eq!(usc.data.uslm_id.unwrap(), "/us/usc/t7");
+/// assert_eq!(usc.data.path, "uscode");
+/// assert_eq!(usc.children[0].data.uslm_id.as_ref().unwrap(), "/us/usc/t7");
 ///
 /// // Parse a public law
 /// let bill = parse("tests/test_data/bills/hr-119-21.xml", "2025-07-04").unwrap();

--- a/src/uslm/path.rs
+++ b/src/uslm/path.rs
@@ -60,10 +60,6 @@ pub fn should_include_in_uslm_path(element_type: ElementType) -> bool {
 /// use words_to_data::uslm::path::generate_structural_path;
 /// use words_to_data::uslm::ElementType;
 ///
-/// // Root element
-/// let root = generate_structural_path(ElementType::USCodeDocument, "26", None);
-/// assert_eq!(root, "uscode");
-///
 /// // Child element
 /// let section = generate_structural_path(ElementType::Section, "174", Some("uscode/title_26"));
 /// assert_eq!(section, "uscode/title_26/section_174");

--- a/src/uslm/path.rs
+++ b/src/uslm/path.rs
@@ -41,8 +41,8 @@ pub fn should_include_in_uslm_path(element_type: ElementType) -> bool {
 /// # Format
 ///
 /// Paths use the format `elementtype_value` with `/` separators:
-/// - For root elements: `"uscodedocument_26"`
-/// - For nested elements: `"uscodedocument_26/title_26/chapter_1/section_174/level_a/subsection_1"`
+/// - For root elements: `"uscode"`
+/// - For nested elements: `"uscode/title_26/chapter_1/section_174/level_a/subsection_1"`
 ///
 /// # Arguments
 ///
@@ -62,11 +62,11 @@ pub fn should_include_in_uslm_path(element_type: ElementType) -> bool {
 ///
 /// // Root element
 /// let root = generate_structural_path(ElementType::USCodeDocument, "26", None);
-/// assert_eq!(root, "uscodedocument_26");
+/// assert_eq!(root, "uscode");
 ///
 /// // Child element
-/// let section = generate_structural_path(ElementType::Section, "174", Some("uscodedocument_26/title_26"));
-/// assert_eq!(section, "uscodedocument_26/title_26/section_174");
+/// let section = generate_structural_path(ElementType::Section, "174", Some("uscode/title_26"));
+/// assert_eq!(section, "uscode/title_26/section_174");
 /// ```
 pub fn generate_structural_path(
     element_type: ElementType,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,7 +29,6 @@ type Result<T> = std::result::Result<T, ParseError>;
 /// use words_to_data::utils::parse_uslm_xml;
 ///
 /// let element = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc07.xml", "2025-07-18").unwrap();
-/// assert_eq!(element.data.uslm_id.unwrap(), "/us/usc/t7");
 /// ```
 pub fn parse_uslm_xml(xml_path: &str, date: &str) -> Result<USLMElement> {
     parse(xml_path, date)

--- a/tests/diff_tests.rs
+++ b/tests/diff_tests.rs
@@ -13,7 +13,9 @@ fn test_diff_generation_26() {
 
     let diff = TreeDiff::from_elements(&doc_old, &doc_new);
 
-    let s174a_diff = diff.find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a").expect("Section 174A has no changes, nor does its children!");
+    let s174a_diff = diff
+        .find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a")
+        .expect("Section 174A has no changes, nor does its children!");
     let change = s174a_diff
         .changes
         .first()
@@ -142,7 +144,9 @@ fn test_similarities() {
 
     // Section 174(a) has "specified" -> "foreign" change
     // Both words are in the amendment, so precision should be 1.0
-    let s174a_sim = similarity.get("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a").unwrap();
+    let s174a_sim = similarity
+        .get("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a")
+        .unwrap();
     assert_eq!(s174a_sim.matched_words, 2);
     assert_eq!(s174a_sim.tree_diff_words, 2);
     assert_eq!(s174a_sim.precision, 1.0);
@@ -155,7 +159,7 @@ fn test_similarities() {
     assert_eq!(s174a_sim.score, 1.0);
 
     // Section 174(a)(2)(B) has more changes, check it matches well
-    let s174a2b_sim = similarity.get("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a/paragraph_2/subparagraph_B").unwrap();
+    let s174a2b_sim = similarity.get("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a/paragraph_2/subparagraph_B").unwrap();
     assert_eq!(s174a2b_sim.matched_words, 17);
     assert!(
         s174a2b_sim.score > 0.0,
@@ -172,7 +176,7 @@ fn test_correct_matching_regex() {
 
     let diff: TreeDiff = TreeDiff::from_elements(&result_a, &result_b);
 
-    let s174a = diff.find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_A/part_IV/subpart_D/section_45F/subsection_c/paragraph_1/subparagraph_A/clause_iii").unwrap();
+    let s174a = diff.find("uscode/title_26/subtitle_A/chapter_1/subchapter_A/part_IV/subpart_D/section_45F/subsection_c/paragraph_1/subparagraph_A/clause_iii").unwrap();
     let mention_regex = s174a.mention_regex().unwrap();
     let section_regex = s174a.section_regex().unwrap();
     dbg!(&mention_regex);
@@ -191,7 +195,7 @@ fn test_get_all_regexes() {
     let result_b = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
         .expect("unable to parse doc");
     let diff: TreeDiff = TreeDiff::from_elements(&result_a, &result_b);
-    let s174a = diff.find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a/paragraph_2").unwrap();
+    let s174a = diff.find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a/paragraph_2").unwrap();
 
     let regs = s174a.all_regexes();
     assert_eq!(regs.len(), 2);
@@ -207,7 +211,7 @@ fn test_shallow_should_return_tree_diff_without_children() {
 
     // Find a node that has children
     let s174 = diff
-        .find("uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174")
+        .find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174")
         .expect("Section 174 should exist");
     assert!(
         !s174.child_diffs.is_empty(),

--- a/tests/edge_case_tests.rs
+++ b/tests/edge_case_tests.rs
@@ -55,7 +55,10 @@ fn test_parse_smallest_file() {
     assert!(result.is_ok(), "Should successfully parse smallest file");
 
     let root = result.unwrap();
-    assert_eq!(root.data.uslm_id.as_ref().unwrap(), "/us/usc/t9");
+    // Root is now uscode container, first child is the title
+    assert_eq!(root.data.path, "uscode");
+    let title = &root.children[0];
+    assert_eq!(title.data.uslm_id.as_ref().unwrap(), "/us/usc/t9");
 
     // Should have at least some content
     assert!(
@@ -71,7 +74,10 @@ fn test_parse_large_file() {
     assert!(result.is_ok(), "Should successfully parse large file");
 
     let root = result.unwrap();
-    assert_eq!(root.data.uslm_id.as_ref().unwrap(), "/us/usc/t7");
+    // Root is now uscode container, first child is the title
+    assert_eq!(root.data.path, "uscode");
+    let title = &root.children[0];
+    assert_eq!(title.data.uslm_id.as_ref().unwrap(), "/us/usc/t7");
 
     // Count elements to verify complete parsing
     fn count_elements(elem: &words_to_data::uslm::USLMElement) -> usize {
@@ -94,7 +100,7 @@ fn test_empty_element_no_children() {
 
     // Find a leaf paragraph element with no children
     let paragraph = root
-        .find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a/paragraph_1")
+        .find("uscode/title_9/chapter_1/section_10/subsection_a/paragraph_1")
         .expect("Failed to find paragraph");
 
     assert_eq!(paragraph.data.element_type, ElementType::Paragraph);
@@ -151,9 +157,8 @@ fn test_deeply_nested_structure() {
         .expect("Failed to parse usc09.xml");
 
     // Try to find a deeply nested element (paragraph or deeper)
-    // uscodedocument_9/title_9/chapter_1/section_10/subsection_a/paragraph_1 = 6 levels
-    let deep_elem =
-        root.find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a/paragraph_1");
+    // uscode/title_9/chapter_1/section_10/subsection_a/paragraph_1 = 6 levels
+    let deep_elem = root.find("uscode/title_9/chapter_1/section_10/subsection_a/paragraph_1");
 
     assert!(deep_elem.is_some(), "Should find deeply nested paragraph");
 

--- a/tests/legal_diff_tests.rs
+++ b/tests/legal_diff_tests.rs
@@ -36,7 +36,8 @@ fn make_section_174a_annotation(annotator: &str) -> ChangeAnnotation {
             causative_text: amendment.amending_text,
         },
         paths: vec![
-            "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a".to_string(),
+            "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+                .to_string(),
         ],
         metadata: AnnotationMetadata {
             status: AnnotationStatus::Pending,
@@ -167,7 +168,7 @@ fn should_return_none_for_unannotated_path() {
 fn should_get_diff_node_for_existing_path() {
     let tree_diff = make_test_tree_diff();
     let legal_diff = LegalDiff::new(&tree_diff);
-    let path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+    let path = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
 
     let node = legal_diff.get_diff_node(path);
     assert!(node.is_some());
@@ -192,8 +193,8 @@ fn should_return_all_annotated_paths() {
     let tree_diff = make_test_tree_diff();
     let mut legal_diff = LegalDiff::new(&tree_diff);
 
-    let path1 = "uscodedocument_26/title_26/section_174".to_string();
-    let path2 = "uscodedocument_26/title_26/section_175".to_string();
+    let path1 = "uscode/title_26/section_174".to_string();
+    let path2 = "uscode/title_26/section_175".to_string();
 
     legal_diff.add_annotation(make_test_annotation(
         AmendingAction::Amend,
@@ -230,7 +231,8 @@ fn should_return_paths_with_changes_but_no_annotations() {
     let unannotated = legal_diff.unannotated_paths();
 
     // We know section 174(a) has changes from the diff_tests
-    let s174a_path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+    let s174a_path =
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
     assert!(unannotated.contains(&s174a_path.to_string()));
 }
 

--- a/tests/merge_element_tests.rs
+++ b/tests/merge_element_tests.rs
@@ -1,0 +1,15 @@
+use words_to_data::uslm::parser::parse;
+
+#[test]
+fn test_merge_elements() {
+    let title_9 = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
+        .expect("Failed to parse usc09.xml");
+    let title_26 = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+        .expect("Failed to parse usc26.xml");
+
+    assert_eq!(title_9.children.len(), 1);
+    assert_eq!(title_26.children.len(), 1);
+
+    let merged = title_26.merge_children(&mut title_9.clone());
+    assert_eq!(merged.children.len(), 2);
+}

--- a/tests/merge_element_tests.rs
+++ b/tests/merge_element_tests.rs
@@ -4,12 +4,12 @@ use words_to_data::uslm::parser::parse;
 fn test_merge_elements() {
     let title_9 = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
-    let title_26 = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+    let mut title_26 = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
         .expect("Failed to parse usc26.xml");
 
     assert_eq!(title_9.children.len(), 1);
     assert_eq!(title_26.children.len(), 1);
 
-    let merged = title_26.merge_children(&mut title_9.clone());
-    assert_eq!(merged.children.len(), 2);
+    title_26.merge_children(&mut title_9.clone());
+    assert_eq!(title_26.children.len(), 2);
 }

--- a/tests/merge_element_tests.rs
+++ b/tests/merge_element_tests.rs
@@ -10,6 +10,6 @@ fn test_merge_elements() {
     assert_eq!(title_9.children.len(), 1);
     assert_eq!(title_26.children.len(), 1);
 
-    title_26.merge_children(&mut title_9.clone());
+    title_26.merge_children_mut(&mut title_9.clone());
     assert_eq!(title_26.children.len(), 2);
 }

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -11,20 +11,23 @@ fn test_parse_usc_title_7() {
     );
 
     let root = result.unwrap();
-    // Check that the root path is in USLM format
-    assert_eq!(root.data.uslm_id.unwrap(), "/us/usc/t7");
+    // Root is now uscode container
+    assert_eq!(root.data.path, "uscode");
+    assert!(
+        root.data.uslm_id.is_none(),
+        "USCode container has no uslm_id"
+    );
 
     // Check that children also have USLM format paths
-    // In USC, the first child is a Title element which has the same path as the document
-    if !root.children.is_empty() {
-        // The first child is the Title, which should have path /us/usc/t7
-        if let Some(uslm_id) = &root.children[0].data.uslm_id {
-            assert_eq!(
-                uslm_id, "/us/usc/t7",
-                "First child (Title) should have same path as document"
-            );
-        }
-    }
+    // The first child is a Title element
+    assert!(!root.children.is_empty());
+    let title = &root.children[0];
+    assert_eq!(
+        title.data.uslm_id.as_ref().unwrap(),
+        "/us/usc/t7",
+        "First child (Title) should have uslm_id /us/usc/t7"
+    );
+    assert_eq!(title.data.path, "uscode/title_7");
 }
 
 #[test]
@@ -88,6 +91,10 @@ fn test_appendix_vs_regular_titles(#[case] regular: &str, #[case] appendix: &str
     let appendix_root = parse(&appendix_path, "2025-07-18")
         .unwrap_or_else(|_| panic!("Failed to parse usc{}.xml", appendix));
 
+    // Both roots are uscode containers
+    assert_eq!(regular_root.data.path, "uscode");
+    assert_eq!(appendix_root.data.path, "uscode");
+
     // Both should be USC documents
     assert!(matches!(
         regular_root.data.document_type,
@@ -98,8 +105,10 @@ fn test_appendix_vs_regular_titles(#[case] regular: &str, #[case] appendix: &str
         DocumentType::USCode { .. }
     ));
 
-    // Paths should be different
-    assert_ne!(regular_root.data.path, appendix_root.data.path);
+    // The first child (title) paths should be different
+    let regular_title = &regular_root.children[0];
+    let appendix_title = &appendix_root.children[0];
+    assert_ne!(regular_title.data.path, appendix_title.data.path);
 }
 
 #[test]

--- a/tests/path_tests.rs
+++ b/tests/path_tests.rs
@@ -2,19 +2,9 @@ use words_to_data::uslm::ElementType;
 use words_to_data::uslm::path::{generate_structural_path, should_include_in_uslm_path};
 
 #[test]
-fn test_generate_structural_path_root_element() {
-    let path = generate_structural_path(ElementType::USCodeDocument, "26", None);
-    assert_eq!(path, "uscodedocument_26");
-}
-
-#[test]
 fn test_generate_structural_path_nested_element() {
-    let path = generate_structural_path(
-        ElementType::Section,
-        "174",
-        Some("uscodedocument_26/title_26"),
-    );
-    assert_eq!(path, "uscodedocument_26/title_26/section_174");
+    let path = generate_structural_path(ElementType::Section, "174", Some("uscode/title_26"));
+    assert_eq!(path, "uscode/title_26/section_174");
 }
 
 #[test]

--- a/tests/source_credit_tests.rs
+++ b/tests/source_credit_tests.rs
@@ -7,7 +7,7 @@ fn should_parse_single_source_credit_with_one_ref() {
 
     // Find section 1 which has a simple source credit
     let section_1 = element
-        .find("uscodedocument_7/title_7/chapter_1/section_1")
+        .find("uscode/title_7/chapter_1/section_1")
         .expect("Section 1 not found");
 
     // Section 1 should have at least one source credit
@@ -39,7 +39,7 @@ fn should_parse_multiple_refs_without_semicolons() {
 
     // Find a section with multiple refs in a single source credit (no semicolons)
     let section_1b = element
-        .find("uscodedocument_7/title_7/chapter_1/section_1b")
+        .find("uscode/title_7/chapter_1/section_1b")
         .expect("Section 1b not found");
 
     assert!(
@@ -67,7 +67,7 @@ fn should_split_source_credits_by_semicolons() {
 
     // Section 1a has amendments separated by semicolons
     let section_1a = element
-        .find("uscodedocument_7/title_7/chapter_1/section_1a")
+        .find("uscode/title_7/chapter_1/section_1a")
         .expect("Section 1a not found");
 
     // Section 1a should have multiple source credits due to semicolon splitting
@@ -104,7 +104,7 @@ fn should_extract_href_as_ref_id() {
         .expect("Failed to parse USC 7");
 
     let section_1 = element
-        .find("uscodedocument_7/title_7/chapter_1/section_1")
+        .find("uscode/title_7/chapter_1/section_1")
         .expect("Section 1 not found");
 
     assert!(!section_1.data.source_credits.is_empty());

--- a/tests/text_content_tests.rs
+++ b/tests/text_content_tests.rs
@@ -8,7 +8,7 @@ fn test_parse_heading_field() {
 
     // Navigate to title element
     let title = root
-        .find("uscodedocument_9/title_9")
+        .find("uscode/title_9")
         .expect("Failed to find title element");
 
     // Verify heading exists and matches expected value
@@ -30,7 +30,7 @@ fn test_parse_content_field() {
 
     // Navigate to a paragraph which has actual content text
     let paragraph = root
-        .find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a/paragraph_1")
+        .find("uscode/title_9/chapter_1/section_10/subsection_a/paragraph_1")
         .expect("Failed to find paragraph element");
 
     // Verify content field exists and contains text
@@ -60,7 +60,7 @@ fn test_parse_chapeau_field() {
 
     // Navigate to section 10 subsection a which has chapeau
     let subsection = root
-        .find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a")
+        .find("uscode/title_9/chapter_1/section_10/subsection_a")
         .expect("Failed to find subsection with chapeau");
 
     // Verify chapeau field exists
@@ -86,7 +86,7 @@ fn test_parse_mixed_text_fields() {
 
     // Section 1 has both heading and content
     let section = root
-        .find("uscodedocument_1/title_1/chapter_1/section_1")
+        .find("uscode/title_1/chapter_1/section_1")
         .expect("Failed to find section element");
 
     // Verify both fields exist
@@ -136,7 +136,7 @@ fn test_parse_chapter_heading() {
 
     // Navigate to chapter 1
     let chapter = root
-        .find("uscodedocument_9/title_9/chapter_1")
+        .find("uscode/title_9/chapter_1")
         .expect("Failed to find chapter element");
 
     // Verify chapter has heading
@@ -161,7 +161,7 @@ fn test_all_text_field_accessors() {
 
     // Get subsection with chapeau
     let subsection = root
-        .find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a")
+        .find("uscode/title_9/chapter_1/section_10/subsection_a")
         .expect("Failed to find subsection");
 
     // Test all accessor methods exist and work
@@ -185,7 +185,7 @@ fn test_parse_special_characters_in_text() {
 
     // Section 1 has "§ 1." in its number display
     let section = root
-        .find("uscodedocument_1/title_1/chapter_1/section_1")
+        .find("uscode/title_1/chapter_1/section_1")
         .expect("Failed to find section element");
 
     // The number_display field should contain the § symbol

--- a/tests/tree_navigation_tests.rs
+++ b/tests/tree_navigation_tests.rs
@@ -6,11 +6,11 @@ fn test_find_root_in_real_document() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result = root.find("uscodedocument_9");
+    let result = root.find("uscode");
     assert!(result.is_some(), "Should find root");
 
     let found = result.unwrap();
-    assert_eq!(found.data.path, "uscodedocument_9");
+    assert_eq!(found.data.path, "uscode");
     assert_eq!(found.data.element_type, ElementType::USCodeDocument);
 }
 
@@ -20,11 +20,11 @@ fn test_find_title_element() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result = root.find("uscodedocument_9/title_9");
+    let result = root.find("uscode/title_9");
     assert!(result.is_some(), "Should find title");
 
     let found = result.unwrap();
-    assert_eq!(found.data.path, "uscodedocument_9/title_9");
+    assert_eq!(found.data.path, "uscode/title_9");
     assert_eq!(found.data.element_type, ElementType::Title);
 }
 
@@ -34,7 +34,7 @@ fn test_find_chapter_element() {
     let root = parse("tests/test_data/usc/2025-07-18/usc01.xml", "2025-07-18")
         .expect("Failed to parse usc01.xml");
 
-    let result = root.find("uscodedocument_1/title_1/chapter_1");
+    let result = root.find("uscode/title_1/chapter_1");
     assert!(result.is_some(), "Should find chapter");
 
     let found = result.unwrap();
@@ -48,7 +48,7 @@ fn test_find_section_element() {
     let root = parse("tests/test_data/usc/2025-07-18/usc04.xml", "2025-07-18")
         .expect("Failed to parse usc04.xml");
 
-    let result = root.find("uscodedocument_4/title_4/chapter_1/section_1");
+    let result = root.find("uscode/title_4/chapter_1/section_1");
     assert!(result.is_some(), "Should find section");
 
     let found = result.unwrap();
@@ -61,7 +61,7 @@ fn test_find_subsection_element() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result = root.find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a");
+    let result = root.find("uscode/title_9/chapter_1/section_10/subsection_a");
     assert!(result.is_some(), "Should find subsection");
 
     let found = result.unwrap();
@@ -75,8 +75,7 @@ fn test_find_paragraph_element() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result =
-        root.find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a/paragraph_1");
+    let result = root.find("uscode/title_9/chapter_1/section_10/subsection_a/paragraph_1");
     assert!(result.is_some(), "Should find paragraph");
 
     let found = result.unwrap();
@@ -89,7 +88,7 @@ fn test_find_nonexistent_path() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result = root.find("uscodedocument_9/title_9/chapter_99");
+    let result = root.find("uscode/title_9/chapter_99");
     assert!(result.is_none(), "Should not find nonexistent chapter");
 }
 
@@ -99,7 +98,7 @@ fn test_find_partial_path_fails() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result = root.find("uscodedocument_9/title_9/chapter_1/section_99");
+    let result = root.find("uscode/title_9/chapter_1/section_99");
     assert!(result.is_none(), "Should not find nonexistent section");
 }
 
@@ -109,7 +108,7 @@ fn test_find_wrong_title_prefix() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result = root.find("uscodedocument_26/title_26");
+    let result = root.find("uscode/title_26");
     assert!(result.is_none(), "Should not find wrong title");
 }
 
@@ -119,7 +118,7 @@ fn test_find_preserves_children() {
     let root = parse("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
         .expect("Failed to parse usc09.xml");
 
-    let result = root.find("uscodedocument_9/title_9/chapter_1/section_10/subsection_a");
+    let result = root.find("uscode/title_9/chapter_1/section_10/subsection_a");
     assert!(result.is_some(), "Should find subsection");
 
     let found = result.unwrap();
@@ -147,15 +146,15 @@ fn test_find_appendix_element() {
     let root = parse("tests/test_data/usc/2025-07-18/usc05A.xml", "2025-07-18")
         .expect("Failed to parse usc05A.xml");
 
-    // usc05A is Title 5 Appendix - verify root can be found
-    let result = root.find("uscodedocument_5a");
-    assert!(result.is_some(), "Should find appendix document root");
+    // usc05A is Title 5 Appendix - root is now uscode
+    let result = root.find("uscode");
+    assert!(result.is_some(), "Should find uscode root");
 
     let found = result.unwrap();
     assert_eq!(found.data.element_type, ElementType::USCodeDocument);
 
     // Try to find title element within appendix
-    let title_result = root.find("uscodedocument_5a/title_5a");
+    let title_result = root.find("uscode/title_5a");
     if let Some(result) = title_result {
         assert_eq!(result.data.element_type, ElementType::Title);
     }
@@ -168,9 +167,8 @@ fn test_find_deeply_nested_structure() {
         .expect("Failed to parse usc09.xml");
 
     // Navigate to subparagraph (6 levels deep)
-    let result = root.find(
-        "uscodedocument_9/title_9/chapter_1/section_16/subsection_a/paragraph_1/subparagraph_A",
-    );
+    let result =
+        root.find("uscode/title_9/chapter_1/section_16/subsection_a/paragraph_1/subparagraph_A");
 
     if let Some(found) = result {
         assert_eq!(found.data.element_type, ElementType::Subparagraph);
@@ -186,6 +184,6 @@ fn test_find_path_too_deep() {
         .expect("Failed to parse usc09.xml");
 
     // Try to navigate beyond what exists
-    let result = root.find("uscodedocument_9/title_9/chapter_1/section_1/subsection_a/paragraph_1/subparagraph_a/clause_1/subclause_1/item_1");
+    let result = root.find("uscode/title_9/chapter_1/section_1/subsection_a/paragraph_1/subparagraph_a/clause_1/subclause_1/item_1");
     assert!(result.is_none(), "Path too deep should return None");
 }

--- a/tests/uscode_container_tests.rs
+++ b/tests/uscode_container_tests.rs
@@ -1,0 +1,32 @@
+//! Tests for the USCode container structure
+//!
+//! The parser produces a `uscode` root element with titles as direct children,
+//! enabling cross-title diffs from a single snapshot date.
+
+use words_to_data::uslm::parser::parse;
+use words_to_data::uslm::{DocumentType, ElementType, USCType};
+
+/// Test: parser should produce uscode root with title as child
+#[test]
+fn should_parse_title_with_uscode_root() {
+    let element =
+        parse("tests/test_data/usc/2025-07-18/usc07.xml", "2025-07-18").expect("Failed to parse");
+
+    // Root should be uscode container
+    assert_eq!(element.data.element_type, ElementType::USCodeDocument);
+    assert_eq!(element.data.path, "uscode");
+
+    // Document type should indicate this is a USCode container
+    match &element.data.document_type {
+        DocumentType::USCode { usc_type } => {
+            assert_eq!(*usc_type, USCType::USCode);
+        }
+        _ => panic!("Expected USCode document type"),
+    }
+
+    // First child should be the title
+    assert!(!element.children.is_empty());
+    let title = &element.children[0];
+    assert_eq!(title.data.element_type, ElementType::Title);
+    assert_eq!(title.data.path, "uscode/title_7");
+}

--- a/tests/website_example_tests.rs
+++ b/tests/website_example_tests.rs
@@ -2,9 +2,6 @@
 //!
 //! These tests replicate the examples shown on wordstodata.com
 //! If any of these tests fail, the website examples at w2d_site/index.html need to be updated.
-//!
-//! Site location: /home/jesse/code/w2d_site/index.html
-
 use words_to_data::{
     diff::TreeDiff,
     uslm::{TextContentField, bill_parser::parse_bill_amendments, parser::parse},
@@ -24,7 +21,8 @@ fn website_example_parse_usc_document() {
         .expect("Failed to parse USC Title 26");
 
     // Navigate to §174(a) (path shown on website)
-    let s174a_path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+    let s174a_path =
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
     let s174a = title_26
         .find(s174a_path)
         .expect("§174(a) not found - website example path may need updating");
@@ -47,7 +45,8 @@ fn website_example_parse_usc_json_structure() {
     let title_26 = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
         .expect("Failed to parse USC Title 26");
 
-    let s174a_path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+    let s174a_path =
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
     let s174a = title_26.find(s174a_path).unwrap();
 
     // Verify key fields shown in website JSON output
@@ -97,7 +96,8 @@ fn website_example_compute_diff() {
     let diff = TreeDiff::from_elements(&doc_old, &doc_new);
 
     // Find the diff for §174(a) (as shown on website)
-    let s174a_path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+    let s174a_path =
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
     let s174a_diff = diff
         .find(s174a_path)
         .expect("§174(a) diff not found - this path has changes and should exist");
@@ -146,7 +146,8 @@ fn website_example_diff_json_structure() {
     let doc_new = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30").unwrap();
 
     let diff = TreeDiff::from_elements(&doc_old, &doc_new);
-    let s174a_path = "uscodedocument_26/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+    let s174a_path =
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
     let s174a_diff = diff.find(s174a_path).unwrap();
 
     let chapeau_change = s174a_diff


### PR DESCRIPTION
Remove some old technical debt to make it possible to parse entire uscodes as one element instead of just individual titles