### PR TITLE
Fix unwrap() panics in property getters

### DIFF
--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -410,7 +410,30 @@ def test_legal_diff_json_roundtrip():
     assert restored_anns[0].source_bill.bill_id == "119-21"
 
 
-def test_tree_diff_shallow():
+def test_getter_properties_return_correct_types():
+    """Regression: seven getters previously used unwrap() and would crash Python on error."""
+    element = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+
+    data = element.data
+    assert isinstance(data, dict)
+    assert "path" in data
+
+    old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+    new = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+    diff = compute_diff(old, new)
+
+    assert isinstance(diff.from_element, dict)
+    assert isinstance(diff.to_element, dict)
+    assert isinstance(diff.added, list)
+    assert isinstance(diff.removed, list)
+
+    from words_to_data import LegalDiff
+
+    legal_diff = LegalDiff(diff)
+    assert isinstance(legal_diff.annotations_dict, dict)
+    assert isinstance(legal_diff.amendments_dict, dict)
+
+
     """Test that shallow() returns a TreeDiff without children"""
     old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
     new = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")

--- a/src/python.rs
+++ b/src/python.rs
@@ -313,8 +313,9 @@ impl TreeDiff {
             .added
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem)
-                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+                let data = serde_json::to_value(elem).map_err(|e| {
+                    PyRuntimeError::new_err(format!("JSON serialization error: {}", e))
+                })?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
@@ -328,8 +329,9 @@ impl TreeDiff {
             .removed
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem)
-                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+                let data = serde_json::to_value(elem).map_err(|e| {
+                    PyRuntimeError::new_err(format!("JSON serialization error: {}", e))
+                })?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))

--- a/src/python.rs
+++ b/src/python.rs
@@ -39,12 +39,13 @@ impl USLMElement {
 impl USLMElement {
     #[getter]
     fn data(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.data).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+        let data = serde_json::to_value(&self.inner.data)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        Python::attach(|py| {
+            pythonize(py, &data)
+                .map(|obj| obj.unbind())
+                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
+        })
     }
 
     #[getter]
@@ -286,22 +287,24 @@ impl TreeDiff {
     #[getter]
     #[allow(clippy::wrong_self_convention)]
     fn from_element(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.from_element).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+        let data = serde_json::to_value(&self.inner.from_element)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        Python::attach(|py| {
+            pythonize(py, &data)
+                .map(|obj| obj.unbind())
+                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
+        })
     }
 
     #[getter]
     fn to_element(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.to_element).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+        let data = serde_json::to_value(&self.inner.to_element)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        Python::attach(|py| {
+            pythonize(py, &data)
+                .map(|obj| obj.unbind())
+                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
+        })
     }
 
     #[getter]
@@ -310,7 +313,8 @@ impl TreeDiff {
             .added
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem).unwrap();
+                let data = serde_json::to_value(elem)
+                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
@@ -324,7 +328,8 @@ impl TreeDiff {
             .removed
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem).unwrap();
+                let data = serde_json::to_value(elem)
+                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
@@ -860,22 +865,24 @@ impl LegalDiff {
 
     #[getter]
     fn annotations_dict(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.annotations).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+        let data = serde_json::to_value(&self.inner.annotations)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        Python::attach(|py| {
+            pythonize(py, &data)
+                .map(|obj| obj.unbind())
+                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
+        })
     }
 
     #[getter]
     fn amendments_dict(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.amendments).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+        let data = serde_json::to_value(&self.inner.amendments)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        Python::attach(|py| {
+            pythonize(py, &data)
+                .map(|obj| obj.unbind())
+                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
+        })
     }
 
     /// Add an annotation for a specific structural path


### PR DESCRIPTION
## Summary

Seven property getters used `.unwrap()` on `serde_json::to_value` and `pythonize` calls. When either of those fails, Rust panics — which crashes the Python interpreter with an abort rather than raising a catchable `RuntimeError`.

**Affected getters:**
- `USLMElement.data`
- `TreeDiff.from_element`
- `TreeDiff.to_element`
- `TreeDiff.added`
- `TreeDiff.removed`
- `LegalDiff.annotations_dict`
- `LegalDiff.amendments_dict`

All now follow the same error-propagation pattern already used by `to_dict()`: `map_err` on `serde_json::to_value` and `pythonize`, returning a `PyRuntimeError` instead of panicking.

## Test plan

- [ ] Existing Python test suite passes (`test_bindings.py`, `test_dataset.py`, `test_website_examples.py`)
- [ ] Confirm that accessing `.data`, `.from_element`, `.to_element`, `.added`, `.removed`, `.annotations_dict`, `.amendments_dict` on valid objects still works

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSY6TER2j2mYj951QedciE)_