### PR TITLE
Fix panics in __repr__ methods

### DIFF
--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -410,6 +410,30 @@ def test_legal_diff_json_roundtrip():
     assert restored_anns[0].source_bill.bill_id == "119-21"
 
 
+def test_repr_methods():
+    """Regression: BillAmendment repr panicked on short IDs; TextChange repr cloned value twice."""
+    element = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+    assert repr(element).startswith("USLMElement(")
+
+    old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+    new = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+    diff = compute_diff(old, new)
+    assert repr(diff).startswith("TreeDiff(")
+
+    s174a = diff.find(
+        "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a"
+    )
+    assert repr(s174a.changes[0]).startswith("FieldChangeEvent(")
+
+    text_change = s174a.changes[0].changes[0]
+    r = repr(text_change)
+    assert r.startswith("TextChange(")
+    assert len(r) < 200
+
+    data = parse_bill_amendments("tests/test_data/bills/pl-119-21.xml")
+    assert repr(data.amendments[0]).startswith("BillAmendment(")
+
+
 def test_tree_diff_shallow():
     """Test that shallow() returns a TreeDiff without children"""
     old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")

--- a/src/python.rs
+++ b/src/python.rs
@@ -127,10 +127,11 @@ impl TextChange {
     }
 
     fn __repr__(&self) -> String {
+        let value = &self.inner.value;
         format!(
             "TextChange(tag='{}', value='{}')",
             self.tag(),
-            &self.value()[..self.value().len().min(20)]
+            &value[..value.len().min(20)]
         )
     }
 
@@ -1056,7 +1057,7 @@ impl BillAmendment {
         };
         format!(
             "BillAmendment(id='{}', action_types={:?}, changes={}, amending_text='{}')",
-            &self.inner.id[..12],
+            &self.inner.id[..self.inner.id.len().min(12)],
             self.action_types(),
             self.inner.changes.len(),
             text_preview


### PR DESCRIPTION
## Summary

Two `__repr__` methods had bugs:

**`BillAmendment.__repr__`** — used a fixed byte-slice `&self.inner.id[..12]` which panics if the ID string is shorter than 12 bytes. Changed to `[..self.inner.id.len().min(12)]`.

**`TextChange.__repr__`** — called `self.value()` twice, which clones the `String` on each call. The second call was also used as both operands in `[..self.value().len().min(20)]`, meaning three clones total. Changed to borrow `&self.inner.value` once.

## Test plan

- [ ] Existing Python test suite passes
- [ ] `repr(element)`, `repr(diff)`, `repr(text_change)`, `repr(amendment)` all work without panic

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSY6TER2j2mYj951QedciE)_