### PR TITLE
Fix inaccurate type stubs

### DIFF
--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -410,6 +410,28 @@ def test_legal_diff_json_roundtrip():
     assert restored_anns[0].source_bill.bill_id == "119-21"
 
 
+def test_merge_children_returns_none():
+    """Regression: stub said -> USLMElement but the method has no return value."""
+    title_9 = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18")
+    title_26 = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+    result = title_26.merge_children(title_9)
+    assert result is None
+
+
+def test_get_annotations_returns_empty_list_not_none():
+    """Regression: stub said -> list | None but the method always returns a list."""
+    from words_to_data import LegalDiff
+
+    old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+    new = parse_uslm_xml("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+    legal_diff = LegalDiff(compute_diff(old, new))
+
+    result = legal_diff.get_annotations("nonexistent/path")
+    assert result is not None
+    assert isinstance(result, list)
+    assert len(result) == 0
+
+
 def test_tree_diff_shallow():
     """Test that shallow() returns a TreeDiff without children"""
     old = parse_uslm_xml("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")

--- a/python/words_to_data/__init__.pyi
+++ b/python/words_to_data/__init__.pyi
@@ -39,7 +39,7 @@ class USLMElement:
         """Deserialize a JSON string to a USLMElement."""
         ...
 
-    def merge_children(self, other: USLMElement) -> USLMElement:
+    def merge_children(self, other: USLMElement) -> None:
         """Merge the children of two nodes into one, retains the caller's ElementData"""
 
 class TextChange:
@@ -677,14 +677,14 @@ class LegalDiff:
         """
         ...
 
-    def get_annotations(self, path: str) -> list[ChangeAnnotation] | None:
+    def get_annotations(self, path: str) -> list[ChangeAnnotation]:
         """Get all annotations for a specific path.
 
         Args:
             path: The structural path to look up
 
         Returns:
-            List of annotations for the path, or None if no annotations exist
+            List of annotations for the path (empty if none exist)
         """
         ...
 


### PR DESCRIPTION
## Summary

Two stubs in `__init__.pyi` advertised return types that didn't match the Rust implementation:

**`USLMElement.merge_children`** — stub said `-> USLMElement` but the Rust binding is `fn merge_children(&mut self, other: &mut USLMElement)` with no return value. Any code that tried to use the return value would get `None` at runtime. Changed to `-> None`.

**`LegalDiff.get_annotations`** — stub said `-> list[ChangeAnnotation] | None` but the binding always returns `Vec<ChangeAnnotation>` (empty list when nothing found, never `None`). Code written against this stub would add unnecessary `if result is not None:` guards. Changed to `-> list[ChangeAnnotation]` and updated the docstring accordingly.

## Test plan

- [ ] Existing Python test suite passes
- [ ] Type-checker (Pylance/mypy) no longer reports a `None` branch on `get_annotations`
- [ ] `merge_children` usage does not show a false return value in IDE completions

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSY6TER2j2mYj951QedciE)_