### PR TITLE
Fix add_uslm_folder silent failure and version mismatch

### DIFF
--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -159,11 +159,27 @@ def test_add_uslm_folder_invalid_path_raises_os_error():
         dataset.add_uslm_folder("/nonexistent/path/that/does/not/exist", "2025-01-01")
 
 
-def test_version_matches_pyproject():
-    """Regression: __version__ was 0.1.2 while pyproject.toml said 0.2.0."""
+def test_version_matches_cargo_toml():
+    """Cargo.toml is the source of truth; pyproject.toml and __version__ must agree."""
+    import tomllib
     import words_to_data
+    from pathlib import Path
 
-    assert words_to_data.__version__ == "0.2.0"
+    repo_root = Path(__file__).parent.parent.parent
+    with open(repo_root / "Cargo.toml", "rb") as f:
+        cargo = tomllib.load(f)
+    with open(repo_root / "pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
+
+    cargo_version = cargo["package"]["version"]
+    assert pyproject["project"]["version"] == cargo_version, (
+        f"pyproject.toml version {pyproject['project']['version']!r} "
+        f"does not match Cargo.toml version {cargo_version!r}"
+    )
+    assert words_to_data.__version__ == cargo_version, (
+        f"words_to_data.__version__ {words_to_data.__version__!r} "
+        f"does not match Cargo.toml version {cargo_version!r}"
+    )
 
 
 def test_search_text():

--- a/python/tests/test_dataset.py
+++ b/python/tests/test_dataset.py
@@ -141,6 +141,31 @@ def test_add_and_query_bills():
     assert not_found is None
 
 
+def test_add_uslm_folder_invalid_path_raises_os_error():
+    """Regression: add_uslm_folder previously panicked (expect()) on bad paths."""
+    import pytest
+
+    metadata = DatasetMetadata(
+        name="Test",
+        description="Test",
+        author="Test",
+        source_urls=[],
+        license="MIT",
+        version="1.0.0",
+    )
+    dataset = Dataset(metadata)
+
+    with pytest.raises(OSError):
+        dataset.add_uslm_folder("/nonexistent/path/that/does/not/exist", "2025-01-01")
+
+
+def test_version_matches_pyproject():
+    """Regression: __version__ was 0.1.2 while pyproject.toml said 0.2.0."""
+    import words_to_data
+
+    assert words_to_data.__version__ == "0.2.0"
+
+
 def test_search_text():
     metadata = DatasetMetadata(
         name="Test",

--- a/python/words_to_data/__init__.py
+++ b/python/words_to_data/__init__.py
@@ -24,7 +24,7 @@ from .words_to_data import (
     SearchResult,
 )
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 __all__ = [
     "parse_uslm_xml",
     "compute_diff",

--- a/python/words_to_data/__init__.pyi
+++ b/python/words_to_data/__init__.pyi
@@ -1095,6 +1095,9 @@ class Dataset:
             folder_path: Path to directory containing USLM XML files
             date: Publication date in YYYY-MM-DD format
             label: Optional human-readable label for this version
+
+        Raises:
+            OSError: If the folder is empty or cannot be read
         """
         ...
 

--- a/src/dataset/error.rs
+++ b/src/dataset/error.rs
@@ -13,4 +13,7 @@ pub enum DatasetError {
 
     #[error("Version not found: {0}")]
     VersionNotFound(String),
+
+    #[error("Failed to load folder '{0}': folder is empty or unreadable")]
+    FolderLoadFailed(String),
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -285,13 +285,20 @@ impl Dataset {
     /// * `folder_path` - Path to directory containing USLM XML files
     /// * `date` - Publication date string in "YYYY-MM-DD" format
     /// * `label` - Optional label for the snapshot
-    pub fn add_uslm_folder(&mut self, folder_path: &str, date: &str, label: Option<String>) {
-        let result = load_uslm_folder(folder_path, date).expect("Error loading element in dir");
+    pub fn add_uslm_folder(
+        &mut self,
+        folder_path: &str,
+        date: &str,
+        label: Option<String>,
+    ) -> Result<(), DatasetError> {
+        let element = load_uslm_folder(folder_path, date)
+            .ok_or_else(|| DatasetError::FolderLoadFailed(folder_path.to_string()))?;
         self.add_version(VersionSnapshot {
             date: date.to_string(),
             label,
-            element: result,
+            element,
         });
+        Ok(())
     }
 
     /// Search for text across all versions

--- a/src/python.rs
+++ b/src/python.rs
@@ -1281,6 +1281,9 @@ fn dataset_error_to_py(err: DatasetError) -> PyErr {
         DatasetError::VersionNotFound(v) => {
             PyValueError::new_err(format!("Version not found: {}", v))
         }
+        DatasetError::FolderLoadFailed(p) => {
+            PyOSError::new_err(format!("Failed to load folder '{}': empty or unreadable", p))
+        }
     }
 }
 
@@ -1599,8 +1602,15 @@ impl Dataset {
 
     /// Load all USLM XML files from a folder and add as a merged version snapshot
     #[pyo3(signature = (folder_path, date, label=None))]
-    fn add_uslm_folder(&mut self, folder_path: &str, date: &str, label: Option<String>) {
-        self.inner.add_uslm_folder(folder_path, date, label);
+    fn add_uslm_folder(
+        &mut self,
+        folder_path: &str,
+        date: &str,
+        label: Option<String>,
+    ) -> PyResult<()> {
+        self.inner
+            .add_uslm_folder(folder_path, date, label)
+            .map_err(dataset_error_to_py)
     }
 
     fn __repr__(&self) -> String {

--- a/src/python.rs
+++ b/src/python.rs
@@ -1281,9 +1281,10 @@ fn dataset_error_to_py(err: DatasetError) -> PyErr {
         DatasetError::VersionNotFound(v) => {
             PyValueError::new_err(format!("Version not found: {}", v))
         }
-        DatasetError::FolderLoadFailed(p) => {
-            PyOSError::new_err(format!("Failed to load folder '{}': empty or unreadable", p))
-        }
+        DatasetError::FolderLoadFailed(p) => PyOSError::new_err(format!(
+            "Failed to load folder '{}': empty or unreadable",
+            p
+        )),
     }
 }
 


### PR DESCRIPTION
## Summary

Two unrelated but small fixes:

### `Dataset.add_uslm_folder` silent failure

The Rust `Dataset::add_uslm_folder` called `.expect("Error loading element in dir")` on the result of `load_uslm_folder`, which returns `Option<USLMElement>`. When the folder is empty or unreadable, this panics (hard crash) instead of raising a Python `OSError`.

Fix: add `DatasetError::FolderLoadFailed(String)` to the error enum, make `Dataset::add_uslm_folder` return `Result<(), DatasetError>`, propagate through the Python binding, and add the new variant to `dataset_error_to_py`. The stub is updated with a `Raises: OSError` note.

### `__version__` mismatch

`python/words_to_data/__init__.py` advertised `__version__ = "0.1.2"` while `pyproject.toml` says `0.2.0`. Users checking `words_to_data.__version__` would see a different value than `pip show words-to-data`. Synced to `"0.2.0"`.

## Test plan

- [ ] Existing Python test suite passes
- [ ] `words_to_data.__version__ == "0.2.0"`
- [ ] `dataset.add_uslm_folder("/nonexistent", "2025-01-01")` raises `OSError` instead of panicking

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSY6TER2j2mYj951QedciE)_