### PR TITLE
Use py: Python<'_> parameter instead of Python::attach in #[pymethods]

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -38,13 +38,12 @@ impl USLMElement {
 #[pymethods]
 impl USLMElement {
     #[getter]
-    fn data(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.data).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+    fn data(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let data = serde_json::to_value(&self.inner.data)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[getter]
@@ -70,14 +69,12 @@ impl USLMElement {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     fn merge_children(&mut self, other: &mut USLMElement) {
@@ -139,14 +136,12 @@ impl TextChange {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -211,14 +206,12 @@ impl FieldChangeEvent {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -285,32 +278,31 @@ impl TreeDiff {
 
     #[getter]
     #[allow(clippy::wrong_self_convention)]
-    fn from_element(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.from_element).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+    fn from_element(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let data = serde_json::to_value(&self.inner.from_element)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[getter]
-    fn to_element(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.to_element).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+    fn to_element(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let data = serde_json::to_value(&self.inner.to_element)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[getter]
-    fn added(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
+    fn added(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
         self.inner
             .added
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem).unwrap();
+                let data = serde_json::to_value(elem)
+                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
@@ -319,12 +311,13 @@ impl TreeDiff {
     }
 
     #[getter]
-    fn removed(&self, py: Python) -> PyResult<Vec<Py<PyAny>>> {
+    fn removed(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
         self.inner
             .removed
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem).unwrap();
+                let data = serde_json::to_value(elem)
+                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
@@ -362,14 +355,12 @@ impl TreeDiff {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -473,14 +464,12 @@ impl AmendmentSimilarity {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -534,14 +523,12 @@ impl MentionMatch {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -619,14 +606,12 @@ impl BillReference {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -705,14 +690,12 @@ impl AnnotationMetadata {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -810,14 +793,12 @@ impl ChangeAnnotation {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -859,23 +840,21 @@ impl LegalDiff {
     }
 
     #[getter]
-    fn annotations_dict(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.annotations).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+    fn annotations_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let data = serde_json::to_value(&self.inner.annotations)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[getter]
-    fn amendments_dict(&self) -> PyResult<Py<PyAny>> {
-        let data = serde_json::to_value(&self.inner.amendments).unwrap();
-        let result = Python::attach(|py| {
-            let obj = pythonize(py, &data).unwrap();
-            obj.unbind()
-        });
-        Ok(result)
+    fn amendments_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let data = serde_json::to_value(&self.inner.amendments)
+            .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     /// Add an annotation for a specific structural path
@@ -922,14 +901,12 @@ impl LegalDiff {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -990,14 +967,12 @@ impl BillDiff {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -1080,14 +1055,12 @@ impl BillAmendment {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]
@@ -1162,14 +1135,12 @@ impl AmendmentData {
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))
     }
 
-    fn to_dict(&self) -> PyResult<Py<PyAny>> {
+    fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let data = serde_json::to_value(&self.inner)
             .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
-        Python::attach(|py| {
-            pythonize(py, &data)
-                .map(|obj| obj.unbind())
-                .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
-        })
+        pythonize(py, &data)
+            .map(|obj| obj.unbind())
+            .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
     }
 
     #[staticmethod]

--- a/src/python.rs
+++ b/src/python.rs
@@ -301,8 +301,9 @@ impl TreeDiff {
             .added
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem)
-                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+                let data = serde_json::to_value(elem).map_err(|e| {
+                    PyRuntimeError::new_err(format!("JSON serialization error: {}", e))
+                })?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))
@@ -316,8 +317,9 @@ impl TreeDiff {
             .removed
             .iter()
             .map(|elem| {
-                let data = serde_json::to_value(elem)
-                    .map_err(|e| PyRuntimeError::new_err(format!("JSON serialization error: {}", e)))?;
+                let data = serde_json::to_value(elem).map_err(|e| {
+                    PyRuntimeError::new_err(format!("JSON serialization error: {}", e))
+                })?;
                 pythonize(py, &data)
                     .map(|obj| obj.unbind())
                     .map_err(|e| PyRuntimeError::new_err(format!("Conversion error: {}", e)))


### PR DESCRIPTION
## Summary

Inside `#[pymethods]`, PyO3 already holds the GIL. The idiomatic way to get the Python token is to accept `py: Python<'_>` as a method parameter — PyO3 passes it through automatically. Calling `Python::attach` instead re-enters the GIL via a closure, which is safe but non-idiomatic and adds unnecessary overhead.

All 18 `Python::attach` call sites in `python.rs` are converted:

- Property getters: `USLMElement.data`, `TreeDiff.from_element`, `TreeDiff.to_element`, `LegalDiff.annotations_dict`, `LegalDiff.amendments_dict`
- `to_dict()` methods on every class
- `TreeDiff.added` / `TreeDiff.removed` getters (also had `unwrap()` on serde_json that's fixed here as a side effect)

The `to_dict` pattern goes from:
```rust
fn to_dict(&self) -> PyResult<Py<PyAny>> {
    let data = serde_json::to_value(&self.inner)...?;
    Python::attach(|py| {
        pythonize(py, &data).map(|obj| obj.unbind())...
    })
}
```
to:
```rust
fn to_dict(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
    let data = serde_json::to_value(&self.inner)...?;
    pythonize(py, &data).map(|obj| obj.unbind())...
}
```

No behaviour change — this is purely a style/correctness refactor.

## Test plan

- [ ] Existing Python test suite passes (`test_bindings.py`, `test_dataset.py`, `test_website_examples.py`)
- [ ] All `to_dict()` calls still return correct dicts
- [ ] All affected property getters still return correct values

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSY6TER2j2mYj951QedciE)_