### PR TITLE
Remove duplicate children storage in USLMElement Python wrapper

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -20,17 +20,12 @@ use crate::uslm::parser::ParseError;
 #[derive(Clone)]
 struct USLMElement {
     pub inner: crate::uslm::USLMElement,
-
-    /// Child elements in document order
-    pub children: Vec<USLMElement>,
 }
 
 impl USLMElement {
     pub fn from(rust_elem: &crate::uslm::USLMElement) -> Self {
-        let children = rust_elem.children.iter().map(Self::from).collect();
         USLMElement {
             inner: rust_elem.clone(),
-            children,
         }
     }
 }
@@ -47,8 +42,8 @@ impl USLMElement {
     }
 
     #[getter]
-    fn children(&self) -> PyResult<Vec<USLMElement>> {
-        Ok(self.children.clone())
+    fn children(&self) -> Vec<USLMElement> {
+        self.inner.children.iter().map(USLMElement::from).collect()
     }
 
     fn find(&self, path: &str) -> Option<USLMElement> {
@@ -60,7 +55,7 @@ impl USLMElement {
             "USLMElement(path='{}', element_type={:?}, children={})",
             self.inner.data.path,
             self.inner.data.element_type,
-            self.children.len()
+            self.inner.children.len()
         )
     }
 
@@ -79,14 +74,13 @@ impl USLMElement {
 
     fn merge_children(&mut self, other: &mut USLMElement) {
         self.inner.merge_children_mut(&mut other.inner);
-        self.children.append(&mut other.children.clone());
     }
 
     #[staticmethod]
     fn from_json(json_str: &str) -> PyResult<Self> {
         let inner: crate::uslm::USLMElement = serde_json::from_str(json_str)
             .map_err(|e| PyValueError::new_err(format!("JSON deserialization error: {}", e)))?;
-        Ok(Self::from(&inner))
+        Ok(Self { inner })
     }
 }
 


### PR DESCRIPTION
## Summary

The Python `USLMElement` wrapper previously held two copies of every child node:

- `inner: crate::uslm::USLMElement` — the full Rust element tree, which recursively contains all descendants in `inner.children`
- `children: Vec<USLMElement>` — a separately allocated vec of Python-wrapped children, also built recursively

For a document with N nodes every node was allocated twice. On a large USC title this is a significant overhead.

## Fix

Drop the `children` field. The `.children` getter now wraps `inner.children` on demand:

```rust
// Before
#[pyclass]
struct USLMElement {
    inner: crate::uslm::USLMElement,  // contains inner.children recursively
    children: Vec<USLMElement>,        // duplicate copy of the same data
}

// After
#[pyclass]
struct USLMElement {
    inner: crate::uslm::USLMElement,  // single source of truth
}

#[getter]
fn children(&self) -> Vec<USLMElement> {
    self.inner.children.iter().map(USLMElement::from).collect()
}
```

`merge_children` also no longer needs to sync the now-removed parallel vec — `merge_children_mut` mutating `inner` is sufficient.

## Test plan

- [ ] `cargo build --features python` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] Python: `element.children` returns the correct list
- [ ] Python: `element.merge_children(other)` still merges correctly

https://claude.ai/code/session_01KSY6TER2j2mYj951QedciE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSY6TER2j2mYj951QedciE)_