### PR TITLE
fix: diff silently dropped every pure insertion

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -252,6 +252,15 @@ impl TreeDiff {
     ///
     /// let diff = TreeDiff::from_elements(&old, &new);
     /// ```
+    /// True when this diff records nothing at all: no field changes, no added or
+    /// removed children, and no changed descendant.
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+            && self.added.is_empty()
+            && self.removed.is_empty()
+            && self.child_diffs.is_empty()
+    }
+
     pub fn from_elements(from_element: &USLMElement, to_element: &USLMElement) -> TreeDiff {
         assert!(from_element.data.path == to_element.data.path);
         let root_path = from_element.data.path.clone();
@@ -279,8 +288,12 @@ impl TreeDiff {
             match children_b.get(path) {
                 Some(child_b) => {
                     // Matched - recurse
+                    // Keep any child that records something. Testing only
+                    // `changes` and `child_diffs` here dropped a child whose
+                    // sole content was an added or removed element, which lost
+                    // every pure insertion in the tree (#54).
                     let child_diff = TreeDiff::from_elements(child_a, child_b);
-                    if !child_diff.child_diffs.is_empty() || !child_diff.changes.is_empty() {
+                    if !child_diff.is_empty() {
                         child_diffs.push(child_diff);
                     }
                 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,150 @@
+//! End-to-end tests that drive the `words_to_data` binary as a subprocess.
+//!
+//! These pin the behaviour that must survive the core refactor (#51). They assert
+//! on `--json` output, because that is the surface an agent reads, and because it
+//! survives a change to the human-readable text.
+
+use std::process::{Command, Output};
+use std::sync::OnceLock;
+
+use words_to_data::dataset::{Dataset, DatasetMetadata, VersionSnapshot};
+use words_to_data::uslm::parser::parse;
+
+/// The two US Code release points held in `tests/test_data`.
+const EARLY: &str = "2025-07-18";
+const LATE: &str = "2025-07-30";
+
+/// Title 9 (Arbitration) did not change between the two release points. Its two
+/// files differ by ten bytes of release stamp, which the parser ignores.
+const UNCHANGED_TITLE: &str = "usc09";
+
+/// Title 51 (National and Commercial Space Programs) did change: it is the
+/// smallest title in the corpus that carries real amendments between the two
+/// release points, at 2.8 MB and +26 KB.
+const AMENDED_TITLE: &str = "usc51";
+
+/// Build a SQLite dataset holding one title at both release points.
+fn build_fixture(title: &str) -> String {
+    let path = format!("{}/cli_{title}.sqlite", env!("CARGO_TARGET_TMPDIR"));
+    let _ = std::fs::remove_file(&path);
+
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "CLI Test Fixture".to_string(),
+        description: format!("{title} at two release points"),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "MIT".to_string(),
+        version: "1.0.0".to_string(),
+    });
+
+    for (date, label) in [(EARLY, "Before"), (LATE, "After")] {
+        let xml = format!("tests/test_data/usc/{date}/{title}.xml");
+        dataset
+            .add_version(VersionSnapshot {
+                date: date.to_string(),
+                label: Some(label.to_string()),
+                element: parse(&xml, date).expect("the corpus should parse"),
+            })
+            .expect("a version should be added");
+    }
+
+    dataset
+        .save_to_sqlite(&path)
+        .expect("the fixture should save");
+    path
+}
+
+/// A dataset over a title that really was amended. Built once per test binary.
+fn amended_fixture() -> &'static str {
+    static FIXTURE: OnceLock<String> = OnceLock::new();
+    FIXTURE.get_or_init(|| build_fixture(AMENDED_TITLE))
+}
+
+/// A dataset over a title that did not change. Built once per test binary.
+fn unchanged_fixture() -> &'static str {
+    static FIXTURE: OnceLock<String> = OnceLock::new();
+    FIXTURE.get_or_init(|| build_fixture(UNCHANGED_TITLE))
+}
+
+/// Run the CLI as a subprocess, the way an agent or a shell would.
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args(args)
+        .output()
+        .expect("the binary should run")
+}
+
+#[test]
+fn should_report_metadata_and_counts_when_info_runs_on_a_dataset() {
+    let output = run(&["info", amended_fixture(), "--json"]);
+
+    assert!(
+        output.status.success(),
+        "info should exit zero, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let info: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("info --json should emit json");
+
+    assert_eq!(info["name"], "CLI Test Fixture");
+    assert_eq!(info["version_count"], 2);
+    assert_eq!(info["bill_count"], 0);
+}
+
+/// Run `diff` over a fixture and return its parsed JSON summary.
+fn diff_summary(dataset: &str) -> serde_json::Value {
+    let output = run(&["diff", dataset, "--from", EARLY, "--to", LATE, "--json"]);
+
+    assert!(
+        output.status.success(),
+        "diff should exit zero, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    serde_json::from_slice(&output.stdout).expect("diff --json should emit json")
+}
+
+/// Count the paths under one key of a diff summary.
+fn path_count(summary: &serde_json::Value, key: &str) -> usize {
+    summary[key].as_array().expect("an array of paths").len()
+}
+
+/// Title 51 gained 26 KB of text and 63 elements between the two release points,
+/// but `diff` reports nothing at all. This test states the behaviour we want, not
+/// the behaviour we have, so it stays ignored until the defect is fixed. Do not
+/// "fix" it by asserting zero: that would pin the bug as if it were correct.
+#[test]
+#[ignore = "TreeDiff::from_elements reports no changes for a real amendment"]
+fn should_list_the_paths_that_changed_between_two_versions_when_diff_runs() {
+    let summary = diff_summary(amended_fixture());
+
+    assert_eq!(summary["from_date"], EARLY);
+    assert_eq!(summary["to_date"], LATE);
+
+    let total = path_count(&summary, "changed_paths")
+        + path_count(&summary, "added_paths")
+        + path_count(&summary, "removed_paths");
+
+    assert!(
+        total > 0,
+        "an amended title should produce at least one path, got {summary}"
+    );
+}
+
+/// The two files of an unchanged title differ by ten bytes of release stamp.
+/// A diff that reported those as changes would flood every real result with
+/// noise, so this pins that it reports nothing.
+#[test]
+fn should_report_no_changes_when_only_the_release_stamp_differs() {
+    let summary = diff_summary(unchanged_fixture());
+
+    assert_eq!(
+        (
+            path_count(&summary, "changed_paths"),
+            path_count(&summary, "added_paths"),
+            path_count(&summary, "removed_paths"),
+        ),
+        (0, 0, 0)
+    );
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -110,12 +110,9 @@ fn path_count(summary: &serde_json::Value, key: &str) -> usize {
     summary[key].as_array().expect("an array of paths").len()
 }
 
-/// Title 51 gained 26 KB of text and 63 elements between the two release points,
-/// but `diff` reports nothing at all. This test states the behaviour we want, not
-/// the behaviour we have, so it stays ignored until the defect is fixed. Do not
-/// "fix" it by asserting zero: that would pin the bug as if it were correct.
+/// Title 51 gained 26 KB of text and 63 elements between the two release points.
+/// Those are pure insertions, which `from_elements` used to discard (#54).
 #[test]
-#[ignore = "TreeDiff::from_elements reports no changes for a real amendment"]
 fn should_list_the_paths_that_changed_between_two_versions_when_diff_runs() {
     let summary = diff_summary(amended_fixture());
 


### PR DESCRIPTION
Closes #54. Part of #50.

Two commits: the CLI test net that found the defect, and the one-condition fix.

## The defect

`TreeDiff::from_elements` kept a child diff only when it had field changes or nested child diffs:

```rust
if !child_diff.child_diffs.is_empty() || !child_diff.changes.is_empty() {
```

A child whose only content was an added or removed element was dropped. Every pure insertion in the tree vanished.

Title 51 gained two sections between the `2025-07-18` and `2025-07-30` release points, 63 elements in all. `diff` reported `Changed (0) Added (0) Removed (0)`. A researcher reads that as "this title did not change" — a confident false answer, not an error. That is the failure mode our honesty rules exist to prevent.

## The fix

`TreeDiff::is_empty` tests all four fields, and the retention condition uses it.

After:

```
Added (2):
  uscode/title_51/subtitle_V/chapter_509/section_50924
  uscode/title_51/subtitle_II/chapter_203/section_20306
```

Two subtree roots, not 63 rows, which is the right granularity.

## The test net

`tests/cli_tests.rs` drives the binary as a subprocess and asserts on `--json`, because that is the surface an agent reads and the one that survives the core split (#51). No new dependency: `CARGO_BIN_EXE_words_to_data` and `CARGO_TARGET_TMPDIR`.

Fixtures come from the real corpus, per the rule against invented data:

- **Title 9** did not change; its two files differ by ten bytes of release stamp. The test pins that this produces no phantom changes.
- **Title 51** really was amended, and is the smallest title in the corpus that was.

Three tests: `info` metadata and counts, `diff` over an amended title, and `diff` over an unchanged one.

## Verification

| | |
|---|---|
| Baseline before this work | 171 passed, 5 ignored |
| After the test net, defect recorded as ignored | 173 passed, 6 ignored |
| After the fix, test un-ignored | **174 passed, 5 ignored, 0 failed** |

## Known gap, not fixed here

Exit codes are not distinct. Nearly every subcommand ends in `.expect(...)`, so a missing file, a corrupt dataset, and a bad argument all panic with 101. Only `validate` (1) and `convert-dataset` (2) differ. Recorded against #50; #51 rewrites these paths anyway.