### PR TITLE
ci: run on vibes, and on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, vibes ]
+  # No branch filter: every pull request runs CI, whatever it targets. Filtering
+  # on `main` meant no PR into `vibes` was ever tested, and it would also skip a
+  # stacked PR that targets a feature branch.
   pull_request:
-    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## The problem

```yaml
on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]
```

Both triggers filter on `main`. Day-to-day work happens on `vibes`, so no push to `vibes` and no PR into `vibes` has ever run CI. #46, #48, and #55 all merged or await merge untested by the pipeline.

## The change

- `push` covers `main` and `vibes`
- `pull_request` loses its branch filter, so every PR runs CI whatever it targets

The second point matters beyond `vibes`: a stacked PR onto a feature branch would also have been skipped. An unfiltered `pull_request` is the usual shape, because the base branch is not what decides whether code should be tested.

`publish_crates.yaml` is untouched. It triggers on `v*` tags, which is right for publishing.

## Verified

`tests/test_data/test_files.tar.xz` holds 117 `usc/` entries, including `usc09.xml` and `usc51.xml` at both release points, so the CLI test net added in #55 has its fixtures in CI.

This PR tests itself: with the filter gone, CI runs on it.