### PR TITLE
test: finish the CLI test net

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -129,6 +129,173 @@ fn should_list_the_paths_that_changed_between_two_versions_when_diff_runs() {
     );
 }
 
+#[test]
+fn should_list_every_version_with_its_element_count_when_versions_runs() {
+    let output = run(&["versions", amended_fixture(), "--json"]);
+
+    assert!(output.status.success(), "versions should exit zero");
+
+    let versions: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("versions --json should emit json");
+    let versions = versions.as_array().expect("an array of versions");
+
+    assert_eq!(versions.len(), 2);
+    assert_eq!(versions[0]["date"], EARLY);
+    assert_eq!(versions[0]["label"], "Before");
+    assert_eq!(versions[1]["date"], LATE);
+    assert_eq!(versions[1]["label"], "After");
+
+    // The later release carries the two sections title 51 gained, so it must
+    // hold more elements than the earlier one.
+    let count = |v: &serde_json::Value| v["element_count"].as_u64().expect("a count");
+    assert!(
+        count(&versions[1]) > count(&versions[0]),
+        "the amended version should hold more elements: {} then {}",
+        count(&versions[0]),
+        count(&versions[1])
+    );
+}
+
+#[test]
+fn should_find_matching_text_across_versions_when_search_runs() {
+    let output = run(&["search", amended_fixture(), "space", "--json"]);
+
+    assert!(output.status.success(), "search should exit zero");
+
+    let hits: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("search --json should emit json");
+    let hits = hits.as_array().expect("an array of hits");
+
+    assert!(!hits.is_empty(), "title 51 should contain the word 'space'");
+
+    for hit in hits {
+        let date = hit["date"].as_str().expect("a date");
+        assert!(
+            date == EARLY || date == LATE,
+            "a hit should name one of the two versions, got {date}"
+        );
+        let path = hit["path"].as_str().expect("a path");
+        assert!(
+            path.starts_with("uscode/title_51"),
+            "a hit should sit under the title in the dataset, got {path}"
+        );
+        assert!(
+            !hit["snippet"].as_str().expect("a snippet").is_empty(),
+            "a hit should carry a snippet"
+        );
+    }
+}
+
+/// A search that finds nothing must say so, rather than fail or return noise.
+#[test]
+fn should_find_nothing_when_search_has_no_match() {
+    let output = run(&["search", amended_fixture(), "zzqqxnotarealterm", "--json"]);
+
+    assert!(output.status.success(), "an empty search should exit zero");
+
+    let hits: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("search --json should emit json");
+
+    assert_eq!(hits.as_array().expect("an array of hits").len(), 0);
+}
+
+/// Nothing in this fixture is annotated, so every changed path is unannotated.
+/// This pins the empty end of the scale: coverage must report the work left,
+/// not zero work.
+#[test]
+fn should_report_every_changed_path_as_unannotated_when_nothing_is_annotated() {
+    let output = run(&[
+        "coverage",
+        amended_fixture(),
+        "--from",
+        EARLY,
+        "--to",
+        LATE,
+        "--json",
+    ]);
+
+    assert!(output.status.success(), "coverage should exit zero");
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("coverage --json should emit json");
+
+    let changed = report["changed_path_count"].as_u64().expect("a count");
+    assert!(
+        changed > 0,
+        "the amended title should have a change universe"
+    );
+    assert_eq!(report["annotated_count"], 0);
+    assert_eq!(report["unannotated_count"], changed);
+    assert_eq!(report["coverage"], 0.0);
+}
+
+#[test]
+fn should_return_no_annotations_when_the_dataset_has_none() {
+    let output = run(&[
+        "annotations",
+        amended_fixture(),
+        "--from",
+        EARLY,
+        "--to",
+        LATE,
+        "--json",
+    ]);
+
+    assert!(output.status.success(), "annotations should exit zero");
+
+    let annotations: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("annotations --json should emit json");
+
+    assert_eq!(annotations.as_array().expect("an array").len(), 0);
+}
+
+/// `annotations` needs one of three filters. Asking for everything is a usage
+/// error, and it exits 2 rather than panicking.
+#[test]
+fn should_exit_two_when_annotations_is_given_no_filter() {
+    let output = run(&["annotations", amended_fixture(), "--json"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("filter"),
+        "the error should say what is missing"
+    );
+}
+
+/// These two pin that a bad request fails rather than reporting an empty
+/// result. They assert failure, not a specific code, because the codes are not
+/// yet distinct: most commands panic with 101 today. When #51 gives them
+/// meaningful codes, these tests still hold.
+#[test]
+fn should_fail_when_the_dataset_file_does_not_exist() {
+    let output = run(&["info", "no/such/dataset.sqlite", "--json"]);
+
+    assert!(
+        !output.status.success(),
+        "a missing dataset must not look like an empty one"
+    );
+    assert!(!output.stderr.is_empty(), "the failure should be explained");
+}
+
+#[test]
+fn should_fail_when_the_version_date_is_unknown() {
+    let output = run(&[
+        "diff",
+        amended_fixture(),
+        "--from",
+        "1999-01-01",
+        "--to",
+        LATE,
+        "--json",
+    ]);
+
+    assert!(
+        !output.status.success(),
+        "an unknown version must not look like an empty diff"
+    );
+    assert!(!output.stderr.is_empty(), "the failure should be explained");
+}
+
 /// The two files of an unchanged title differ by ten bytes of release stamp.
 /// A diff that reported those as changes would flood every real result with
 /// noise, so this pins that it reports nothing.


### PR DESCRIPTION
Closes #50.

Completes the net begun in #55. Eleven tests now drive the binary as a subprocess and assert on `--json`, the surface an agent reads.

## What this adds

| Command | Pinned |
|---|---|
| `versions` | both releases, their labels, and the later one holding more elements |
| `search` | every hit names a version in the dataset, sits under its title, and carries a snippet |
| `search` (no match) | empty list, exit zero — not a failure |
| `coverage` | with nothing annotated, every changed path is unannotated and coverage is `0.0` |
| `annotations` | empty result for a pair with none |
| `annotations` (no filter) | exit **2**, with an explanation naming the missing filter |
| `info` on a missing file | fails, and explains itself |
| `diff` with an unknown date | fails, rather than reporting an empty diff |

## Two deliberate choices

**The error tests assert failure, not an exit code.** Most commands end in `.expect(...)` and panic with 101, so asserting the code would pin a defect as if it were the contract. Asserting that a bad request fails, and says why, is true now and stays true once #51 gives the commands distinct codes.

**`coverage` pins the empty end of the scale.** With nothing annotated, the report must say every changed path is outstanding. A report that claimed zero work left would be the same class of error as #54: a confident false answer.

## Verification

```
cargo fmt --check     clean
cargo clippy --all-targets --all-features -- -D warnings     no issues
cargo test     182 passed, 5 ignored, 0 failed
```

Baseline before this branch was 174 passed.

## Not covered, on purpose

`build-dataset`, `convert-dataset`, `extract-changes`, `score-amendments`, and `match-amendments`. The first two are slow write paths; the last three call an LLM, and mocking that boundary would test the mock. They need a different approach, and #51 changes them anyway.