### PR TITLE
refactor: split the core storage interface from the legislature extension

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -17,7 +17,8 @@ use crate::congress::{
 };
 use crate::diff::TreeDiff;
 use crate::storage::{
-    DatasetReader, DatasetWriter, InMemoryStorage, SqliteStorage, Storage, VersionInfo,
+    DocumentReader, DocumentWriter, InMemoryStorage, LegislatureReader, LegislatureWriter,
+    LinkReader, LinkWriter, SqliteStorage, Storage, VersionInfo,
 };
 use crate::uslm::bill_parser::Bill;
 use crate::uslm::parser::ParseError;
@@ -472,41 +473,13 @@ impl Dataset<SqliteStorage> {
 
 // --- Implement traits for Dataset<S> ---
 
-impl<S: Storage> DatasetReader for Dataset<S> {
+impl<S: Storage> DocumentReader for Dataset<S> {
     fn list_versions(&self) -> Result<Vec<VersionInfo>, DatasetError> {
         self.storage.list_versions()
     }
 
     fn get_version(&self, date: &str) -> Result<Option<VersionSnapshot>, DatasetError> {
         self.storage.get_version(date)
-    }
-
-    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError> {
-        self.storage.get_bill(id)
-    }
-
-    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
-        self.storage.list_bill_ids()
-    }
-
-    fn get_annotations(
-        &self,
-        from: &str,
-        to: &str,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
-        self.storage.get_annotations(from, to)
-    }
-
-    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
-        self.storage.get_member(bioguide_id)
-    }
-
-    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
-        self.storage.get_sponsor_info(bill_id)
-    }
-
-    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
-        self.storage.get_bill_votes(bill_id)
     }
 
     fn compute_diff(&self, from: &str, to: &str) -> Result<TreeDiff, DatasetError> {
@@ -529,6 +502,20 @@ impl<S: Storage> DatasetReader for Dataset<S> {
         self.storage.prev_version(date)
     }
 
+    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError> {
+        self.storage.find_element(path)
+    }
+}
+
+impl<S: Storage> LinkReader for Dataset<S> {
+    fn get_annotations(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
+        self.storage.get_annotations(from, to)
+    }
+
     fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
         self.storage.annotations_for_path(path)
     }
@@ -540,9 +527,27 @@ impl<S: Storage> DatasetReader for Dataset<S> {
     fn annotation_pairs(&self) -> Result<Vec<VersionPair>, DatasetError> {
         self.storage.annotation_pairs()
     }
+}
 
-    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError> {
-        self.storage.find_element(path)
+impl<S: Storage> LegislatureReader for Dataset<S> {
+    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError> {
+        self.storage.get_bill(id)
+    }
+
+    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
+        self.storage.list_bill_ids()
+    }
+
+    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
+        self.storage.get_member(bioguide_id)
+    }
+
+    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
+        self.storage.get_sponsor_info(bill_id)
+    }
+
+    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
+        self.storage.get_bill_votes(bill_id)
     }
 
     fn votes_by_member(
@@ -553,7 +558,7 @@ impl<S: Storage> DatasetReader for Dataset<S> {
     }
 }
 
-impl<S: Storage> DatasetWriter for Dataset<S> {
+impl<S: Storage> DocumentWriter for Dataset<S> {
     fn metadata(&self) -> &DatasetMetadata {
         self.storage.metadata()
     }
@@ -565,11 +570,9 @@ impl<S: Storage> DatasetWriter for Dataset<S> {
     fn add_version(&mut self, snapshot: VersionSnapshot) -> Result<(), DatasetError> {
         self.storage.add_version(snapshot)
     }
+}
 
-    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
-        self.storage.add_bill(bill)
-    }
-
+impl<S: Storage> LinkWriter for Dataset<S> {
     fn add_annotation(
         &mut self,
         from: &str,
@@ -577,6 +580,12 @@ impl<S: Storage> DatasetWriter for Dataset<S> {
         annotation: ChangeAnnotation,
     ) -> Result<(), DatasetError> {
         self.storage.add_annotation(from, to, annotation)
+    }
+}
+
+impl<S: Storage> LegislatureWriter for Dataset<S> {
+    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
+        self.storage.add_bill(bill)
     }
 
     fn add_member(&mut self, member: Member) -> Result<(), DatasetError> {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -9,7 +9,10 @@ use crate::congress::{BillVotes, HouseRollCall, Member, SponsorInfo, VotePositio
 use crate::dataset::{DatasetError, DatasetMetadata, SearchResult, VersionPair, VersionSnapshot};
 use crate::diff::TreeDiff;
 use crate::intern::StringInterner;
-use crate::storage::{DatasetReader, DatasetWriter, Storage, VersionInfo};
+use crate::storage::{
+    DocumentReader, DocumentWriter, LegislatureReader, LegislatureWriter, LinkReader, LinkWriter,
+    Storage, VersionInfo,
+};
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
 
@@ -134,7 +137,7 @@ impl InMemoryStorage {
     }
 }
 
-impl DatasetReader for InMemoryStorage {
+impl DocumentReader for InMemoryStorage {
     fn list_versions(&self) -> Result<Vec<VersionInfo>, DatasetError> {
         Ok(self
             .versions
@@ -148,35 +151,6 @@ impl DatasetReader for InMemoryStorage {
 
     fn get_version(&self, date: &str) -> Result<Option<VersionSnapshot>, DatasetError> {
         Ok(self.versions.iter().find(|v| v.date == date).cloned())
-    }
-
-    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError> {
-        Ok(self.bills.get(id).cloned())
-    }
-
-    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
-        Ok(self.bills.keys().cloned().collect())
-    }
-
-    fn get_annotations(
-        &self,
-        from: &str,
-        to: &str,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
-        let key = (from.to_string(), to.to_string());
-        Ok(self.diff_annotations.get(&key).cloned())
-    }
-
-    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
-        Ok(self.members.get(bioguide_id).cloned())
-    }
-
-    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
-        Ok(self.sponsors.get(bill_id).cloned())
-    }
-
-    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
-        Ok(self.bill_votes.get(bill_id).cloned())
     }
 
     fn compute_diff(&self, from: &str, to: &str) -> Result<TreeDiff, DatasetError> {
@@ -228,6 +202,25 @@ impl DatasetReader for InMemoryStorage {
         }))
     }
 
+    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError> {
+        Ok(self
+            .versions
+            .iter()
+            .filter_map(|v| v.element.find(path).map(|e| (v.date.clone(), e.clone())))
+            .collect())
+    }
+}
+
+impl LinkReader for InMemoryStorage {
+    fn get_annotations(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
+        let key = (from.to_string(), to.to_string());
+        Ok(self.diff_annotations.get(&key).cloned())
+    }
+
     fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
         Ok(self
             .diff_annotations
@@ -251,13 +244,27 @@ impl DatasetReader for InMemoryStorage {
     fn annotation_pairs(&self) -> Result<Vec<VersionPair>, DatasetError> {
         Ok(self.diff_annotations.keys().cloned().collect())
     }
+}
 
-    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError> {
-        Ok(self
-            .versions
-            .iter()
-            .filter_map(|v| v.element.find(path).map(|e| (v.date.clone(), e.clone())))
-            .collect())
+impl LegislatureReader for InMemoryStorage {
+    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError> {
+        Ok(self.bills.get(id).cloned())
+    }
+
+    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
+        Ok(self.bills.keys().cloned().collect())
+    }
+
+    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
+        Ok(self.members.get(bioguide_id).cloned())
+    }
+
+    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
+        Ok(self.sponsors.get(bill_id).cloned())
+    }
+
+    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
+        Ok(self.bill_votes.get(bill_id).cloned())
     }
 
     fn votes_by_member(
@@ -278,7 +285,7 @@ impl DatasetReader for InMemoryStorage {
     }
 }
 
-impl DatasetWriter for InMemoryStorage {
+impl DocumentWriter for InMemoryStorage {
     fn metadata(&self) -> &DatasetMetadata {
         &self.metadata
     }
@@ -295,12 +302,9 @@ impl DatasetWriter for InMemoryStorage {
         self.versions.insert(pos, snapshot);
         Ok(())
     }
+}
 
-    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
-        self.bills.insert(bill.bill_id.clone(), bill);
-        Ok(())
-    }
-
+impl LinkWriter for InMemoryStorage {
     fn add_annotation(
         &mut self,
         from: &str,
@@ -311,6 +315,13 @@ impl DatasetWriter for InMemoryStorage {
             .entry((from.to_string(), to.to_string()))
             .or_default()
             .push(annotation);
+        Ok(())
+    }
+}
+
+impl LegislatureWriter for InMemoryStorage {
+    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
+        self.bills.insert(bill.bill_id.clone(), bill);
         Ok(())
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,4 +1,19 @@
-//! Storage backends for dataset persistence
+//! Storage backends for dataset persistence.
+//!
+//! The traits split three ways, which is the shape the data model needs (#51):
+//!
+//! - **Documents** are the core. Versions, navigation, diffing, and search work
+//!   the same whether the document is a statute, a regulation, or an opinion.
+//!   Nothing here names a legislature or a court.
+//! - **Links** are also core. A link connects a provision to something else and
+//!   carries its provenance. Today the only kind is the change annotation, which
+//!   ties a change to the amendment that caused it.
+//! - **Legislature** is an extension. Bills, sponsors, members, and votes exist
+//!   only in datasets that hold legislative material. A dataset of court
+//!   opinions has none of them, and must not have to pretend otherwise.
+//!
+//! `Storage` is the full set that both first-party backends implement today. A
+//! backend that holds only documents implements [`DocumentReader`] alone.
 
 pub mod memory;
 pub mod sqlite;
@@ -20,46 +35,16 @@ pub struct VersionInfo {
     pub label: Option<String>,
 }
 
-/// Trait for querying dataset contents
+/// Reading the documents a dataset holds.
 ///
-/// Implemented by both `Dataset` (in-memory) and `SqliteStorage` (database).
-/// Allows consumer code to work with either backend.
-pub trait DatasetReader {
+/// This is the core interface. Every document class supports it, so nothing
+/// here may name a legislature, a court, or any other extension concept.
+pub trait DocumentReader {
     /// List all available versions (date + label, no element tree)
     fn list_versions(&self) -> Result<Vec<VersionInfo>, DatasetError>;
 
     /// Get a specific version by date
     fn get_version(&self, date: &str) -> Result<Option<VersionSnapshot>, DatasetError>;
-
-    /// Get a bill by ID
-    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError>;
-
-    /// List the IDs of every bill in the dataset
-    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError>;
-
-    /// Get annotations for a version pair
-    fn get_annotations(
-        &self,
-        from: &str,
-        to: &str,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError>;
-
-    /// Get a Congress member by bioguide ID
-    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError>;
-
-    /// Get sponsor info for a bill
-    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError>;
-
-    /// Get votes for a bill
-    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError>;
-
-    /// Compute diff between two versions
-    fn compute_diff(&self, from: &str, to: &str) -> Result<TreeDiff, DatasetError>;
-
-    /// Search text across versions
-    fn search_text(&self, query: &str) -> Result<Vec<SearchResult>, DatasetError>;
-
-    // --- Navigation methods ---
 
     /// Get a version by label
     fn get_version_by_label(&self, label: &str) -> Result<Option<VersionSnapshot>, DatasetError>;
@@ -70,7 +55,33 @@ pub trait DatasetReader {
     /// Get the previous version before the given date
     fn prev_version(&self, date: &str) -> Result<Option<VersionSnapshot>, DatasetError>;
 
-    // --- Cross-reference queries ---
+    /// Compute diff between two versions
+    fn compute_diff(&self, from: &str, to: &str) -> Result<TreeDiff, DatasetError>;
+
+    /// Search text across versions
+    fn search_text(&self, query: &str) -> Result<Vec<SearchResult>, DatasetError>;
+
+    /// Find element by path across all versions
+    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError>;
+}
+
+/// Reading the links a dataset holds.
+///
+/// A link connects a provision to something else and carries its provenance.
+/// Links are core, not part of any extension, so that a reader which does not
+/// know an extension can still see, report, and preserve its links
+/// (`docs/adr/0002-links-live-in-the-core.md`).
+///
+/// Today the only kind is the change annotation. `annotations_for_bill` is a
+/// query by link object, and the bill id is an opaque string here: this trait
+/// does not need to know what a bill is.
+pub trait LinkReader {
+    /// Get annotations for a version pair
+    fn get_annotations(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError>;
 
     /// Find all annotations that include the given path (across all version pairs)
     fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError>;
@@ -80,9 +91,29 @@ pub trait DatasetReader {
 
     /// List every `(from_date, to_date)` pair that carries annotations
     fn annotation_pairs(&self) -> Result<Vec<crate::dataset::VersionPair>, DatasetError>;
+}
 
-    /// Find element by path across all versions
-    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError>;
+/// Reading the legislature facts a dataset holds.
+///
+/// An extension, not core. Implement it only for a backend that actually holds
+/// bills. A dataset of court opinions does not, and a caller reading a file
+/// from another party must be able to find that out rather than get an error
+/// from a method that should never have existed for that data.
+pub trait LegislatureReader {
+    /// Get a bill by ID
+    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError>;
+
+    /// List the IDs of every bill in the dataset
+    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError>;
+
+    /// Get a Congress member by bioguide ID
+    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError>;
+
+    /// Get sponsor info for a bill
+    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError>;
+
+    /// Get votes for a bill
+    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError>;
 
     /// Get all roll calls where a member voted, with their position
     fn votes_by_member(
@@ -91,8 +122,8 @@ pub trait DatasetReader {
     ) -> Result<Vec<(HouseRollCall, VotePosition)>, DatasetError>;
 }
 
-/// Trait for writing dataset contents
-pub trait DatasetWriter {
+/// Writing documents and dataset metadata.
+pub trait DocumentWriter {
     /// Get metadata
     fn metadata(&self) -> &DatasetMetadata;
 
@@ -101,10 +132,10 @@ pub trait DatasetWriter {
 
     /// Add a version snapshot
     fn add_version(&mut self, snapshot: VersionSnapshot) -> Result<(), DatasetError>;
+}
 
-    /// Add a bill
-    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError>;
-
+/// Writing links.
+pub trait LinkWriter {
     /// Add an annotation for a version pair
     fn add_annotation(
         &mut self,
@@ -112,6 +143,12 @@ pub trait DatasetWriter {
         to: &str,
         annotation: ChangeAnnotation,
     ) -> Result<(), DatasetError>;
+}
+
+/// Writing legislature facts. An extension, like [`LegislatureReader`].
+pub trait LegislatureWriter {
+    /// Add a bill
+    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError>;
 
     /// Add a Congress member
     fn add_member(&mut self, member: Member) -> Result<(), DatasetError>;
@@ -123,5 +160,12 @@ pub trait DatasetWriter {
     fn add_bill_votes(&mut self, votes: BillVotes) -> Result<(), DatasetError>;
 }
 
-/// Combined storage trait for full dataset access
-pub trait Storage: DatasetReader + DatasetWriter {}
+/// The full set of capabilities, which both first-party backends provide.
+///
+/// Code that needs everything binds to this. Code that needs only documents
+/// should bind to [`DocumentReader`] instead, so it keeps working against a
+/// dataset that carries no legislative material.
+pub trait Storage:
+    DocumentReader + LinkReader + LegislatureReader + DocumentWriter + LinkWriter + LegislatureWriter
+{
+}

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -10,7 +10,10 @@ use crate::congress::{BillVotes, HouseRollCall, Member, MemberVote, SponsorInfo,
 use crate::dataset::{DatasetError, DatasetMetadata, SearchResult, VersionPair, VersionSnapshot};
 use crate::diff::TreeDiff;
 use crate::intern::StringInterner;
-use crate::storage::{DatasetReader, DatasetWriter, InMemoryStorage, Storage, VersionInfo};
+use crate::storage::{
+    DocumentReader, DocumentWriter, InMemoryStorage, LegislatureReader, LegislatureWriter,
+    LinkReader, LinkWriter, Storage, VersionInfo,
+};
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
 
@@ -730,7 +733,7 @@ impl SqliteStorage {
     }
 }
 
-impl DatasetReader for SqliteStorage {
+impl DocumentReader for SqliteStorage {
     fn list_versions(&self) -> Result<Vec<VersionInfo>, DatasetError> {
         let mut stmt = self
             .conn
@@ -766,74 +769,6 @@ impl DatasetReader for SqliteStorage {
         } else {
             Ok(None)
         }
-    }
-
-    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT data_json FROM bills WHERE bill_id = ?1")?;
-        let mut rows = stmt.query(params![id])?;
-
-        if let Some(row) = rows.next()? {
-            let data_json: String = row.get(0)?;
-            let bill: Bill = serde_json::from_str(&data_json)?;
-            Ok(Some(bill))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
-        let mut stmt = self.conn.prepare("SELECT bill_id FROM bills")?;
-        let ids = stmt
-            .query_map([], |row| row.get(0))?
-            .collect::<Result<Vec<String>, _>>()?;
-        Ok(ids)
-    }
-
-    fn get_annotations(
-        &self,
-        from: &str,
-        to: &str,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
-        let all = self.load_annotations()?;
-        let key = (from.to_string(), to.to_string());
-        Ok(all.get(&key).cloned())
-    }
-
-    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT data_json FROM members WHERE bioguide_id = ?1")?;
-        let mut rows = stmt.query(params![bioguide_id])?;
-
-        if let Some(row) = rows.next()? {
-            let data_json: String = row.get(0)?;
-            let member: Member = serde_json::from_str(&data_json)?;
-            Ok(Some(member))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT data_json FROM sponsors WHERE bill_id = ?1")?;
-        let mut rows = stmt.query(params![bill_id])?;
-
-        if let Some(row) = rows.next()? {
-            let data_json: String = row.get(0)?;
-            let info: SponsorInfo = serde_json::from_str(&data_json)?;
-            Ok(Some(info))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
-        let all = self.load_bill_votes()?;
-        Ok(all.get(bill_id).cloned())
     }
 
     fn compute_diff(&self, from: &str, to: &str) -> Result<TreeDiff, DatasetError> {
@@ -936,6 +871,38 @@ impl DatasetReader for SqliteStorage {
         } else {
             Ok(None)
         }
+    }
+
+    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError> {
+        // Use element_index to find which versions have this path
+        let mut stmt = self
+            .conn
+            .prepare("SELECT DISTINCT version_date FROM element_index WHERE path = ?1")?;
+        let mut rows = stmt.query(params![path])?;
+
+        let mut results = Vec::new();
+        while let Some(row) = rows.next()? {
+            let date: String = row.get(0)?;
+            if let Some(version) = self.get_version(&date)?
+                && let Some(elem) = version.element.find(path)
+            {
+                results.push((date, elem.clone()));
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+impl LinkReader for SqliteStorage {
+    fn get_annotations(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
+        let all = self.load_annotations()?;
+        let key = (from.to_string(), to.to_string());
+        Ok(all.get(&key).cloned())
     }
 
     fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
@@ -1123,25 +1090,65 @@ impl DatasetReader for SqliteStorage {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(pairs)
     }
+}
 
-    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError> {
-        // Use element_index to find which versions have this path
+impl LegislatureReader for SqliteStorage {
+    fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError> {
         let mut stmt = self
             .conn
-            .prepare("SELECT DISTINCT version_date FROM element_index WHERE path = ?1")?;
-        let mut rows = stmt.query(params![path])?;
+            .prepare("SELECT data_json FROM bills WHERE bill_id = ?1")?;
+        let mut rows = stmt.query(params![id])?;
 
-        let mut results = Vec::new();
-        while let Some(row) = rows.next()? {
-            let date: String = row.get(0)?;
-            if let Some(version) = self.get_version(&date)?
-                && let Some(elem) = version.element.find(path)
-            {
-                results.push((date, elem.clone()));
-            }
+        if let Some(row) = rows.next()? {
+            let data_json: String = row.get(0)?;
+            let bill: Bill = serde_json::from_str(&data_json)?;
+            Ok(Some(bill))
+        } else {
+            Ok(None)
         }
+    }
 
-        Ok(results)
+    fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
+        let mut stmt = self.conn.prepare("SELECT bill_id FROM bills")?;
+        let ids = stmt
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<Vec<String>, _>>()?;
+        Ok(ids)
+    }
+
+    fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT data_json FROM members WHERE bioguide_id = ?1")?;
+        let mut rows = stmt.query(params![bioguide_id])?;
+
+        if let Some(row) = rows.next()? {
+            let data_json: String = row.get(0)?;
+            let member: Member = serde_json::from_str(&data_json)?;
+            Ok(Some(member))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT data_json FROM sponsors WHERE bill_id = ?1")?;
+        let mut rows = stmt.query(params![bill_id])?;
+
+        if let Some(row) = rows.next()? {
+            let data_json: String = row.get(0)?;
+            let info: SponsorInfo = serde_json::from_str(&data_json)?;
+            Ok(Some(info))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
+        let all = self.load_bill_votes()?;
+        Ok(all.get(bill_id).cloned())
     }
 
     fn votes_by_member(
@@ -1228,7 +1235,7 @@ impl DatasetReader for SqliteStorage {
     }
 }
 
-impl DatasetWriter for SqliteStorage {
+impl DocumentWriter for SqliteStorage {
     fn metadata(&self) -> &DatasetMetadata {
         &self.metadata
     }
@@ -1253,16 +1260,9 @@ impl DatasetWriter for SqliteStorage {
 
         Ok(())
     }
+}
 
-    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
-        let json = serde_json::to_string(&bill)?;
-        self.conn.execute(
-            "INSERT OR REPLACE INTO bills (bill_id, data_json) VALUES (?1, ?2)",
-            params![&bill.bill_id, json],
-        )?;
-        Ok(())
-    }
-
+impl LinkWriter for SqliteStorage {
     fn add_annotation(
         &mut self,
         from: &str,
@@ -1299,6 +1299,17 @@ impl DatasetWriter for SqliteStorage {
             )?;
         }
 
+        Ok(())
+    }
+}
+
+impl LegislatureWriter for SqliteStorage {
+    fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
+        let json = serde_json::to_string(&bill)?;
+        self.conn.execute(
+            "INSERT OR REPLACE INTO bills (bill_id, data_json) VALUES (?1, ?2)",
+            params![&bill.bill_id, json],
+        )?;
         Ok(())
     }
 

--- a/tests/sqlite_tests.rs
+++ b/tests/sqlite_tests.rs
@@ -3,7 +3,9 @@ use std::io::BufReader;
 
 use words_to_data::annotation::ChangeAnnotation;
 use words_to_data::dataset::{Dataset, DatasetMetadata, VersionSnapshot};
-use words_to_data::storage::{DatasetReader, InMemoryStorage, SqliteStorage};
+use words_to_data::storage::{
+    DocumentReader, InMemoryStorage, LegislatureReader, LinkReader, SqliteStorage,
+};
 use words_to_data::uslm::bill_parser::parse_bill_amendments;
 use words_to_data::uslm::parser::parse;
 
@@ -180,7 +182,7 @@ fn should_query_via_trait_interface() {
     dataset.save_to_sqlite(path).unwrap();
 
     // Query via trait - works for both Dataset and SqliteStorage
-    fn check_reader(reader: &impl DatasetReader) {
+    fn check_reader(reader: &(impl DocumentReader + LinkReader + LegislatureReader)) {
         // list_versions
         let versions = reader.list_versions().unwrap();
         assert_eq!(versions.len(), 2);
@@ -288,7 +290,7 @@ fn should_query_annotations_for_path_via_trait() {
     dataset.save_to_sqlite(path).unwrap();
 
     // Test via trait - should work for both
-    fn check_annotations_for_path(reader: &impl DatasetReader) {
+    fn check_annotations_for_path(reader: &impl LinkReader) {
         let anns = reader.annotations_for_path(TEST_PATH).unwrap();
         assert!(!anns.is_empty());
         // All returned annotations should contain the path

--- a/tests/storage_traits_tests.rs
+++ b/tests/storage_traits_tests.rs
@@ -1,0 +1,98 @@
+//! Proves the core storage interface is independent of the legislature
+//! extension (#51).
+//!
+//! `DocumentsOnly` implements `DocumentReader` and nothing else. It holds no
+//! bills, no sponsors, no members, and no votes, and it is never asked for any.
+//! If this file compiles, a backend for a document class that has no
+//! legislature — a court opinion, a state regulation — can be written without
+//! implementing methods that make no sense for it.
+//!
+//! Before the split that was impossible: `DatasetReader` demanded `get_bill`,
+//! `get_member`, `get_sponsor_info`, and `get_bill_votes` from every backend.
+
+use words_to_data::dataset::{DatasetError, DatasetMetadata, SearchResult, VersionSnapshot};
+use words_to_data::diff::TreeDiff;
+use words_to_data::storage::{DocumentReader, DocumentWriter, InMemoryStorage, VersionInfo};
+use words_to_data::uslm::USLMElement;
+use words_to_data::uslm::parser::parse;
+
+const TITLE_9: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
+
+/// A documents-only backend. It delegates to real storage, so the data under
+/// test is the real corpus, not an invention.
+struct DocumentsOnly(InMemoryStorage);
+
+impl DocumentReader for DocumentsOnly {
+    fn list_versions(&self) -> Result<Vec<VersionInfo>, DatasetError> {
+        self.0.list_versions()
+    }
+
+    fn get_version(&self, date: &str) -> Result<Option<VersionSnapshot>, DatasetError> {
+        self.0.get_version(date)
+    }
+
+    fn get_version_by_label(&self, label: &str) -> Result<Option<VersionSnapshot>, DatasetError> {
+        self.0.get_version_by_label(label)
+    }
+
+    fn next_version(&self, date: &str) -> Result<Option<VersionSnapshot>, DatasetError> {
+        self.0.next_version(date)
+    }
+
+    fn prev_version(&self, date: &str) -> Result<Option<VersionSnapshot>, DatasetError> {
+        self.0.prev_version(date)
+    }
+
+    fn compute_diff(&self, from: &str, to: &str) -> Result<TreeDiff, DatasetError> {
+        self.0.compute_diff(from, to)
+    }
+
+    fn search_text(&self, query: &str) -> Result<Vec<SearchResult>, DatasetError> {
+        self.0.search_text(query)
+    }
+
+    fn find_element(&self, path: &str) -> Result<Vec<(String, USLMElement)>, DatasetError> {
+        self.0.find_element(path)
+    }
+}
+
+/// Accepts anything that can read documents, and asks for nothing else.
+fn count_versions(reader: &impl DocumentReader) -> usize {
+    reader.list_versions().expect("versions should list").len()
+}
+
+#[test]
+fn should_read_documents_from_a_backend_that_implements_no_legislature_methods() {
+    let mut storage = InMemoryStorage::new(DatasetMetadata {
+        name: "Documents only".to_string(),
+        description: "One title, no bills".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "MIT".to_string(),
+        version: "1.0.0".to_string(),
+    });
+    storage
+        .add_version(VersionSnapshot {
+            date: "2025-07-18".to_string(),
+            label: Some("Only".to_string()),
+            element: parse(TITLE_9, "2025-07-18").expect("the corpus should parse"),
+        })
+        .expect("a version should be added");
+
+    let documents = DocumentsOnly(storage);
+
+    assert_eq!(count_versions(&documents), 1);
+    assert!(
+        documents
+            .get_version("2025-07-18")
+            .expect("the version should be readable")
+            .is_some()
+    );
+    assert!(
+        !documents
+            .search_text("arbitration")
+            .expect("search should work")
+            .is_empty(),
+        "title 9 is the Arbitration title"
+    );
+}


### PR DESCRIPTION
First slice of #51. Behaviour-preserving.

## The problem

`DatasetReader` put US Congress concepts in the interface every backend had to implement:

```rust
fn get_bill(&self, id: &str) -> ...;
fn get_member(&self, bioguide_id: &str) -> ...;
fn get_sponsor_info(&self, bill_id: &str) -> ...;
fn get_bill_votes(&self, bill_id: &str) -> ...;
fn votes_by_member(&self, bioguide_id: &str) -> ...;
```

A court opinion has no sponsor. A state regulation has no roll-call vote. Neither could be stored without a backend pretending to have them.

## The split

| Trait | Holds |
|---|---|
| `DocumentReader` / `DocumentWriter` | versions, navigation, diff, search, `find_element`, metadata |
| `LinkReader` / `LinkWriter` | the annotation queries |
| `LegislatureReader` / `LegislatureWriter` | bills, sponsors, members, votes |

`Storage` is the union of all six, and both first-party backends implement it, so callers needing everything are untouched.

**Links stay core**, per `docs/adr/0002-links-live-in-the-core.md`. A reader that does not know an extension must still see, report, and preserve its links. `annotations_for_bill` is a query by link object, and the bill id is an opaque string to that trait.

## The proof it is not cosmetic

`tests/storage_traits_tests.rs` defines a backend implementing `DocumentReader` **alone** — no legislature methods — over real corpus data from title 9. It compiles, so a documents-only backend is now writable. Before the split it was not.

## Verification

```
cargo fmt --check     clean
cargo clippy --all-targets --all-features -- -D warnings     no issues
cargo test     185 passed, 5 ignored, 0 failed
```

Baseline before the change was 184 passed; the extra one is the new proof test. No existing test changed its expectations, which is the point: this slice moves methods between traits and nothing else.

## Method: how the backends were regrouped

The methods were interleaved by trait declaration order, so I reassembled the two large impl blocks with `sed` line ranges rather than retyping ~600 lines of SQL by hand. The compiler and the unchanged test results are the check on that.

## Still to come in #51

The run-time door (`Dataset::legislature() -> Option<&dyn LegislatureReader>`), scope as a first-class answer, works and expressions replacing date keys, the `Link` type with namespaced kinds, and separating `ingest/uslm` from the legislature domain. Each needs its own slice; this one deliberately changes no behaviour.