### PR TITLE
feat: add the run-time door to the legislature extension

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -97,6 +97,23 @@ impl<S: Storage> Dataset<S> {
         &mut self.storage
     }
 
+    /// The legislature extension, when this dataset carries one.
+    ///
+    /// Use this when reading a dataset whose contents you do not control:
+    ///
+    /// ```ignore
+    /// match dataset.legislature() {
+    ///     Some(legislature) => legislature.get_bill(id)?,
+    ///     None => return Err("this dataset holds no legislative material".into()),
+    /// }
+    /// ```
+    ///
+    /// `None` means the dataset has no legislative material at all, which is a
+    /// different answer from "no bill matches that id".
+    pub fn legislature(&self) -> Option<&dyn LegislatureReader> {
+        self.storage.legislature()
+    }
+
     // --- Delegate DatasetReader methods ---
 
     pub fn list_versions(&self) -> Result<Vec<VersionInfo>, DatasetError> {
@@ -601,4 +618,8 @@ impl<S: Storage> LegislatureWriter for Dataset<S> {
     }
 }
 
-impl<S: Storage> Storage for Dataset<S> {}
+impl<S: Storage> Storage for Dataset<S> {
+    fn legislature(&self) -> Option<&dyn LegislatureReader> {
+        self.storage.legislature()
+    }
+}

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -341,4 +341,12 @@ impl LegislatureWriter for InMemoryStorage {
     }
 }
 
-impl Storage for InMemoryStorage {}
+impl Storage for InMemoryStorage {
+    fn legislature(&self) -> Option<&dyn LegislatureReader> {
+        let holds_legislature = !self.bills.is_empty()
+            || !self.members.is_empty()
+            || !self.sponsors.is_empty()
+            || !self.bill_votes.is_empty();
+        holds_legislature.then_some(self as &dyn LegislatureReader)
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -168,4 +168,20 @@ pub trait LegislatureWriter {
 pub trait Storage:
     DocumentReader + LinkReader + LegislatureReader + DocumentWriter + LinkWriter + LegislatureWriter
 {
+    /// The legislature extension, when this dataset actually carries one.
+    ///
+    /// This is the run-time door. A dataset arriving from another party is
+    /// whatever it is, and the caller cannot know at compile time whether it
+    /// holds bills. `None` means "this dataset has no legislative material",
+    /// which is a different answer from "it has no bills matching your query",
+    /// and the difference is the one a researcher needs.
+    ///
+    /// Code of our own that always needs bills should take
+    /// `impl DocumentReader + LegislatureReader` instead, and let the compiler
+    /// enforce it.
+    ///
+    /// Today the answer comes from the contents. Once a dataset declares its
+    /// scope, the declaration decides, and a mismatch between the two becomes
+    /// a reported gap.
+    fn legislature(&self) -> Option<&dyn LegislatureReader>;
 }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1363,4 +1363,33 @@ impl LegislatureWriter for SqliteStorage {
     }
 }
 
-impl Storage for SqliteStorage {}
+impl SqliteStorage {
+    /// True when any legislative table holds a row.
+    ///
+    /// A dataset that was never given bills, sponsors, members, or votes has
+    /// no legislature to offer, even though the tables exist because every
+    /// dataset shares one schema today.
+    fn holds_legislature(&self) -> Result<bool, DatasetError> {
+        for table in ["bills", "members", "sponsors", "roll_calls"] {
+            let present: bool = self.conn.query_row(
+                &format!("SELECT EXISTS(SELECT 1 FROM {table} LIMIT 1)"),
+                [],
+                |row| row.get(0),
+            )?;
+            if present {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+impl Storage for SqliteStorage {
+    fn legislature(&self) -> Option<&dyn LegislatureReader> {
+        // A database error here means we cannot show legislative material, so
+        // the honest answer is that this dataset offers none.
+        self.holds_legislature()
+            .unwrap_or(false)
+            .then_some(self as &dyn LegislatureReader)
+    }
+}

--- a/tests/storage_traits_tests.rs
+++ b/tests/storage_traits_tests.rs
@@ -10,13 +10,18 @@
 //! Before the split that was impossible: `DatasetReader` demanded `get_bill`,
 //! `get_member`, `get_sponsor_info`, and `get_bill_votes` from every backend.
 
-use words_to_data::dataset::{DatasetError, DatasetMetadata, SearchResult, VersionSnapshot};
+use words_to_data::dataset::{
+    Dataset, DatasetError, DatasetMetadata, SearchResult, VersionSnapshot,
+};
 use words_to_data::diff::TreeDiff;
 use words_to_data::storage::{DocumentReader, DocumentWriter, InMemoryStorage, VersionInfo};
 use words_to_data::uslm::USLMElement;
+use words_to_data::uslm::bill_parser::parse_bill_amendments;
 use words_to_data::uslm::parser::parse;
 
 const TITLE_9: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
+const BILL_XML: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml";
+const BILL_ID: &str = "119-21";
 
 /// A documents-only backend. It delegates to real storage, so the data under
 /// test is the real corpus, not an invention.
@@ -94,5 +99,60 @@ fn should_read_documents_from_a_backend_that_implements_no_legislature_methods()
             .expect("search should work")
             .is_empty(),
         "title 9 is the Arbitration title"
+    );
+}
+
+/// Build a dataset holding one release of title 9, and optionally a real bill.
+fn dataset_holding(bill: bool) -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Door test".to_string(),
+        description: "Title 9, with or without a bill".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "MIT".to_string(),
+        version: "1.0.0".to_string(),
+    });
+    dataset
+        .add_version(VersionSnapshot {
+            date: "2025-07-18".to_string(),
+            label: None,
+            element: parse(TITLE_9, "2025-07-18").expect("the corpus should parse"),
+        })
+        .expect("a version should be added");
+
+    if bill {
+        let parsed = parse_bill_amendments(BILL_ID, BILL_XML).expect("the public law should parse");
+        dataset.add_bill(parsed).expect("the bill should be added");
+    }
+
+    dataset
+}
+
+/// A dataset of statutes and bills carries legislative material, so the door
+/// opens and the caller can read bills through it.
+#[test]
+fn should_open_the_legislature_door_when_the_dataset_holds_a_bill() {
+    let dataset = dataset_holding(true);
+
+    let legislature = dataset
+        .legislature()
+        .expect("a dataset holding a bill should offer the legislature extension");
+
+    assert_eq!(
+        legislature.list_bill_ids().expect("ids should list"),
+        vec![BILL_ID.to_string()]
+    );
+}
+
+/// The point of the door: a dataset that holds only documents reports that it
+/// has no legislature, instead of answering "no bills" as though the question
+/// made sense for its contents.
+#[test]
+fn should_close_the_legislature_door_when_the_dataset_holds_no_legislative_material() {
+    let dataset = dataset_holding(false);
+
+    assert!(
+        dataset.legislature().is_none(),
+        "a dataset of documents alone should not offer the legislature extension"
     );
 }


### PR DESCRIPTION
Second slice of #51, following #60. This one changes behaviour.

## Why a run-time door

#60 split the traits, so a documents-only backend is now writable. But `Dataset<S: Storage>` still requires every capability, and a W2D file arriving from another party is whatever it is. The caller cannot know at compile time whether it holds bills.

```rust
match dataset.legislature() {
    Some(legislature) => legislature.get_bill(id)?,
    None => // this dataset holds no legislative material
}
```

`None` means the dataset carries no legislative material at all. That is a **different answer** from "no bill matches that id". Conflating them is the same failure as #54: absence of an answer reading as absence in the law.

## How each backend decides

- `InMemoryStorage`: whether bills, members, sponsors, or votes are present.
- `SqliteStorage`: the same question of its tables. The tables exist in every dataset because the schema is shared, so emptiness is the only signal available today. A database error is treated as "no legislature" — we cannot show what we cannot read.

Compile-time bounds remain the right tool for our own code: anything that always needs bills should take `impl DocumentReader + LegislatureReader`. The door is for data whose shape is unknown until opened.

## Tests

- a dataset holding a real bill from HR 1 opens the door, and bills are readable through it
- a dataset holding only title 9 closes it

## Verification

```
cargo fmt --check     clean
cargo clippy --all-targets --all-features -- -D warnings     no issues
cargo test     187 passed, 6 ignored, 0 failed
```

Baseline was 185 passed, 5 ignored. Two new tests; the extra ignored one is the ```ignore doc example on `Dataset::legislature`.

## Known limit

Deciding from contents means a legislative dataset that has not been given bills yet reports no legislature. The fix is scope: once a dataset declares what it intends to cover, the declaration decides and a mismatch with the contents becomes a reported gap. That is the next slice.