### PR TITLE
feat: report what a dataset covers in info

### DIFF
--- a/src/bin/words_to_data/info.rs
+++ b/src/bin/words_to_data/info.rs
@@ -5,6 +5,9 @@ use words_to_data::inspect;
 
 use crate::load::{self, with_dataset};
 
+/// How many coverage units the human output lists before it summarizes.
+const SCOPE_SAMPLE: usize = 5;
+
 #[derive(ClapArgs)]
 pub struct Args {
     /// Dataset file (`.json` compact or `.sqlite`)
@@ -34,4 +37,18 @@ pub fn run(args: Args) {
     }
     println!("Versions:    {}", info.version_count);
     println!("Bills:       {}", info.bill_count);
+
+    // Scope is the answer to "why did my query find nothing". Print it, so a
+    // reader of this dataset knows what it does not hold.
+    match info.scope.held.len() {
+        0 => println!("Covers:      nothing"),
+        // A full US Code dataset holds 60+ units, which is a wall of text on
+        // one line. Show a sample and the count; `--json` carries them all.
+        count if count > SCOPE_SAMPLE => println!(
+            "Covers:      {} units, including {}",
+            count,
+            info.scope.held[..SCOPE_SAMPLE].join(", ")
+        ),
+        _ => println!("Covers:      {}", info.scope.held.join(", ")),
+    }
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -112,15 +112,7 @@ impl<S: Storage> Dataset<S> {
     /// }
     /// ```
     pub fn scope(&self) -> Result<Scope, DatasetError> {
-        let mut versions = Vec::new();
-        for info in self.storage.list_versions()? {
-            if let Some(snapshot) = self.storage.get_version(&info.date)? {
-                versions.push(snapshot);
-            }
-        }
-        Ok(Scope::from_versions(
-            versions.iter().map(|v| (v.date.as_str(), &v.element)),
-        ))
+        Scope::derive(&self.storage)
     }
 
     /// The legislature extension, when this dataset carries one.

--- a/src/dataset/scope.rs
+++ b/src/dataset/scope.rs
@@ -17,6 +17,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::dataset::DatasetError;
+use crate::storage::DocumentReader;
 use crate::uslm::USLMElement;
 
 /// Whether a dataset covers something.
@@ -41,6 +43,19 @@ pub struct Scope {
 }
 
 impl Scope {
+    /// Derive the scope of anything that can read documents.
+    pub fn derive<R: DocumentReader + ?Sized>(reader: &R) -> Result<Self, DatasetError> {
+        let mut versions = Vec::new();
+        for info in reader.list_versions()? {
+            if let Some(snapshot) = reader.get_version(&info.date)? {
+                versions.push(snapshot);
+            }
+        }
+        Ok(Self::from_versions(
+            versions.iter().map(|v| (v.date.as_str(), &v.element)),
+        ))
+    }
+
     /// Build a scope from the root element of each version.
     pub fn from_versions<'a>(versions: impl Iterator<Item = (&'a str, &'a USLMElement)>) -> Self {
         let mut held = Vec::new();

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -12,7 +12,7 @@
 use serde::Serialize;
 
 use crate::annotation::ChangeAnnotation;
-use crate::dataset::{DatasetError, SearchResult};
+use crate::dataset::{DatasetError, Scope, SearchResult};
 use crate::diff::TreeDiff;
 use crate::storage::Storage;
 use crate::uslm::USLMElement;
@@ -30,6 +30,9 @@ pub struct DatasetInfo {
     pub version_count: usize,
     /// Number of bills recorded in the dataset.
     pub bill_count: usize,
+    /// What this dataset covers, so a caller can tell "absent from the law"
+    /// from "absent from this dataset".
+    pub scope: Scope,
 }
 
 /// One version snapshot's headline facts (no element tree).
@@ -487,5 +490,6 @@ pub fn info<S: Storage>(dataset: &S) -> Result<DatasetInfo, DatasetError> {
         source_urls: meta.source_urls.clone(),
         version_count: dataset.list_versions()?.len(),
         bill_count: dataset.list_bill_ids()?.len(),
+        scope: Scope::derive(dataset)?,
     })
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -90,6 +90,12 @@ fn should_report_metadata_and_counts_when_info_runs_on_a_dataset() {
     assert_eq!(info["name"], "CLI Test Fixture");
     assert_eq!(info["version_count"], 2);
     assert_eq!(info["bill_count"], 0);
+
+    // Scope answers "why did my query find nothing". Without it, an agent
+    // reading this output cannot tell an absent provision from an absent title.
+    assert_eq!(info["scope"]["held"][0], "uscode/title_51");
+    assert_eq!(info["scope"]["dates"][0], EARLY);
+    assert_eq!(info["scope"]["dates"][1], LATE);
 }
 
 /// Run `diff` over a fixture and return its parsed JSON summary.


### PR DESCRIPTION
Follows #62, which added scope but wired it to nothing.

## What

`words_to_data info` now reports coverage.

```
Versions:    2
Bills:       5
Covers:      58 units, including uscode/appendix_11a, uscode/appendix_18a, ...
```

`--json` carries the full `held` list and `dates`, which is the surface an agent reads. The human output samples five and gives a count, because a full US Code dataset holds 58 units and one line of 58 is not readable.

`Scope::derive` now works against any `DocumentReader`, so `inspect` builds it directly instead of going through the `Dataset` facade.

## Checked against real data

Run against the production `dataset.sqlite`, not only the fixtures. That mattered: its root element is a bare `uscode` container, so coverage came from the container's children rather than the root path. It reports all 57 titles plus 5 appendices. The fixtures only exercise the other branch, where the root already names a unit (`uscode/title_51`).

## Verification

```
cargo fmt --check     clean
cargo clippy --all-targets --all-features -- -D warnings     no issues
cargo test     189 passed, 7 ignored, 0 failed
```

Unchanged from #62's total: the CLI test for `info` gained scope assertions rather than a new test, since it already drove that command.

## Note

The summary threshold is a constant in `info.rs`, not a flag. If you want the full list on the terminal, `--json` has it, and I would rather not add an option for something a pipe already solves.