### PR TITLE
feat: name works and expressions, so a document needs no release cycle

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -5,9 +5,11 @@
 
 mod error;
 mod scope;
+mod work;
 
 pub use error::DatasetError;
 pub use scope::{Coverage, Scope};
+pub use work::{ExpressionId, WorkId};
 
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -113,6 +115,44 @@ impl<S: Storage> Dataset<S> {
     /// ```
     pub fn scope(&self) -> Result<Scope, DatasetError> {
         Scope::derive(&self.storage)
+    }
+
+    /// Every work this dataset holds.
+    ///
+    /// A work is a document as a concept, with no date. This is the entry point
+    /// for a dataset whose contents do not share a release cycle: ten court
+    /// opinions are ten works, and no global date describes them.
+    pub fn works(&self) -> Result<Vec<WorkId>, DatasetError> {
+        Ok(self.scope()?.held.into_iter().map(WorkId::new).collect())
+    }
+
+    /// Every expression of one work, in date order.
+    ///
+    /// A work with one expression is normal, not a degenerate case: a court
+    /// opinion is published once and never amended.
+    pub fn expressions(&self, work: &WorkId) -> Result<Vec<ExpressionId>, DatasetError> {
+        let mut expressions: Vec<ExpressionId> = self
+            .storage
+            .find_element(work.as_str())?
+            .into_iter()
+            .map(|(date, _)| ExpressionId::new(work.clone(), date))
+            .collect();
+        expressions.sort();
+        Ok(expressions)
+    }
+
+    /// One work as it read on one date.
+    ///
+    /// `None` means this dataset holds no such expression. Ask
+    /// [`Dataset::scope`] whether it holds the work at all, so an absent
+    /// expression is not mistaken for an absent document.
+    pub fn get_expression(&self, id: &ExpressionId) -> Result<Option<USLMElement>, DatasetError> {
+        Ok(self
+            .storage
+            .find_element(id.work.as_str())?
+            .into_iter()
+            .find(|(date, _)| *date == id.at)
+            .map(|(_, element)| element))
     }
 
     /// The legislature extension, when this dataset carries one.

--- a/src/dataset/work.rs
+++ b/src/dataset/work.rs
@@ -1,0 +1,71 @@
+//! Works and expressions: naming a document without a date, and with one.
+//!
+//! A **work** is a legal document as a concept, with no date attached. Title 9
+//! is one work, from 1947 until today. An **expression** is that work as it read
+//! on one date.
+//!
+//! The distinction matters because the current interface keys on a global
+//! release date: `get_version("2025-07-18")` asks for the whole tree at a
+//! moment. That fits the US Code, where every title is republished together. It
+//! fits nothing else. A court opinion is a work with a single expression, and it
+//! belongs to no release cycle at all, so a dataset holding opinions has no
+//! global date to key on.
+//!
+//! This module adds the work-scoped view alongside the date-keyed one. It does
+//! not remove the older shape yet: the global version list still exists, and
+//! expressions are still discovered through it.
+
+use serde::{Deserialize, Serialize};
+
+/// A legal document as a concept, with no date attached.
+///
+/// Named by its structural path, such as `uscode/title_9`. That path locates
+/// rather than identifies, so this becomes a stable identity when one exists
+/// (`docs/adr/0001-structural-paths-locate-not-identify.md`).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct WorkId(pub String);
+
+impl WorkId {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self(path.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for WorkId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// One work as it read on one date.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ExpressionId {
+    /// The work this is an expression of.
+    pub work: WorkId,
+    /// The date it read this way, `YYYY-MM-DD`.
+    ///
+    /// For a statute this is the release point. For a document published once
+    /// and never amended, such as a court opinion, it is the date of
+    /// publication, and there will only ever be one.
+    pub at: String,
+}
+
+impl ExpressionId {
+    pub fn new(work: WorkId, at: impl Into<String>) -> Self {
+        Self {
+            work,
+            at: at.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ExpressionId {
+    /// `uscode/title_9@2025-07-18`, the form Akoma Ntoso and ELI use.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}@{}", self.work, self.at)
+    }
+}

--- a/tests/work_tests.rs
+++ b/tests/work_tests.rs
@@ -1,0 +1,111 @@
+//! Works and expressions, over the real corpus.
+//!
+//! The point of this shape is that it survives a document class with no release
+//! cycle. These tests use statutes, because that is the corpus we have, but each
+//! one is written so it would still make sense for a court opinion: a work with
+//! a single expression is the normal case here, not a degenerate one.
+
+use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, VersionSnapshot, WorkId};
+use words_to_data::uslm::parser::parse;
+
+const EARLY: &str = "2025-07-18";
+const LATE: &str = "2025-07-30";
+
+/// Title 51 gained two sections between the two release points.
+const AMENDED: &str = "usc51";
+/// Title 9 did not change.
+const UNCHANGED: &str = "usc09";
+
+fn dataset_of(title: &str, dates: &[&str]) -> Dataset<words_to_data::storage::InMemoryStorage> {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Works".to_string(),
+        description: format!("{title} at {} release points", dates.len()),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "MIT".to_string(),
+        version: "1.0.0".to_string(),
+    });
+    for date in dates {
+        dataset
+            .add_version(VersionSnapshot {
+                date: date.to_string(),
+                label: None,
+                element: parse(&format!("tests/test_data/usc/{date}/{title}.xml"), date)
+                    .expect("the corpus should parse"),
+            })
+            .expect("a version should be added");
+    }
+    dataset
+}
+
+#[test]
+fn should_name_every_work_the_dataset_holds() {
+    let dataset = dataset_of(AMENDED, &[EARLY, LATE]);
+
+    assert_eq!(
+        dataset.works().expect("works should list"),
+        vec![WorkId::new("uscode/title_51")],
+        "two releases of one title are one work, not two"
+    );
+}
+
+#[test]
+fn should_list_an_expression_for_each_date_a_work_was_published() {
+    let dataset = dataset_of(AMENDED, &[EARLY, LATE]);
+    let work = WorkId::new("uscode/title_51");
+
+    assert_eq!(
+        dataset.expressions(&work).expect("expressions should list"),
+        vec![
+            ExpressionId::new(work.clone(), EARLY),
+            ExpressionId::new(work.clone(), LATE),
+        ]
+    );
+}
+
+/// A work published once has one expression. For a court opinion that is the
+/// only case there will ever be, so it must be ordinary rather than special.
+#[test]
+fn should_give_one_expression_for_a_work_published_once() {
+    let dataset = dataset_of(UNCHANGED, &[EARLY]);
+    let work = WorkId::new("uscode/title_9");
+
+    let expressions = dataset.expressions(&work).expect("expressions should list");
+
+    assert_eq!(expressions, vec![ExpressionId::new(work, EARLY)]);
+}
+
+#[test]
+fn should_read_the_text_of_one_expression() {
+    let dataset = dataset_of(AMENDED, &[EARLY, LATE]);
+    let id = ExpressionId::new(WorkId::new("uscode/title_51"), LATE);
+
+    let element = dataset
+        .get_expression(&id)
+        .expect("reading should work")
+        .expect("the expression should be there");
+
+    assert_eq!(element.data.path.to_string(), "uscode/title_51");
+}
+
+#[test]
+fn should_find_no_expression_for_a_date_the_work_was_not_published() {
+    let dataset = dataset_of(AMENDED, &[EARLY, LATE]);
+    let id = ExpressionId::new(WorkId::new("uscode/title_51"), "1999-01-01");
+
+    assert!(
+        dataset
+            .get_expression(&id)
+            .expect("reading should work")
+            .is_none()
+    );
+}
+
+/// The identifier prints in the form Akoma Ntoso and ELI use, so it can be
+/// written in a citation or a URL without translation.
+#[test]
+fn should_print_an_expression_as_work_at_date() {
+    let id = ExpressionId::new(WorkId::new("uscode/title_9"), EARLY);
+
+    assert_eq!(id.to_string(), "uscode/title_9@2025-07-18");
+}


### PR DESCRIPTION
Fifth slice of #51. Implements the identity half of `docs/adr/0001-structural-paths-locate-not-identify.md`.

## The problem this removes

`get_version("2025-07-18")` asks for the whole tree at a moment. That fits the US Code, where every title is republished together. It fits nothing else.

A court opinion belongs to no release cycle. Ten opinions are ten documents with ten publication dates and nothing shared. #53 runs straight into this: there is no global date to key them on.

## The shape

- **`WorkId`** — a document as a concept, no date: `uscode/title_9`
- **`ExpressionId`** — that work on one date, printed `uscode/title_9@2025-07-18`, the form Akoma Ntoso and ELI use, so it can go in a citation or a URL untranslated

```rust
dataset.works()?                      // every work held
dataset.expressions(&work)?           // every date it was published
dataset.get_expression(&id)?          // the text on one date
```

Most of this was already computed and unnamed. `Scope::held` was the list of works. `find_element` already returned every date a path appears with its element — which is exactly "every expression of this work".

## A work with one expression is ordinary

Pinned by a test, because for a court opinion it is the only case there will ever be. If it reads as degenerate now, the case law spike will fight the interface.

## Additive

The date-keyed methods stay, and expressions are still discovered through the global version list. That list is the thing case law cannot have, so removing it is the next step, not this one.

## Verification

```
cargo fmt --check     clean
cargo clippy --all-targets --all-features -- -D warnings     no issues
cargo test     201 passed, 7 ignored, 0 failed
```

Baseline 195. Six new tests, all over the real corpus.