### PR TITLE
fix: carry the model's reasoning as link evidence

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -96,10 +96,12 @@ pub struct Provenance {
     pub method: Option<String>,
     /// How far the statement can be trusted.
     pub verification: VerificationState,
-    /// What the statement was based on.
+    /// What the statement was based on, in the maker's own words.
     ///
-    /// `None` for everything produced so far: raw model replies were never
-    /// persisted (#58), so the evidence behind those claims is gone.
+    /// For a machine-made annotation this is the reasoning the model gave for
+    /// its answer. It is not the verbatim reply: the text around the answer,
+    /// including any fences and prose, was never persisted (#58). So this
+    /// explains a claim without being enough to reproduce how it was parsed.
     pub evidence: Option<String>,
     /// The raw score a model reported, kept as diagnostic data only. It is not
     /// a probability and must not be presented as one.
@@ -172,7 +174,7 @@ impl Link {
             source: annotation.metadata.annotator.clone(),
             method: Some(format!("{:?}", annotation.operation)),
             verification: verification_of(annotation),
-            evidence: None,
+            evidence: annotation.metadata.reasoning.clone(),
             raw_score: annotation.metadata.confidence,
             corroboration: None,
         };

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -88,9 +88,9 @@ fn should_mark_unreviewed_model_output_as_machine_suggested() {
             );
             assert_eq!(link.provenance.source, annotation.metadata.annotator);
             assert_eq!(link.provenance.raw_score, annotation.metadata.confidence);
-            assert!(
-                link.provenance.evidence.is_none(),
-                "raw model replies were never persisted (#58), so there is no evidence to carry"
+            assert_eq!(
+                link.provenance.evidence, annotation.metadata.reasoning,
+                "the model's stated reasoning is the evidence we do have"
             );
         }
     }
@@ -192,5 +192,32 @@ fn should_carry_a_reproducible_measurement_from_real_similarity_scores() {
 
         assert_eq!(detail["matched_words"], similarity.matched_words as f32);
         assert_eq!(detail["tree_diff_words"], similarity.tree_diff_words as f32);
+    }
+}
+
+/// The fixture's annotations carry the model's reasoning, so the links built
+/// from them carry it as evidence. A machine claim that cannot say why is
+/// weaker than one that can, and this is the part of "why" that survived.
+#[test]
+fn should_carry_the_models_reasoning_as_evidence() {
+    let annotations = real_annotations();
+    let with_reasoning: Vec<&ChangeAnnotation> = annotations
+        .iter()
+        .filter(|a| a.metadata.reasoning.is_some())
+        .collect();
+
+    assert!(
+        !with_reasoning.is_empty(),
+        "the fixture should hold annotations the model explained"
+    );
+
+    for annotation in with_reasoning {
+        for link in Link::from_annotation(annotation) {
+            let evidence = link
+                .provenance
+                .evidence
+                .expect("a link should carry the reasoning behind it");
+            assert!(!evidence.trim().is_empty());
+        }
     }
 }


### PR DESCRIPTION
Corrects an overstatement I made in #58, in #64, and in the `link.rs` docs.

## The error

I wrote that raw model replies were never persisted, so the evidence behind every machine claim is gone. Part of it is not gone.

`match_amendments` parses the model's `reasoning` out of its reply and stores it on every annotation (`src/bin/words_to_data/match_amendments.rs:135`). The real annotations carry it:

> "Section reference matches exactly (Section 163(j)(8)(A)(v)), and the old text in the diff ('in the case of taxable years beginning before') is a truncated version of the text being struck..."

## The fix

`Provenance.evidence` is filled from that field instead of always being `None`. A machine claim in a link can now say why it was made, using the existing data — no migration, no regeneration.

The test that asserted `evidence.is_none()` now asserts it equals the stored reasoning, which is a stronger assertion against the same fixture. A second test covers the explained annotations directly.

## What #58 still covers

The **verbatim** reply: fences, the JSON envelope, prose around the answer. Two things still need it:

- proving the parser survives what a model really emits, since reconstructed payloads are well-formed by construction
- confirming the reasoning we stored is what the model actually wrote

`extract-changes` remains the weaker case: it keeps only the parsed `{added, removed}` and uses the raw text solely inside an error message, so none of the model's words survive there.

I have added the correction as a comment on #58 rather than editing its body, so the original claim and the correction both stay visible.

## Verification

```
cargo clippy --all-targets --all-features -- -D warnings     no issues
cargo test     202 passed, 7 ignored, 0 failed
```