### PR TITLE
feat: refuse a dataset written by a different schema

### DIFF
--- a/src/dataset/error.rs
+++ b/src/dataset/error.rs
@@ -19,4 +19,10 @@ pub enum DatasetError {
 
     #[error("Failed to load folder '{0}': folder is empty or unreadable")]
     FolderLoadFailed(String),
+
+    #[error(
+        "This dataset was written with schema version {found}, and this build reads version \
+         {expected}. Datasets are rebuilt rather than migrated, so regenerate it."
+    )]
+    SchemaVersionMismatch { found: i32, expected: i32 },
 }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -24,9 +24,38 @@ pub struct SqliteStorage {
     metadata: DatasetMetadata,
 }
 
+/// Refuse a dataset this build cannot read.
+///
+/// Datasets are rebuilt rather than migrated, so a schema change is a clean
+/// break. That is only safe if the break is loud: `CREATE TABLE IF NOT EXISTS`
+/// would otherwise graft this build's tables onto an older file, and every
+/// query against the new tables would return nothing. An empty answer that
+/// means "wrong schema" is the failure this whole model exists to prevent.
+///
+/// A file with no `schema_version` table is new, and gets this build's schema.
+fn check_schema_version(conn: &Connection) -> Result<(), DatasetError> {
+    let found: Option<i32> = conn
+        .query_row("SELECT version FROM schema_version LIMIT 1", [], |row| {
+            row.get(0)
+        })
+        .ok();
+
+    match found {
+        Some(version) if version != SCHEMA_VERSION => Err(DatasetError::SchemaVersionMismatch {
+            found: version,
+            expected: SCHEMA_VERSION,
+        }),
+        _ => Ok(()),
+    }
+}
+
 impl SqliteStorage {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, DatasetError> {
         let conn = Connection::open(path)?;
+        // Check before init_schema, which would otherwise add this build's
+        // tables to an older file and leave a hybrid that answers queries with
+        // nothing rather than saying it cannot read them.
+        check_schema_version(&conn)?;
         let mut storage = Self {
             conn,
             metadata: DatasetMetadata::default(),

--- a/tests/schema_version_tests.rs
+++ b/tests/schema_version_tests.rs
@@ -1,0 +1,87 @@
+//! A dataset written by a different schema must be refused, not half-read.
+//!
+//! Datasets are rebuilt rather than migrated, so changing the schema is a clean
+//! break. That is only safe if the break is loud. Without this check,
+//! `CREATE TABLE IF NOT EXISTS` grafts the current build's tables onto an older
+//! file, and every query against them returns nothing — an empty answer that
+//! actually means "wrong schema", which is the failure this project exists to
+//! prevent.
+
+use rusqlite::Connection;
+use words_to_data::dataset::{DatasetError, DatasetMetadata, VersionSnapshot};
+use words_to_data::storage::{DocumentReader, DocumentWriter, SqliteStorage};
+use words_to_data::uslm::parser::parse;
+
+const TITLE_9: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
+
+/// Write a real dataset to disk and hand back its path.
+fn written_dataset(name: &str) -> String {
+    let path = format!("{}/{name}.sqlite", env!("CARGO_TARGET_TMPDIR"));
+    let _ = std::fs::remove_file(&path);
+
+    let mut storage = SqliteStorage::open(&path).expect("a new dataset should open");
+    storage.set_metadata(DatasetMetadata {
+        name: "Schema guard".to_string(),
+        description: "Title 9 at one release point".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "MIT".to_string(),
+        version: "1.0.0".to_string(),
+    });
+    storage
+        .add_version(VersionSnapshot {
+            date: "2025-07-18".to_string(),
+            label: None,
+            element: parse(TITLE_9, "2025-07-18").expect("the corpus should parse"),
+        })
+        .expect("a version should be added");
+    drop(storage);
+
+    path
+}
+
+#[test]
+fn should_open_a_dataset_written_by_this_build() {
+    let path = written_dataset("schema_current");
+
+    let storage = SqliteStorage::open(&path).expect("the dataset should reopen");
+
+    assert_eq!(
+        storage.list_versions().expect("versions should list").len(),
+        1
+    );
+}
+
+#[test]
+fn should_refuse_a_dataset_written_by_a_different_schema() {
+    let path = written_dataset("schema_stale");
+
+    // Mark the file as written by an older build, the way a real one would be.
+    let conn = Connection::open(&path).expect("the file should open directly");
+    conn.execute("UPDATE schema_version SET version = 1", [])
+        .expect("the version should update");
+    drop(conn);
+
+    match SqliteStorage::open(&path) {
+        Err(DatasetError::SchemaVersionMismatch { found, expected }) => {
+            assert_eq!(found, 1);
+            assert_ne!(expected, 1, "this build should read a later schema");
+        }
+        Err(other) => panic!("the failure should name the schema, got {other}"),
+        Ok(_) => panic!("a dataset from another schema must not open"),
+    }
+}
+
+/// The refusal has to say what to do about it, because the answer is not
+/// obvious: there is no migration, so the file must be rebuilt.
+#[test]
+fn should_explain_that_the_dataset_must_be_rebuilt() {
+    let error = DatasetError::SchemaVersionMismatch {
+        found: 1,
+        expected: 2,
+    };
+
+    let message = error.to_string();
+    assert!(message.contains("schema version 1"), "got: {message}");
+    assert!(message.contains("regenerate"), "got: {message}");
+}


### PR DESCRIPTION
Prerequisite for the remaining #51 slices, and it exists because of your call that migrations are not necessary.

## The hole

`SCHEMA_VERSION` was written into every dataset and never read back. `init_schema` uses `CREATE TABLE IF NOT EXISTS`, so opening a file from an older build **grafted this build's tables onto it**. The file kept claiming the old version, the new tables were empty, and every query against them returned nothing.

An empty answer that actually means "wrong schema" is the same class of failure as #54 and as the scope work: the tool reports absence when it should report that it cannot read the thing.

## The check

Runs **before** `init_schema`, so an old file is refused rather than quietly altered. A file with no `schema_version` table is new and gets this build's schema.

```
This dataset was written with schema version 1, and this build reads version 2.
Datasets are rebuilt rather than migrated, so regenerate it.
```

The message names the remedy, because it is not guessable without knowing the policy.

## Why now

You said an ad-hoc migration is nice but not necessary. That makes a schema change a clean break — no backfill, no dual-read path — and the next two slices both change the schema. A clean break is only safe if it is loud, so this is the piece that has to land first.

## Verification

```
cargo clippy --all-targets --all-features -- -D warnings     no issues
cargo test     205 passed, 7 ignored, 0 failed
```

Baseline 202. Three new tests: a current dataset reopens, a dataset marked with an older version is refused with the typed error, and the message tells the reader to regenerate.

Checked against the production `dataset.sqlite`, which is at the current version and still opens.