### PR TITLE
feat: cover a corpus in one annotation run, one work at a time

### DIFF
--- a/src/bin/words_to_data/main.rs
+++ b/src/bin/words_to_data/main.rs
@@ -19,6 +19,7 @@ mod path;
 mod score_amendments;
 mod search;
 mod show_bill;
+mod span;
 mod validate;
 
 /// Words to Data — legal document tooling

--- a/src/bin/words_to_data/match_amendments.rs
+++ b/src/bin/words_to_data/match_amendments.rs
@@ -13,29 +13,25 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use clap::Args as ClapArgs;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use words_to_data::annotation::{
     AnnotationMetadata, AnnotationStatus, BillReference, ChangeAnnotation,
 };
-use words_to_data::dataset::{Dataset, ExpressionId, Format};
+use words_to_data::dataset::{Dataset, Format};
 use words_to_data::diff::{AmendmentSimilarity, MentionMatch, TreeDiff};
 use words_to_data::legislature::AmendingAction;
 use words_to_data::uslm::TextContentField;
 
 use crate::llm::{ChatOptions, LlmClient};
+use crate::span::Span;
 
 #[derive(ClapArgs)]
 pub struct Args {
     /// Path to a dataset (compact JSON) that already has amendment changes + expressions
     pub dataset: String,
 
-    /// Older expression, e.g. `uscode/title_26@2025-07-18`
-    #[arg(long)]
-    pub from: ExpressionId,
-
-    /// Newer expression of the same work
-    #[arg(long)]
-    pub to: ExpressionId,
+    #[command(flatten)]
+    pub span: Span,
 
     /// Base URL of an OpenAI-compatible chat-completions server
     #[arg(long, default_value = "http://localhost:8080")]
@@ -64,6 +60,18 @@ struct Candidate {
     mentions: Vec<MentionMatch>,
 }
 
+/// One work's candidate view, tagged with the pair it was built from.
+///
+/// A corpus run covers many works, and the candidates carry no work of their
+/// own, so a flat list would mix title 26's with title 51's.
+#[derive(Serialize)]
+struct CandidatesOfWork {
+    work: String,
+    from: String,
+    to: String,
+    amendments: Vec<serde_json::Value>,
+}
+
 /// One amendment plus the candidate diffs to disambiguate between.
 struct AmendmentMatch {
     bill_id: String,
@@ -74,21 +82,12 @@ struct AmendmentMatch {
 }
 
 pub fn run(args: Args) {
-    let mut dataset = Dataset::load(&args.dataset, Format::Compact).expect("Error loading dataset");
+    let mut dataset = crate::fail::or_exit(
+        Dataset::load(&args.dataset, Format::Compact),
+        "Error loading dataset",
+    );
 
-    let diff = dataset
-        .compute_diff(&args.from, &args.to)
-        .expect("Error computing diff");
-
-    let matches = build_matches(&dataset, &diff);
-    print_stats(&matches);
-
-    // Persist the candidate view next to the dataset for inspection.
-    let candidates_path = sibling(&args.dataset, "candidates.json");
-    fs::write(&candidates_path, candidates_json(&matches)).expect("Error writing candidates.json");
-
-    // Ask the LLM which candidate(s) each amendment matches.
-    let llm = LlmClient::new(args.base_url, args.model.clone(), None);
+    let llm = LlmClient::new(args.base_url.clone(), args.model.clone(), None);
     let annotator = format!(
         "model:{}",
         if args.model.is_empty() {
@@ -97,61 +96,96 @@ pub fn run(args: Args) {
             &args.model
         }
     );
-    let matched = classify_all(&llm, &matches, args.threads);
 
-    // Apply the LLM's annotations single-threaded.
+    let pairs = args.span.resolve(&dataset);
+    let mut candidates_by_work = Vec::new();
     let mut applied = 0;
-    for (match_idx, annotations) in matched {
-        let m = &matches[match_idx];
-        for ann in annotations {
-            let Some(candidate) = usize::try_from(ann.candidate_index)
-                .ok()
-                .and_then(|i| m.candidates.get(i))
-            else {
-                continue;
-            };
+    let mut annotated_paths = 0;
 
-            let annotation = ChangeAnnotation {
-                operation: ann
-                    .operation
-                    .as_deref()
-                    .and_then(|op| AmendingAction::from_str(op).ok())
-                    .unwrap_or(AmendingAction::Amend),
-                source_bill: BillReference {
-                    bill_id: m.bill_id.clone(),
-                    amendment_id: m.amendment_id.clone(),
-                    causative_text: ann
-                        .causative_text
-                        .clone()
-                        .unwrap_or_else(|| m.amending_text.clone()),
-                },
-                paths: vec![candidate.diff.root_path.clone()],
-                metadata: AnnotationMetadata {
-                    status: AnnotationStatus::Pending,
-                    confidence: ann.confidence,
-                    annotator: annotator.clone(),
-                    timestamp: time::OffsetDateTime::now_utc(),
-                    notes: None,
-                    reasoning: ann.reasoning,
-                },
-            };
-            dataset
-                .add_annotation(&args.from, &args.to, annotation)
-                .expect("Error adding annotation");
-            applied += 1;
+    for (from, to) in pairs {
+        let diff = crate::fail::or_exit(dataset.compute_diff(&from, &to), "Error computing diff");
+
+        let matches = build_matches(&dataset, &diff);
+        println!("\n{from} -> {to}");
+        print_stats(&matches);
+
+        // Ask the LLM which candidate(s) each amendment matches.
+        let matched = classify_all(&llm, &matches, args.threads);
+
+        // Apply the LLM's annotations single-threaded.
+        for (match_idx, annotations) in matched {
+            let m = &matches[match_idx];
+            for ann in annotations {
+                let Some(candidate) = usize::try_from(ann.candidate_index)
+                    .ok()
+                    .and_then(|i| m.candidates.get(i))
+                else {
+                    continue;
+                };
+
+                let annotation = ChangeAnnotation {
+                    operation: ann
+                        .operation
+                        .as_deref()
+                        .and_then(|op| AmendingAction::from_str(op).ok())
+                        .unwrap_or(AmendingAction::Amend),
+                    source_bill: BillReference {
+                        bill_id: m.bill_id.clone(),
+                        amendment_id: m.amendment_id.clone(),
+                        causative_text: ann
+                            .causative_text
+                            .clone()
+                            .unwrap_or_else(|| m.amending_text.clone()),
+                    },
+                    paths: vec![candidate.diff.root_path.clone()],
+                    metadata: AnnotationMetadata {
+                        status: AnnotationStatus::Pending,
+                        confidence: ann.confidence,
+                        annotator: annotator.clone(),
+                        timestamp: time::OffsetDateTime::now_utc(),
+                        notes: None,
+                        reasoning: ann.reasoning,
+                    },
+                };
+                crate::fail::or_exit(
+                    dataset.add_annotation(&from, &to, annotation),
+                    "Error adding annotation",
+                );
+                applied += 1;
+            }
         }
+
+        annotated_paths += dataset.annotated_paths(&from, &to).len();
+        candidates_by_work.push(CandidatesOfWork {
+            work: from.work.to_string(),
+            from: from.to_string(),
+            to: to.to_string(),
+            amendments: candidates_view(&matches),
+        });
     }
 
-    let output = args.output.as_deref().unwrap_or(&args.dataset);
-    dataset
-        .save(output, Format::Compact)
-        .expect("Error saving dataset");
-
-    println!("Applied {applied} annotations");
-    println!(
-        "Annotated paths: {}",
-        dataset.annotated_paths(&args.from, &args.to).len()
+    // Persist the candidate view next to the dataset for inspection.
+    let candidates_path = sibling(&args.dataset, "candidates.json");
+    crate::fail::or_exit(
+        fs::write(
+            &candidates_path,
+            serde_json::to_string_pretty(&candidates_by_work)
+                .expect("Error serializing candidates"),
+        ),
+        "Error writing candidates.json",
     );
+
+    let output = args.output.as_deref().unwrap_or(&args.dataset);
+    crate::fail::or_exit(
+        dataset.save(output, Format::Compact),
+        "Error saving dataset",
+    );
+
+    println!(
+        "\nApplied {applied} annotation(s) across {} work(s)",
+        candidates_by_work.len()
+    );
+    println!("Annotated paths: {annotated_paths}");
     println!("Wrote {}", candidates_path.display());
     println!("Wrote {output}");
 }
@@ -478,8 +512,8 @@ fn sibling(dataset_path: &str, filename: &str) -> PathBuf {
 }
 
 /// Serialize the candidate view to pretty JSON for inspection.
-fn candidates_json(matches: &[AmendmentMatch]) -> String {
-    let view: Vec<_> = matches
+fn candidates_view(matches: &[AmendmentMatch]) -> Vec<serde_json::Value> {
+    matches
         .iter()
         .map(|m| {
             serde_json::json!({
@@ -493,8 +527,7 @@ fn candidates_json(matches: &[AmendmentMatch]) -> String {
                 })).collect::<Vec<_>>(),
             })
         })
-        .collect();
-    serde_json::to_string_pretty(&view).expect("Error serializing candidates")
+        .collect()
 }
 
 /// System prompt (ported verbatim from the Python `ai_bill_matching` tool).

--- a/src/bin/words_to_data/score_amendments.rs
+++ b/src/bin/words_to_data/score_amendments.rs
@@ -9,20 +9,19 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::Args as ClapArgs;
-use words_to_data::dataset::{Dataset, ExpressionId, Format};
+use serde::Serialize;
+use words_to_data::dataset::{Dataset, Format};
+use words_to_data::diff::AmendmentSimilarity;
+
+use crate::span::Span;
 
 #[derive(ClapArgs)]
 pub struct Args {
-    /// Dataset (compact JSON) with extracted amendment changes and both expressions
+    /// Dataset (compact JSON) with extracted amendment changes and the expressions to score
     pub dataset: String,
 
-    /// Older expression, e.g. `uscode/title_26@2025-07-18`
-    #[arg(long)]
-    pub from: ExpressionId,
-
-    /// Newer expression of the same work
-    #[arg(long)]
-    pub to: ExpressionId,
+    #[command(flatten)]
+    pub span: Span,
 
     /// Only keep similarity scores strictly above this cutoff
     #[arg(long, default_value_t = 0.4)]
@@ -33,36 +32,72 @@ pub struct Args {
     pub output: Option<String>,
 }
 
+/// One work's scores, tagged with the pair they were computed between.
+///
+/// The scores themselves say nothing about which document they came from, so a
+/// corpus run would otherwise write one flat list in which title 26's matches
+/// and title 51's are indistinguishable.
+#[derive(Serialize)]
+struct ScoredWork {
+    work: String,
+    from: String,
+    to: String,
+    scores: Vec<AmendmentSimilarity>,
+}
+
 pub fn run(args: Args) {
-    let dataset = Dataset::load(&args.dataset, Format::Compact).expect("Error loading dataset");
+    let dataset = crate::fail::or_exit(
+        Dataset::load(&args.dataset, Format::Compact),
+        "Error loading dataset",
+    );
 
-    let diff = dataset
-        .compute_diff(&args.from, &args.to)
-        .expect("Error computing diff");
+    let bills: Vec<_> = crate::fail::or_exit(dataset.list_bill_ids(), "Error listing bills")
+        .into_iter()
+        .map(|id| {
+            crate::fail::or_exit(dataset.get_bill(&id), "Error reading bill")
+                .expect("bill id from list_bill_ids should exist")
+        })
+        .collect();
 
-    // Score every amendment (with changes) against the US Code diff.
-    let mut scores = Vec::new();
-    for bill_id in dataset.list_bill_ids().expect("Error listing bills") {
-        let bill = dataset
-            .get_bill(&bill_id)
-            .expect("Error reading bill")
-            .expect("bill id from list_bill_ids should exist");
-        scores.extend(diff.calculate_amendment_similarities(&bill).into_values());
+    let mut scored = Vec::new();
+    let mut total = 0;
+
+    for (from, to) in args.span.resolve(&dataset) {
+        let diff = crate::fail::or_exit(dataset.compute_diff(&from, &to), "Error computing diff");
+
+        let mut scores: Vec<AmendmentSimilarity> = bills
+            .iter()
+            .flat_map(|bill| diff.calculate_amendment_similarities(bill).into_values())
+            .collect();
+        scores.retain(|s| s.score > args.similarity_cutoff);
+        scores.sort_by(|a, b| b.score.total_cmp(&a.score));
+
+        println!("{from} -> {to}: {} above cutoff", scores.len());
+        total += scores.len();
+        scored.push(ScoredWork {
+            work: from.work.to_string(),
+            from: from.to_string(),
+            to: to.to_string(),
+            scores,
+        });
     }
-    scores.retain(|s| s.score > args.similarity_cutoff);
-    scores.sort_by(|a, b| b.score.total_cmp(&a.score));
 
     let scores_path = args
         .output
         .map(PathBuf::from)
         .unwrap_or_else(|| sibling(&args.dataset, "similarity_scores.json"));
-    fs::write(
-        &scores_path,
-        serde_json::to_string_pretty(&scores).expect("Error serializing scores"),
-    )
-    .expect("Error writing scores");
+    crate::fail::or_exit(
+        fs::write(
+            &scores_path,
+            serde_json::to_string_pretty(&scored).expect("Error serializing scores"),
+        ),
+        "Error writing scores",
+    );
 
-    println!("Scored {} amendment matches above cutoff", scores.len());
+    println!(
+        "Scored {total} amendment match(es) above cutoff across {} work(s)",
+        scored.len()
+    );
     println!("Wrote {}", scores_path.display());
 }
 

--- a/src/bin/words_to_data/span.rs
+++ b/src/bin/words_to_data/span.rs
@@ -1,0 +1,76 @@
+//! Choosing which expression pairs a command runs over.
+//!
+//! A diff is between two expressions of one work, so a job that used to be one
+//! call over a global tree is now one call per document. Two commands need to
+//! make that choice — `score-amendments` and `match-amendments` — and they must
+//! make it the same way, so it is made here.
+
+use clap::Args as ClapArgs;
+use words_to_data::dataset::{ExpressionId, ExpressionPair, works_between};
+use words_to_data::storage::DocumentReader;
+
+/// Which expressions to work over: one named pair, or every work spanning two
+/// dates.
+#[derive(ClapArgs)]
+pub struct Span {
+    /// Every work published on both dates, e.g. `--between 2025-07-18 2025-07-30`
+    #[arg(
+        long,
+        num_args = 2,
+        value_names = ["FROM", "TO"],
+        conflicts_with_all = ["from", "to"],
+        required_unless_present = "from"
+    )]
+    pub between: Option<Vec<String>>,
+
+    /// Older expression, e.g. `uscode/title_26@2025-07-18`
+    #[arg(long, requires = "to")]
+    pub from: Option<ExpressionId>,
+
+    /// Newer expression of the same work
+    #[arg(long, requires = "from")]
+    pub to: Option<ExpressionId>,
+}
+
+impl Span {
+    /// The pairs to run over, and a note of anything this span cannot cover.
+    ///
+    /// Prints what it skipped rather than returning a shorter list quietly: a
+    /// corpus run that covered forty of fifty-eight works and said nothing
+    /// would read as having done the whole job.
+    pub fn resolve<R: DocumentReader + ?Sized>(&self, reader: &R) -> Vec<ExpressionPair> {
+        match (&self.between, &self.from, &self.to) {
+            (Some(dates), _, _) => {
+                let (from, to) = (&dates[0], &dates[1]);
+                let between =
+                    crate::fail::or_exit(works_between(reader, from, to), "Error listing works");
+
+                if !between.skipped.is_empty() {
+                    eprintln!(
+                        "Skipping {} work(s) not held at both {from} and {to}: {}",
+                        between.skipped.len(),
+                        preview(&between.skipped)
+                    );
+                }
+                if between.pairs.is_empty() {
+                    eprintln!("No work is held at both {from} and {to}; nothing to do.");
+                }
+                between.pairs
+            }
+            (None, Some(from), Some(to)) => vec![(from.clone(), to.clone())],
+            // clap's `required_unless_present` and `requires` between them make
+            // the remaining combinations unreachable.
+            _ => unreachable!("clap requires --between or --from/--to"),
+        }
+    }
+}
+
+/// The first few names, and how many more there are.
+fn preview<T: std::fmt::Display>(items: &[T]) -> String {
+    const SHOWN: usize = 5;
+    let shown: Vec<String> = items.iter().take(SHOWN).map(T::to_string).collect();
+    match items.len().checked_sub(SHOWN) {
+        Some(rest) if rest > 0 => format!("{}, and {rest} more", shown.join(", ")),
+        _ => shown.join(", "),
+    }
+}

--- a/src/bin/words_to_data/span.rs
+++ b/src/bin/words_to_data/span.rs
@@ -9,6 +9,19 @@ use clap::Args as ClapArgs;
 use words_to_data::dataset::{ExpressionId, ExpressionPair, works_between};
 use words_to_data::storage::DocumentReader;
 
+/// Check a `--between` date before any work starts.
+///
+/// `--from` and `--to` get this for free, because `ExpressionId` parses its
+/// date. Without the same check here a typo is not an error: no work is held
+/// on `not-a-date`, so every work is skipped, the run reports covering nothing,
+/// and it exits zero. A pipeline would carry straight on past a job that never
+/// happened.
+fn publication_date(text: &str) -> Result<String, String> {
+    words_to_data::date::date_str_to_date(text)
+        .map(|_| text.to_string())
+        .map_err(|_| format!("`{text}` is not a date. Write it as YYYY-MM-DD, such as 2025-07-18."))
+}
+
 /// Which expressions to work over: one named pair, or every work spanning two
 /// dates.
 #[derive(ClapArgs)]
@@ -18,6 +31,7 @@ pub struct Span {
         long,
         num_args = 2,
         value_names = ["FROM", "TO"],
+        value_parser = publication_date,
         conflicts_with_all = ["from", "to"],
         required_unless_present = "from"
     )]

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -10,7 +10,8 @@ mod work;
 pub use error::DatasetError;
 pub use scope::{Coverage, Scope, WorkCoverage};
 pub use work::{
-    Expression, ExpressionId, ExpressionInfo, ParseExpressionIdError, WorkId, work_roots,
+    Expression, ExpressionId, ExpressionInfo, ParseExpressionIdError, WorkId, WorksBetween,
+    work_roots, works_between,
 };
 
 use serde::{Deserialize, Serialize};

--- a/src/dataset/work.rs
+++ b/src/dataset/work.rs
@@ -129,6 +129,52 @@ pub struct ExpressionInfo {
     pub label: Option<String>,
 }
 
+/// Which works a job spanning two dates can and cannot cover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorksBetween {
+    /// Works held on both dates, in work order, as a pair to diff.
+    pub pairs: Vec<crate::dataset::ExpressionPair>,
+    /// Works held on one of the dates but not the other.
+    pub skipped: Vec<WorkId>,
+}
+
+/// Every work this dataset holds on both dates, paired for diffing.
+///
+/// A diff is between two expressions of one work, so a job that spans a corpus
+/// is one diff per document rather than one over everything. This decides which
+/// documents that is, once, for every command that needs it.
+///
+/// A work published on only one of the two dates cannot be diffed between them.
+/// It is returned in `skipped` rather than dropped: a run that quietly covered
+/// forty of fifty-eight works would report success for a job it did not do.
+pub fn works_between<R: crate::storage::DocumentReader + ?Sized>(
+    reader: &R,
+    from: &str,
+    to: &str,
+) -> Result<WorksBetween, crate::dataset::DatasetError> {
+    let mut pairs = Vec::new();
+    let mut skipped = Vec::new();
+
+    for work in reader.works()? {
+        let dates: Vec<String> = reader
+            .expressions(&work)?
+            .into_iter()
+            .map(|info| info.id.at)
+            .collect();
+
+        if dates.iter().any(|d| d == from) && dates.iter().any(|d| d == to) {
+            pairs.push((
+                ExpressionId::new(work.clone(), from),
+                ExpressionId::new(work, to),
+            ));
+        } else {
+            skipped.push(work);
+        }
+    }
+
+    Ok(WorksBetween { pairs, skipped })
+}
+
 /// Split a parsed tree into the works it holds.
 ///
 /// A root that names a work, such as `uscode/title_9`, is one work and is

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -7,7 +7,7 @@
 use std::process::{Command, Output};
 use std::sync::OnceLock;
 
-use words_to_data::dataset::{Dataset, DatasetMetadata};
+use words_to_data::dataset::{Dataset, DatasetMetadata, Format};
 
 /// The two US Code release points held in `tests/test_data`.
 const EARLY: &str = "2025-07-18";
@@ -97,6 +97,70 @@ fn two_works_fixture() -> &'static str {
 
         dataset
             .save_to_sqlite(&path)
+            .expect("the fixture should save");
+        path
+    })
+}
+
+/// A compact-JSON dataset holding both titles at both release points.
+///
+/// JSON rather than SQLite because the annotation commands read that form, and
+/// both titles at both dates because a corpus-wide run needs more than one work
+/// to prove it covered them all.
+fn both_works_json_fixture() -> &'static str {
+    static FIXTURE: OnceLock<String> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let path = format!("{}/cli_both_works.json", env!("CARGO_TARGET_TMPDIR"));
+
+        let mut dataset = Dataset::new(DatasetMetadata {
+            name: "Both Works".to_string(),
+            description: "Two titles, both release points".to_string(),
+            author: "words_to_data tests".to_string(),
+            source_urls: vec![],
+            license: "MIT".to_string(),
+            version: "1.0.0".to_string(),
+        });
+
+        for title in [UNCHANGED_TITLE, AMENDED_TITLE] {
+            for date in [EARLY, LATE] {
+                let xml = format!("tests/test_data/usc/{date}/{title}.xml");
+                dataset
+                    .add_uslm_xml(&xml, date, None)
+                    .expect("the corpus should parse and load");
+            }
+        }
+
+        dataset
+            .save(&path, Format::Compact)
+            .expect("the fixture should save");
+        path
+    })
+}
+
+/// The same two titles, but neither held at both dates.
+fn two_works_json_fixture() -> &'static str {
+    static FIXTURE: OnceLock<String> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let path = format!("{}/cli_two_works.json", env!("CARGO_TARGET_TMPDIR"));
+
+        let mut dataset = Dataset::new(DatasetMetadata {
+            name: "Two Works".to_string(),
+            description: "Two titles, no shared date".to_string(),
+            author: "words_to_data tests".to_string(),
+            source_urls: vec![],
+            license: "MIT".to_string(),
+            version: "1.0.0".to_string(),
+        });
+
+        for (title, date) in [(UNCHANGED_TITLE, EARLY), (AMENDED_TITLE, LATE)] {
+            let xml = format!("tests/test_data/usc/{date}/{title}.xml");
+            dataset
+                .add_uslm_xml(&xml, date, None)
+                .expect("the corpus should parse and load");
+        }
+
+        dataset
+            .save(&path, Format::Compact)
             .expect("the fixture should save");
         path
     })
@@ -534,5 +598,136 @@ fn should_report_no_changes_when_only_the_release_stamp_differs() {
             path_count(&summary, "removed_paths"),
         ),
         (0, 0, 0)
+    );
+}
+
+// --- Covering a corpus, now that a diff is per work ---
+//
+// A diff used to span the whole `uscode` root, so one `score-amendments` run
+// covered every title. It now covers one work, so the command has to loop.
+// `score-amendments` is the deterministic half of the pipeline — no LLM — so it
+// is where this behaviour is pinned.
+
+/// Run `score-amendments` and return the parsed scores file it wrote.
+fn scored(dataset: &str, span: &[&str], out_name: &str) -> (Output, serde_json::Value) {
+    let out = format!("{}/{out_name}", env!("CARGO_TARGET_TMPDIR"));
+    let _ = std::fs::remove_file(&out);
+
+    let mut args = vec!["score-amendments", dataset];
+    args.extend_from_slice(span);
+    args.extend_from_slice(&["--output", &out]);
+    let output = run(&args);
+
+    let written = std::fs::read_to_string(&out).unwrap_or_else(|_| "null".to_string());
+    (
+        output,
+        serde_json::from_str(&written).expect("the scores file should be json"),
+    )
+}
+
+#[test]
+fn should_cover_every_work_when_score_amendments_is_given_two_dates() {
+    let (output, scores) = scored(
+        both_works_json_fixture(),
+        &["--between", EARLY, LATE],
+        "scores_between.json",
+    );
+
+    assert!(
+        output.status.success(),
+        "score-amendments should exit zero, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let entries = scores.as_array().expect("an array of scored works");
+    let works: Vec<&str> = entries
+        .iter()
+        .map(|e| e["work"].as_str().expect("a work"))
+        .collect();
+
+    assert_eq!(
+        works,
+        vec![AMENDED_WORK, UNCHANGED_WORK],
+        "one run should cover both documents"
+    );
+    // Each entry says which pair it came from, so the file is readable without
+    // knowing the command line that produced it.
+    assert_eq!(entries[0]["from"], expression(AMENDED_WORK, EARLY));
+    assert_eq!(entries[0]["to"], expression(AMENDED_WORK, LATE));
+}
+
+#[test]
+fn should_cover_one_work_when_score_amendments_is_given_one_pair() {
+    let (output, scores) = scored(
+        both_works_json_fixture(),
+        &[
+            "--from",
+            &expression(AMENDED_WORK, EARLY),
+            "--to",
+            &expression(AMENDED_WORK, LATE),
+        ],
+        "scores_one.json",
+    );
+
+    assert!(output.status.success(), "score-amendments should exit zero");
+
+    let entries = scores.as_array().expect("an array of scored works");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["work"], AMENDED_WORK);
+}
+
+/// A work held at only one of the two dates cannot be diffed between them.
+/// Saying so is the point: a run that covered nothing and reported success
+/// would read as having done the job.
+#[test]
+fn should_name_the_works_it_could_not_cover() {
+    let (output, scores) = scored(
+        two_works_json_fixture(),
+        &["--between", EARLY, LATE],
+        "scores_skipped.json",
+    );
+
+    assert!(output.status.success(), "score-amendments should exit zero");
+    assert_eq!(
+        scores.as_array().expect("an array").len(),
+        0,
+        "neither title spans both dates"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(UNCHANGED_WORK) && stderr.contains(AMENDED_WORK),
+        "both skipped works should be named, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("nothing to do"),
+        "an empty run should say so, got: {stderr}"
+    );
+}
+
+#[test]
+fn should_reject_a_span_that_names_both_forms() {
+    let output = run(&[
+        "score-amendments",
+        both_works_json_fixture(),
+        "--between",
+        EARLY,
+        LATE,
+        "--from",
+        &expression(AMENDED_WORK, EARLY),
+        "--to",
+        &expression(AMENDED_WORK, LATE),
+    ]);
+
+    assert!(!output.status.success(), "the two forms are exclusive");
+}
+
+#[test]
+fn should_reject_a_span_that_names_neither_form() {
+    let output = run(&["score-amendments", both_works_json_fixture()]);
+
+    assert!(
+        !output.status.success(),
+        "one form or the other is required"
     );
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -731,3 +731,44 @@ fn should_reject_a_span_that_names_neither_form() {
         "one form or the other is required"
     );
 }
+
+/// A `--between` date is checked before any work starts, the way `--from` and
+/// `--to` are by parsing an expression. Without it a typo is not an error: no
+/// work is held on `not-a-date`, so every work is skipped and the run exits
+/// zero having done nothing.
+#[test]
+fn should_reject_a_between_date_that_is_not_a_date() {
+    let output = run(&[
+        "score-amendments",
+        both_works_json_fixture(),
+        "--between",
+        "not-a-date",
+        LATE,
+    ]);
+
+    assert!(!output.status.success(), "a malformed date must not run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("YYYY-MM-DD"),
+        "the error should show the expected form, got: {stderr}"
+    );
+}
+
+/// A real date that no work was published on is a fact about the data, not a
+/// user error, so it reports and exits zero. A dataset of court opinions — one
+/// expression per work — would legitimately span nothing.
+#[test]
+fn should_report_and_succeed_when_a_valid_span_covers_no_work() {
+    let (output, scores) = scored(
+        both_works_json_fixture(),
+        &["--between", "1999-01-01", LATE],
+        "scores_empty_span.json",
+    );
+
+    assert!(output.status.success(), "an empty span is not a failure");
+    assert_eq!(scores.as_array().expect("an array").len(), 0);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("nothing to do"),
+        "it must say it did nothing"
+    );
+}

--- a/tests/work_tests.rs
+++ b/tests/work_tests.rs
@@ -5,7 +5,7 @@
 //! one is written so it would still make sense for a court opinion: a work with
 //! a single expression is the normal case here, not a degenerate one.
 
-use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId};
+use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId, works_between};
 
 const EARLY: &str = "2025-07-18";
 const LATE: &str = "2025-07-30";
@@ -256,5 +256,69 @@ fn should_refuse_a_diff_across_two_works() {
             Err(words_to_data::dataset::DatasetError::WorkMismatch { .. })
         ),
         "expected WorkMismatch, got {refused:?}"
+    );
+}
+
+// --- Covering a whole corpus, one work at a time ---
+//
+// A diff is per work, so a job that used to be one call over a global tree is
+// now one call per document. Deciding which documents that is belongs here
+// rather than in each command that needs it.
+
+/// Both titles at both release points: every work is diffable between them.
+fn two_works_both_dates() -> Dataset<words_to_data::storage::InMemoryStorage> {
+    let mut dataset = empty_dataset();
+    for title in [UNCHANGED, AMENDED] {
+        for date in [EARLY, LATE] {
+            dataset
+                .add_uslm_xml(
+                    &format!("tests/test_data/usc/{date}/{title}.xml"),
+                    date,
+                    None,
+                )
+                .expect("the corpus should load");
+        }
+    }
+    dataset
+}
+
+#[test]
+fn should_pair_every_work_published_on_both_dates() {
+    let dataset = two_works_both_dates();
+
+    let between = works_between(&dataset, EARLY, LATE).expect("works should pair");
+
+    assert_eq!(
+        between.pairs,
+        vec![
+            (
+                ExpressionId::new(WorkId::new("uscode/title_51"), EARLY),
+                ExpressionId::new(WorkId::new("uscode/title_51"), LATE),
+            ),
+            (
+                ExpressionId::new(WorkId::new("uscode/title_9"), EARLY),
+                ExpressionId::new(WorkId::new("uscode/title_9"), LATE),
+            ),
+        ]
+    );
+    assert!(between.skipped.is_empty());
+}
+
+/// A work published on only one of the two dates cannot be diffed between
+/// them. It is reported rather than dropped: a corpus run that quietly covered
+/// none of the works would otherwise print success for a job it did not do.
+#[test]
+fn should_report_works_that_are_not_held_on_both_dates() {
+    let dataset = two_works_no_shared_date();
+
+    let between = works_between(&dataset, EARLY, LATE).expect("works should pair");
+
+    assert!(between.pairs.is_empty(), "neither title spans both dates");
+    assert_eq!(
+        between.skipped,
+        vec![
+            WorkId::new("uscode/title_51"),
+            WorkId::new("uscode/title_9"),
+        ]
     );
 }


### PR DESCRIPTION
Follow-up to #72. Restores a capability that #69 quietly cost.

## The problem

Work-scoped storage made a diff per work. That is correct — diffing across works was only ever safe because everything shared a `uscode` root — but the annotation commands lost something with it.

`compute_diff("2025-07-18", "2025-07-30")` used to span the whole root, so **one** `score-amendments` run covered all 58 titles. After #69 each run covers one, so annotating the corpus meant 58 invocations of each command. Worse for a shell loop: both write a fixed sibling filename — `candidates.json` and `similarity_scores.json` — so every title would clobber the last one's output.

I did not flag this in #72. It surfaced when @Scronkfinkle regenerated the datasets and was about to start an annotation run.

## The shape

Both commands take either form, exactly one required:

```
--between 2025-07-18 2025-07-30      every work published on both dates
--from <expr> --to <expr>            one work, as before
```

clap rejects both together and neither.

```
$ words_to_data score-amendments dataset.json --between 2025-07-18 2025-07-30
uscode/title_1@2025-07-18 -> uscode/title_1@2025-07-30: 0 above cutoff
...
uscode/title_9@2025-07-18 -> uscode/title_9@2025-07-30: 0 above cutoff
Scored 0 amendment match(es) above cutoff across 58 work(s)
```

58 works, one run, 12 seconds against the production dataset.

## No silent partial coverage

`works_between` lives in the library so both commands decide the same way. A work held on only one of the two dates cannot be diffed between them, and comes back in `skipped` rather than being dropped:

```
Skipping 2 work(s) not held at both 2025-07-18 and 2025-07-30:
  uscode/title_51, uscode/title_9
No work is held at both 2025-07-18 and 2025-07-30; nothing to do.
```

A run that covered 40 of 58 works and said nothing would read as having done the whole job. That is the same failure the schema guard exists to prevent, one level up.

## Side files

Each entry gains `work`, `from` and `to`. They are inspection artifacts, not pipeline inputs — `match-amendments` recomputes similarities in-process (`match_amendments.rs:204`) and nothing reads `similarity_scores.json` back — so reshaping them breaks no reader. Without it a corpus run wrote one flat list in which title 26's matches and title 51's were indistinguishable.

Errors in both commands now print their `Display` message rather than the `Debug` form, matching what #72 did for the read-only commands.

## Verification

```
cargo test      230 passed, 7 ignored, 0 failed   (was 223)
cargo fmt --check                                  clean
cargo clippy --all-targets --all-features -D warnings   clean
```

Seven new tests. `works_between` is pinned in `tests/work_tests.rs` against real titles; the CLI behaviour in `tests/cli_tests.rs` through `score-amendments`, which is the deterministic half of the pipeline and needs no LLM. Covered: both forms, the skip report, the empty-span message, and both invalid argument combinations.

## Note on the zero scores above

Not a defect in this change. The production dataset has 606 amendments across 5 bills with **none** carrying extracted changes, because `extract-changes` has not been run yet. `calculate_amendment_similarities` scores an amendment's extracted changes against the diff, so there is nothing to score until that step runs. `extract-changes` is per-bill and takes no span, so the pipeline shape is unchanged:

```
words_to_data extract-changes   dataset.json --base-url ...
words_to_data score-amendments  dataset.json --between 2025-07-18 2025-07-30
words_to_data match-amendments  dataset.json --between 2025-07-18 2025-07-30 --base-url ...
```
