### PR TITLE
fix: order diff and candidate output by document position, not hash order

### DIFF
--- a/src/bin/words_to_data/match_amendments.rs
+++ b/src/bin/words_to_data/match_amendments.rs
@@ -5,7 +5,6 @@
 //! actually caused, and record the answer as a `ChangeAnnotation` written back
 //! into the dataset in place.
 
-use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -18,8 +17,8 @@ use words_to_data::annotation::{
     AnnotationMetadata, AnnotationStatus, BillReference, ChangeAnnotation,
 };
 use words_to_data::dataset::{Dataset, Format};
-use words_to_data::diff::{AmendmentSimilarity, MentionMatch, TreeDiff};
 use words_to_data::legislature::AmendingAction;
+use words_to_data::matching::{AmendmentMatch, Candidate, build_matches};
 use words_to_data::uslm::TextContentField;
 
 use crate::llm::{ChatOptions, LlmClient};
@@ -50,16 +49,6 @@ pub struct Args {
     pub output: Option<String>,
 }
 
-/// A candidate US Code diff that an amendment might have caused.
-struct Candidate {
-    /// Shallow diff at this location (no children).
-    diff: TreeDiff,
-    /// Pre-computed similarity score for this amendment/location, if any.
-    similarity: Option<AmendmentSimilarity>,
-    /// Section mentions from the amendment text found at this location.
-    mentions: Vec<MentionMatch>,
-}
-
 /// One work's candidate view, tagged with the pair it was built from.
 ///
 /// A corpus run covers many works, and the candidates carry no work of their
@@ -70,15 +59,6 @@ struct CandidatesOfWork {
     from: String,
     to: String,
     amendments: Vec<serde_json::Value>,
-}
-
-/// One amendment plus the candidate diffs to disambiguate between.
-struct AmendmentMatch {
-    bill_id: String,
-    amendment_id: String,
-    amending_text: String,
-    action_types: Vec<AmendingAction>,
-    candidates: Vec<Candidate>,
 }
 
 pub fn run(args: Args) {
@@ -190,80 +170,6 @@ pub fn run(args: Args) {
     println!("Wrote {output}");
 }
 
-/// Gather, for every amendment across every bill, the candidate diffs it may explain.
-fn build_matches(
-    dataset: &Dataset<impl words_to_data::storage::Storage>,
-    diff: &TreeDiff,
-) -> Vec<AmendmentMatch> {
-    let mut matches = Vec::new();
-
-    for bill_id in dataset.list_bill_ids().expect("Error listing bills") {
-        let bill = dataset
-            .get_bill(&bill_id)
-            .expect("Error reading bill")
-            .expect("bill id from list_bill_ids should exist");
-
-        // Similarity scores keyed by tree-diff path; mentions keyed by amendment id.
-        let similarities = diff.calculate_amendment_similarities(&bill);
-        let mentions = diff.scan_for_mentions(&bill);
-
-        for amendment in bill.amendments.values() {
-            let amd_scores: Vec<&AmendmentSimilarity> = similarities
-                .values()
-                .filter(|s| s.amendment_id == amendment.id)
-                .collect();
-            let empty = Vec::new();
-            let amd_mentions = mentions.get(&amendment.id).unwrap_or(&empty);
-
-            // Union of every location implicated by a score or a mention.
-            let mut paths: HashSet<&str> = HashSet::new();
-            paths.extend(amd_scores.iter().map(|s| s.tree_diff_path.as_str()));
-            paths.extend(amd_mentions.iter().map(|m| m.tree_diff_path.as_str()));
-
-            let mut candidates = Vec::new();
-            for path in paths {
-                let similarity = amd_scores
-                    .iter()
-                    .find(|s| s.tree_diff_path == path)
-                    .map(|s| (*s).clone());
-                let cand_mentions: Vec<MentionMatch> = amd_mentions
-                    .iter()
-                    .filter(|m| m.tree_diff_path == path)
-                    .cloned()
-                    .collect();
-
-                // Only keep locations that actually have changes.
-                if let Some(node) = diff.find(path) {
-                    let shallow = node.shallow();
-                    if !shallow.added.is_empty()
-                        || !shallow.removed.is_empty()
-                        || !shallow.changes.is_empty()
-                    {
-                        candidates.push(Candidate {
-                            diff: shallow,
-                            similarity,
-                            mentions: cand_mentions,
-                        });
-                    }
-                }
-            }
-
-            if !candidates.is_empty() {
-                matches.push(AmendmentMatch {
-                    bill_id: bill.bill_id.clone(),
-                    amendment_id: amendment.id.clone(),
-                    amending_text: amendment.amending_text.clone(),
-                    action_types: amendment.action_types.clone(),
-                    candidates,
-                });
-            }
-        }
-    }
-
-    matches
-}
-
-/// Print a short summary of the candidate distribution.
 fn print_stats(matches: &[AmendmentMatch]) {
     let total = matches.len();
     if total == 0 {

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -284,8 +284,21 @@ impl TreeDiff {
         let mut added = vec![];
         let mut removed = vec![];
         let mut child_diffs = vec![];
-        // Iterate once through A - handle matched and removed
-        for (path, child_a) in &children_a {
+        // Walk the children themselves, not the maps built from them. The maps
+        // answer "is this path on the other side?"; the child vectors carry
+        // source document order, so `removed` and `child_diffs` come out in the
+        // order the provisions appear in the law. Iterating the maps instead let
+        // hash order decide, which changed between runs (#73).
+        //
+        // A handful of siblings share a path (11 of ~58,000 in title 26, where
+        // the parser generates the same path twice). The maps hold one element
+        // per path, so we skip any child the map does not hold. That keeps one
+        // entry per path, exactly as before; only the order is new.
+        for child_a in &from_element.children {
+            let path = &*child_a.data.path;
+            if !std::ptr::eq(children_a[path], child_a) {
+                continue;
+            }
             match children_b.get(path) {
                 Some(child_b) => {
                     // Matched - recurse
@@ -305,8 +318,12 @@ impl TreeDiff {
             }
         }
 
-        // Iterate through B for added only
-        for (path, child_b) in &children_b {
+        // Iterate through B for added only, again in document order.
+        for child_b in &to_element.children {
+            let path = &*child_b.data.path;
+            if !std::ptr::eq(children_b[path], child_b) {
+                continue;
+            }
             if !children_a.contains_key(path) {
                 added.push(child_b.data.clone()); //ElementSnapshot::from(child_b));
             }
@@ -544,17 +561,26 @@ impl TreeDiff {
                 })
                 .collect();
 
-            // Deduplicate: keep only the longest match per tree_diff_path
-            let mut best_by_path: HashMap<&str, &MentionMatch> = HashMap::new();
+            // Deduplicate: keep only the longest match per tree_diff_path.
+            // Collecting into a Vec rather than a map keeps the paths in the
+            // order the tree walk produced them, which is document order. A map
+            // returned them in hash order, which moved between runs (#73).
+            let mut best_by_path: Vec<&MentionMatch> = Vec::new();
             for m in &all_matches {
-                let dominated = best_by_path
-                    .get(m.tree_diff_path.as_str())
-                    .is_some_and(|existing| existing.matched_text.len() >= m.matched_text.len());
-                if !dominated {
-                    best_by_path.insert(&m.tree_diff_path, m);
+                match best_by_path
+                    .iter_mut()
+                    .find(|existing| existing.tree_diff_path == m.tree_diff_path)
+                {
+                    // Ties keep the match already held, as before.
+                    Some(existing) => {
+                        if m.matched_text.len() > existing.matched_text.len() {
+                            *existing = m;
+                        }
+                    }
+                    None => best_by_path.push(m),
                 }
             }
-            let matches: Vec<MentionMatch> = best_by_path.into_values().cloned().collect();
+            let matches: Vec<MentionMatch> = best_by_path.into_iter().cloned().collect();
 
             if !matches.is_empty() {
                 results.insert(amendment_id.clone(), matches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod intern;
 pub mod io;
 pub mod legislature;
 pub mod link;
+pub mod matching;
 pub mod storage;
 #[cfg(feature = "download")]
 pub mod uscode;

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -1,0 +1,146 @@
+//! Candidate gathering for amendment matching.
+//!
+//! For one diff, this collects the locations each bill amendment might explain,
+//! drawn from two channels: pre-computed similarity scores, and section
+//! mentions found in the amendment text. The result is the candidate set that
+//! `match-amendments` shows an LLM.
+//!
+//! This lives in the library rather than in the binary so that candidate
+//! ordering can be tested. The order matters: it is the order the model reads
+//! its options in, so it must not change between runs (#73).
+
+use std::collections::HashMap;
+
+use crate::dataset::Dataset;
+use crate::diff::{AmendmentSimilarity, MentionMatch, TreeDiff};
+use crate::legislature::AmendingAction;
+use crate::storage::Storage;
+
+/// A candidate US Code diff that an amendment might have caused.
+pub struct Candidate {
+    /// Shallow diff at this location (no children).
+    pub diff: TreeDiff,
+    /// Pre-computed similarity score for this amendment/location, if any.
+    pub similarity: Option<AmendmentSimilarity>,
+    /// Section mentions from the amendment text found at this location.
+    pub mentions: Vec<MentionMatch>,
+}
+
+/// One amendment plus the candidate diffs to disambiguate between.
+pub struct AmendmentMatch {
+    pub bill_id: String,
+    pub amendment_id: String,
+    pub amending_text: String,
+    pub action_types: Vec<AmendingAction>,
+    pub candidates: Vec<Candidate>,
+}
+
+/// Number every node of the diff tree by its position in a document-order walk.
+///
+/// Candidate locations arrive from hash maps, so they carry no usable order of
+/// their own. This index gives each one the position its provision holds in the
+/// law, so candidates can be presented in the order a reader would meet them.
+fn document_order_index(diff: &TreeDiff) -> HashMap<&str, usize> {
+    fn walk<'a>(diff: &'a TreeDiff, index: &mut HashMap<&'a str, usize>) {
+        let next = index.len();
+        index.entry(diff.root_path.as_str()).or_insert(next);
+        for child in &diff.child_diffs {
+            walk(child, index);
+        }
+    }
+
+    let mut index = HashMap::new();
+    walk(diff, &mut index);
+    index
+}
+
+/// Gather, for every amendment across every bill, the candidate diffs it may explain.
+pub fn build_matches(dataset: &Dataset<impl Storage>, diff: &TreeDiff) -> Vec<AmendmentMatch> {
+    let mut matches = Vec::new();
+    let path_order = document_order_index(diff);
+
+    // Bills and amendments are both held in hash maps, so neither arrives in a
+    // usable order. Their ids are stable (an amendment id is a hash of its own
+    // text), so ordering by id gives the same match list on every run.
+    let mut bill_ids = dataset.list_bill_ids().expect("Error listing bills");
+    bill_ids.sort();
+
+    for bill_id in bill_ids {
+        let bill = dataset
+            .get_bill(&bill_id)
+            .expect("Error reading bill")
+            .expect("bill id from list_bill_ids should exist");
+
+        // Similarity scores keyed by tree-diff path; mentions keyed by amendment id.
+        let similarities = diff.calculate_amendment_similarities(&bill);
+        let mentions = diff.scan_for_mentions(&bill);
+
+        let mut amendments: Vec<_> = bill.amendments.values().collect();
+        amendments.sort_by(|a, b| a.id.cmp(&b.id));
+
+        for amendment in amendments {
+            let amd_scores: Vec<&AmendmentSimilarity> = similarities
+                .values()
+                .filter(|s| s.amendment_id == amendment.id)
+                .collect();
+            let empty = Vec::new();
+            let amd_mentions = mentions.get(&amendment.id).unwrap_or(&empty);
+
+            // Union of every location implicated by a score or a mention. Both
+            // channels come out of hash maps, so sort the union into document
+            // order before building candidates; otherwise the model sees its
+            // options shuffled differently on every run.
+            let mut paths: Vec<&str> = amd_scores
+                .iter()
+                .map(|s| s.tree_diff_path.as_str())
+                .chain(amd_mentions.iter().map(|m| m.tree_diff_path.as_str()))
+                .collect();
+            paths.sort_unstable_by_key(|path| {
+                // A path missing from the index cannot be ordered by position,
+                // so fall back to the path itself and keep it deterministic.
+                (path_order.get(path).copied().unwrap_or(usize::MAX), *path)
+            });
+            paths.dedup();
+
+            let mut candidates = Vec::new();
+            for path in paths {
+                let similarity = amd_scores
+                    .iter()
+                    .find(|s| s.tree_diff_path == path)
+                    .map(|s| (*s).clone());
+                let cand_mentions: Vec<MentionMatch> = amd_mentions
+                    .iter()
+                    .filter(|m| m.tree_diff_path == path)
+                    .cloned()
+                    .collect();
+
+                // Only keep locations that actually have changes.
+                if let Some(node) = diff.find(path) {
+                    let shallow = node.shallow();
+                    if !shallow.added.is_empty()
+                        || !shallow.removed.is_empty()
+                        || !shallow.changes.is_empty()
+                    {
+                        candidates.push(Candidate {
+                            diff: shallow,
+                            similarity,
+                            mentions: cand_mentions,
+                        });
+                    }
+                }
+            }
+
+            if !candidates.is_empty() {
+                matches.push(AmendmentMatch {
+                    bill_id: bill.bill_id.clone(),
+                    amendment_id: amendment.id.clone(),
+                    amending_text: amendment.amending_text.clone(),
+                    action_types: amendment.action_types.clone(),
+                    candidates,
+                });
+            }
+        }
+    }
+
+    matches
+}

--- a/tests/diff_tests.rs
+++ b/tests/diff_tests.rs
@@ -2,7 +2,7 @@ use rstest::rstest;
 use words_to_data::{
     diff::{MentionMatch, TreeDiff},
     legislature::BillDiff,
-    uslm::{TextContentField, bill_parser::parse_bill_amendments, parser::parse},
+    uslm::{TextContentField, USLMElement, bill_parser::parse_bill_amendments, parser::parse},
 };
 
 const PL_XML_PATH: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml";
@@ -268,4 +268,160 @@ fn test_scan_for_mentions_should_find_section_45f_mentions_in_bill() {
         "Should find a match containing '45F', got matches: {:?}",
         all_matches
     );
+}
+
+/// Flatten a diff tree into the exact order its nodes and children are stored,
+/// so that two diffs can be compared on ordering and not merely on membership.
+fn ordered_paths(diff: &TreeDiff) -> Vec<String> {
+    let mut out = Vec::new();
+    fn walk(diff: &TreeDiff, out: &mut Vec<String>) {
+        out.push(format!("~{}", diff.root_path));
+        for element in &diff.added {
+            out.push(format!("+{}", element.path));
+        }
+        for element in &diff.removed {
+            out.push(format!("-{}", element.path));
+        }
+        for child in &diff.child_diffs {
+            walk(child, out);
+        }
+    }
+    walk(diff, &mut out);
+    out
+}
+
+#[test]
+fn should_order_diff_children_identically_when_the_same_diff_is_built_twice() {
+    let doc_old = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+        .expect("Error running parser");
+    let doc_new = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+
+    let first = ordered_paths(&TreeDiff::from_elements(&doc_old, &doc_new));
+    let second = ordered_paths(&TreeDiff::from_elements(&doc_old, &doc_new));
+
+    // Membership has never been the problem: the same paths come back every
+    // time. Only their order moves, so compare the sequences, not the sets.
+    let mut first_sorted = first.clone();
+    let mut second_sorted = second.clone();
+    first_sorted.sort();
+    second_sorted.sort();
+    assert_eq!(
+        first_sorted, second_sorted,
+        "The two diffs should contain the same paths"
+    );
+
+    let first_divergence = first
+        .iter()
+        .zip(second.iter())
+        .position(|(a, b)| a != b)
+        .map(|i| format!("index {i}: {:?} vs {:?}", first[i], second[i]))
+        .unwrap_or_else(|| "none".to_string());
+    assert_eq!(
+        first, second,
+        "Two diffs of the same input should be ordered identically. \
+         First divergence at {first_divergence}"
+    );
+}
+
+/// Assert that every list on this node follows the order of the source
+/// document, then recurse. `removed` and `child_diffs` follow the older
+/// expression; `added` follows the newer one.
+fn assert_document_order(diff: &TreeDiff, from: &USLMElement, to: &USLMElement) {
+    // A few siblings share a path. One element represents each path, and it is
+    // the last one, so resolve from the back to match what the diff records.
+    let position_in = |element: &USLMElement, path: &str| -> usize {
+        element
+            .children
+            .iter()
+            .rposition(|child| &*child.data.path == path)
+            .unwrap_or_else(|| panic!("{path} is not a child of {}", element.data.path))
+    };
+
+    let ascending = |positions: &[usize]| positions.windows(2).all(|pair| pair[0] < pair[1]);
+
+    let child_positions: Vec<usize> = diff
+        .child_diffs
+        .iter()
+        .map(|child| position_in(from, &child.root_path))
+        .collect();
+    assert!(
+        ascending(&child_positions),
+        "child_diffs of {} are not in document order: {:?}",
+        diff.root_path,
+        diff.child_diffs
+            .iter()
+            .map(|c| c.root_path.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    let removed_positions: Vec<usize> = diff
+        .removed
+        .iter()
+        .map(|element| position_in(from, &element.path))
+        .collect();
+    assert!(
+        ascending(&removed_positions),
+        "removed of {} is not in document order",
+        diff.root_path
+    );
+
+    let added_positions: Vec<usize> = diff
+        .added
+        .iter()
+        .map(|element| position_in(to, &element.path))
+        .collect();
+    assert!(
+        ascending(&added_positions),
+        "added of {} is not in document order",
+        diff.root_path
+    );
+
+    for child in &diff.child_diffs {
+        let from_child = &from.children[position_in(from, &child.root_path)];
+        let to_child = &to.children[position_in(to, &child.root_path)];
+        assert_document_order(child, from_child, to_child);
+    }
+}
+
+#[test]
+fn should_order_mentions_identically_when_scanning_the_same_bill_twice() {
+    let doc_old = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+        .expect("Error running parser");
+    let doc_new = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+    let diff = TreeDiff::from_elements(&doc_old, &doc_new);
+    let amendment_data = parse_bill_amendments("119-21", PL_XML_PATH).unwrap();
+
+    let first = diff.scan_for_mentions(&amendment_data);
+    let second = diff.scan_for_mentions(&amendment_data);
+
+    // Only amendments with more than one mention can expose an ordering bug.
+    let multi = first.values().filter(|m| m.len() > 1).count();
+    assert!(
+        multi > 0,
+        "This test needs an amendment with more than one mention to be meaningful"
+    );
+
+    for (amendment_id, mentions) in &first {
+        let other = second
+            .get(amendment_id)
+            .expect("both scans should cover the same amendments");
+        assert_eq!(
+            mentions, other,
+            "Mentions for amendment {amendment_id} should come back in the same order every scan"
+        );
+    }
+}
+
+#[test]
+fn should_order_diff_children_by_document_position_when_diffing_a_title() {
+    let doc_old = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+        .expect("Error running parser");
+    let doc_new = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+
+    let diff = TreeDiff::from_elements(&doc_old, &doc_new);
+
+    assert_document_order(&diff, &doc_old, &doc_new);
 }

--- a/tests/matching_tests.rs
+++ b/tests/matching_tests.rs
@@ -1,0 +1,136 @@
+//! Tests for candidate gathering (`words_to_data::matching`).
+//!
+//! The candidate list is what an LLM reads when it decides which change an
+//! amendment caused, so its order is part of the model's input. Two runs over
+//! the same dataset must present the same candidates in the same order (#73).
+
+use std::collections::HashMap;
+
+use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId};
+use words_to_data::diff::TreeDiff;
+use words_to_data::matching::build_matches;
+use words_to_data::storage::InMemoryStorage;
+use words_to_data::uslm::bill_parser::parse_bill_amendments;
+
+const TITLE_26: &str = "uscode/title_26";
+const USC26_18: &str = "tests/test_data/usc/2025-07-18/usc26.xml";
+const USC26_30: &str = "tests/test_data/usc/2025-07-30/usc26.xml";
+const PL_XML: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml";
+
+fn at(date: &str) -> ExpressionId {
+    ExpressionId::new(WorkId::new(TITLE_26), date)
+}
+
+/// Title 26 across two release points, plus the real public law that amends it.
+fn make_fixture() -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Matching Fixture".to_string(),
+        description: "Title 26, two release points".to_string(),
+        author: "Tester".to_string(),
+        source_urls: vec!["https://uscode.house.gov".to_string()],
+        license: "Public Domain".to_string(),
+        version: "1.0".to_string(),
+    });
+    dataset
+        .add_uslm_xml(USC26_18, "2025-07-18", Some("Before".to_string()))
+        .expect("add first version");
+    dataset
+        .add_uslm_xml(USC26_30, "2025-07-30", Some("After".to_string()))
+        .expect("add second version");
+
+    let bill = parse_bill_amendments("119-21", PL_XML).expect("parse bill");
+    dataset.add_bill(bill).expect("add bill");
+    dataset
+}
+
+/// Position of every diff node in a document-order walk of the tree.
+fn document_order(diff: &TreeDiff) -> HashMap<String, usize> {
+    fn walk(diff: &TreeDiff, index: &mut HashMap<String, usize>) {
+        let next = index.len();
+        index.entry(diff.root_path.clone()).or_insert(next);
+        for child in &diff.child_diffs {
+            walk(child, index);
+        }
+    }
+    let mut index = HashMap::new();
+    walk(diff, &mut index);
+    index
+}
+
+fn candidate_paths(matches: &[words_to_data::matching::AmendmentMatch]) -> Vec<Vec<String>> {
+    matches
+        .iter()
+        .map(|m| {
+            m.candidates
+                .iter()
+                .map(|c| c.diff.root_path.clone())
+                .collect()
+        })
+        .collect()
+}
+
+#[test]
+fn should_order_candidates_identically_when_matches_are_built_twice() {
+    let dataset = make_fixture();
+    let diff = dataset
+        .compute_diff(&at("2025-07-18"), &at("2025-07-30"))
+        .expect("compute diff");
+
+    let first = build_matches(&dataset, &diff);
+    let second = build_matches(&dataset, &diff);
+
+    // Only an amendment with more than one candidate can expose an ordering bug.
+    assert!(
+        first.iter().any(|m| m.candidates.len() > 1),
+        "This test needs an amendment with more than one candidate to be meaningful"
+    );
+
+    let first_ids: Vec<&str> = first.iter().map(|m| m.amendment_id.as_str()).collect();
+    let second_ids: Vec<&str> = second.iter().map(|m| m.amendment_id.as_str()).collect();
+    assert_eq!(
+        first_ids, second_ids,
+        "The amendments should be matched in the same order every run"
+    );
+
+    assert_eq!(
+        candidate_paths(&first),
+        candidate_paths(&second),
+        "Each amendment's candidates should be in the same order every run"
+    );
+}
+
+#[test]
+fn should_order_candidates_by_document_position_when_building_matches() {
+    let dataset = make_fixture();
+    let diff = dataset
+        .compute_diff(&at("2025-07-18"), &at("2025-07-30"))
+        .expect("compute diff");
+    let order = document_order(&diff);
+
+    let matches = build_matches(&dataset, &diff);
+    assert!(
+        matches.iter().any(|m| m.candidates.len() > 1),
+        "This test needs an amendment with more than one candidate to be meaningful"
+    );
+
+    for m in &matches {
+        let positions: Vec<usize> = m
+            .candidates
+            .iter()
+            .map(|c| {
+                *order
+                    .get(&c.diff.root_path)
+                    .unwrap_or_else(|| panic!("{} is not a node of the diff", c.diff.root_path))
+            })
+            .collect();
+        assert!(
+            positions.windows(2).all(|pair| pair[0] < pair[1]),
+            "Candidates for amendment {} are not in document order: {:?}",
+            m.amendment_id,
+            m.candidates
+                .iter()
+                .map(|c| c.diff.root_path.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
Closes #73.

## What changed

`TreeDiff::from_elements` built two path-keyed hash maps of child elements and then iterated **those maps**, so `added`, `removed` and `child_diffs` inherited a per-process hash order. The fix iterates the child vectors, which already carry source document order, and uses the maps for membership lookup only.

That also removes the cost question the issue raised. It proposed either sorting or switching to `BTreeMap`, and noted the choice "is not obviously free either way". Iterating what is already ordered needs neither.

Scope was widened during triage to every hash-order site in the chain, so the whole pipeline is reproducible:

| Site | Was | Now |
|---|---|---|
| `TreeDiff::from_elements` | hash order | document order |
| Mention dedup | `HashMap::into_values()` | document order |
| Candidate paths | `HashSet<&str>` | document order |
| Bills and amendments | hash order | by id |

## Measured, on `dataset.json`

`diff --json`, three runs per work:

| Work | Before | After |
|---|---|---|
| `uscode/title_51` | 2 distinct hashes | 1 |
| `uscode/title_7` | 3 distinct hashes | 1 |
| `uscode/title_26` | 3 distinct hashes | 1 |

Contents are unchanged. `uscode/title_7` still reports 151 changed, 131 added and 27 removed paths, with identical path sets and only the order moved.

Ordering is document order, not lexicographic: `paragraph_9` now precedes `paragraph_10`, and `clause_viii` precedes `clause_ix`.

`coverage --json` is byte-identical to before, on both `title_7` and `title_26`. The issue named it as an affected surface; it is not, because it already sorted. It is untouched here.

## Two things found on the way

**Duplicate sibling paths.** A few siblings share a path — 11 of ~58,000 children in title 26, in both expressions, where the parser generates the same path twice. The old maps silently collapsed them. Iterating the vectors naively would have processed such a path twice and changed the contents, so the walk skips any child the map does not hold. Contents are preserved exactly.

**`USLMElement::find` panics on those paths**, on `assert!(child_vec.len() == 1)`. That is pre-existing and out of scope here, but it is a live crash on a public method that `path` and `match-amendments` both call. Filed separately as #77.

## Structure

Candidate gathering moved into the library as `words_to_data::matching`, because it was a private function in the binary crate and no test in `tests/` could reach it. The binary keeps the LLM, prompt and reporting code.

## Tests

Four new tests, all real data from `tests/test_data/`, no mocks. Each was confirmed to fail without the corresponding fix:

- `should_order_diff_children_identically_when_the_same_diff_is_built_twice`
- `should_order_diff_children_by_document_position_when_diffing_a_title`
- `should_order_mentions_identically_when_scanning_the_same_bill_twice`
- `should_order_candidates_identically_when_matches_are_built_twice`
- `should_order_candidates_by_document_position_when_building_matches`

Full suite passes with no regression against the baseline recorded before the work.

## Not in this PR

- The similarity map and its collapse (#75). `similarity_scores.json` is still not byte-stable, because score ties are ordered by the similarity `HashMap`. #75 covers it.
- Re-running the annotation pipeline. Candidate order changes what the model reads, so a re-run is wanted, but it costs model calls and is a human decision.

## Coordination with #75

#75 also edits candidate gathering, to apply a similarity cutoff there. It should rebase onto this branch, since this PR moves that code into `src/matching.rs`.
