### PR TITLE
fix: keep every amendment that explains a change, not just the best one

### DIFF
--- a/src/bin/words_to_data/match_amendments.rs
+++ b/src/bin/words_to_data/match_amendments.rs
@@ -18,7 +18,9 @@ use words_to_data::annotation::{
 };
 use words_to_data::dataset::{Dataset, Format};
 use words_to_data::legislature::AmendingAction;
-use words_to_data::matching::{AmendmentMatch, Candidate, build_matches};
+use words_to_data::matching::{
+    AmendmentMatch, Candidate, DEFAULT_SIMILARITY_CUTOFF, build_matches,
+};
 use words_to_data::uslm::TextContentField;
 
 use crate::llm::{ChatOptions, LlmClient};
@@ -43,6 +45,10 @@ pub struct Args {
     /// Number of concurrent LLM requests
     #[arg(long, default_value_t = 1)]
     pub threads: usize,
+
+    /// Only offer the model candidates scoring strictly above this cutoff
+    #[arg(long, default_value_t = DEFAULT_SIMILARITY_CUTOFF)]
+    pub similarity_cutoff: f32,
 
     /// Where to write the annotated dataset (defaults to overwriting the input)
     #[arg(long)]
@@ -85,7 +91,7 @@ pub fn run(args: Args) {
     for (from, to) in pairs {
         let diff = crate::fail::or_exit(dataset.compute_diff(&from, &to), "Error computing diff");
 
-        let matches = build_matches(&dataset, &diff);
+        let matches = build_matches(&dataset, &diff, args.similarity_cutoff);
         println!("\n{from} -> {to}");
         print_stats(&matches);
 

--- a/src/bin/words_to_data/score_amendments.rs
+++ b/src/bin/words_to_data/score_amendments.rs
@@ -67,10 +67,22 @@ pub fn run(args: Args) {
 
         let mut scores: Vec<AmendmentSimilarity> = bills
             .iter()
-            .flat_map(|bill| diff.calculate_amendment_similarities(bill).into_values())
+            .flat_map(|bill| {
+                diff.calculate_amendment_similarities(bill)
+                    .into_values()
+                    .flatten()
+            })
             .collect();
         scores.retain(|s| s.score > args.similarity_cutoff);
-        scores.sort_by(|a, b| b.score.total_cmp(&a.score));
+        // Sorting by score alone left ties in the order the paths came out of a
+        // hash map, so the file was not reproducible. Settle ties by path, then
+        // by amendment id, both of which are stable.
+        scores.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.tree_diff_path.cmp(&b.tree_diff_path))
+                .then_with(|| a.amendment_id.cmp(&b.amendment_id))
+        });
 
         println!("{from} -> {to}: {} above cutoff", scores.len());
         total += scores.len();

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -378,25 +378,42 @@ impl TreeDiff {
 
     /// Calculate the similarity of diffs in the TreeDiff with the amendment data from a bill
     ///
-    /// Returns a hashmap with the key being the root_path in the tree diff and the value
-    /// being the similarity data
+    /// Returns a hashmap keyed by the root_path in the tree diff. Each value
+    /// holds every amendment that scores above zero at that path, best score
+    /// first, ties broken by amendment id.
+    ///
+    /// More than one amendment can genuinely explain one change: one strikes
+    /// text while another inserts at the same subsection. Keeping only the
+    /// highest score discarded the rest, so the caller now narrows the list
+    /// itself, by cutoff or by asking a model (#75).
     pub fn calculate_amendment_similarities(
         &self,
         data: &Bill,
-    ) -> HashMap<String, AmendmentSimilarity> {
-        let mut result = HashMap::new();
+    ) -> HashMap<String, Vec<AmendmentSimilarity>> {
+        let mut result: HashMap<String, Vec<AmendmentSimilarity>> = HashMap::new();
         self.calculate_similarities_recursive(&mut result, data);
+
+        // The amendments were walked in hash order, so sort each path's list.
+        // Score alone is not enough to settle it: ties are common, and every
+        // difference seen between two runs was a tie (#75).
+        for similarities in result.values_mut() {
+            similarities.sort_by(|a, b| {
+                b.score
+                    .total_cmp(&a.score)
+                    .then_with(|| a.amendment_id.cmp(&b.amendment_id))
+            });
+        }
         result
     }
 
     fn calculate_similarities_recursive(
         &self,
-        result: &mut HashMap<String, AmendmentSimilarity>,
+        result: &mut HashMap<String, Vec<AmendmentSimilarity>>,
         data: &Bill,
     ) {
         // Check if this TreeDiff has any changes
         if !self.changes.is_empty() {
-            // Find the best matching amendment
+            // Keep every amendment that explains any of them
             for (amendment_id, amendment) in &data.amendments {
                 if amendment.changes.is_empty() {
                     continue;
@@ -405,14 +422,10 @@ impl TreeDiff {
                 let similarity = self.calculate_match_with_amendment(amendment_id, amendment);
 
                 if similarity.score > 0.0 {
-                    // Insert or update if this is a better match
-                    let entry = result
+                    result
                         .entry(self.root_path.clone())
-                        .or_insert(similarity.clone());
-
-                    if similarity.score > entry.score {
-                        *entry = similarity;
-                    }
+                        .or_default()
+                        .push(similarity);
                 }
             }
         }

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -54,8 +54,23 @@ fn document_order_index(diff: &TreeDiff) -> HashMap<&str, usize> {
     index
 }
 
+/// The similarity score a candidate must beat to be worth showing a model.
+///
+/// The same value `score-amendments` uses, so the two commands agree on what
+/// counts as a plausible explanation.
+pub const DEFAULT_SIMILARITY_CUTOFF: f32 = 0.4;
+
 /// Gather, for every amendment across every bill, the candidate diffs it may explain.
-pub fn build_matches(dataset: &Dataset<impl Storage>, diff: &TreeDiff) -> Vec<AmendmentMatch> {
+///
+/// `similarity_cutoff` drops weak scores before they become candidates. Scoring
+/// returns every amendment above zero at a path, a far larger set than the one
+/// per path it used to return, so the cutoff is what holds the candidate volume
+/// down (#75).
+pub fn build_matches(
+    dataset: &Dataset<impl Storage>,
+    diff: &TreeDiff,
+    similarity_cutoff: f32,
+) -> Vec<AmendmentMatch> {
     let mut matches = Vec::new();
     let path_order = document_order_index(diff);
 
@@ -81,7 +96,8 @@ pub fn build_matches(dataset: &Dataset<impl Storage>, diff: &TreeDiff) -> Vec<Am
         for amendment in amendments {
             let amd_scores: Vec<&AmendmentSimilarity> = similarities
                 .values()
-                .filter(|s| s.amendment_id == amendment.id)
+                .flatten()
+                .filter(|s| s.amendment_id == amendment.id && s.score > similarity_cutoff)
                 .collect();
             let empty = Vec::new();
             let amd_mentions = mentions.get(&amendment.id).unwrap_or(&empty);

--- a/tests/diff_tests.rs
+++ b/tests/diff_tests.rs
@@ -151,9 +151,12 @@ fn test_similarities() {
 
     // Section 174(a) has "specified" -> "foreign" change
     // Both words are in the amendment, so precision should be 1.0
-    let s174a_sim = similarity
+    let s174a_scores = similarity
         .get("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a")
         .unwrap();
+    // Only one amendment carries changes in this fixture, so only one scores.
+    assert_eq!(s174a_scores.len(), 1);
+    let s174a_sim = &s174a_scores[0];
     assert_eq!(s174a_sim.matched_words, 2);
     assert_eq!(s174a_sim.tree_diff_words, 2);
     assert_eq!(s174a_sim.precision, 1.0);
@@ -166,11 +169,108 @@ fn test_similarities() {
     assert_eq!(s174a_sim.score, 1.0);
 
     // Section 174(a)(2)(B) has more changes, check it matches well
-    let s174a2b_sim = similarity.get("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a/paragraph_2/subparagraph_B").unwrap();
+    let s174a2b_scores = similarity.get("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a/paragraph_2/subparagraph_B").unwrap();
+    assert_eq!(s174a2b_scores.len(), 1);
+    let s174a2b_sim = &s174a2b_scores[0];
     assert_eq!(s174a2b_sim.matched_words, 17);
     assert!(
         s174a2b_sim.score > 0.0,
         "Score should be positive for a match"
+    );
+}
+
+const S174A: &str =
+    "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+
+#[test]
+fn should_return_every_amendment_scoring_above_zero_when_two_amendments_touch_one_path() {
+    let doc_old = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+        .expect("Error running parser");
+    let doc_new = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+    let diff = TreeDiff::from_elements(&doc_old, &doc_new);
+
+    let mut amendment_data = parse_bill_amendments("119-21", PL_XML_PATH).unwrap();
+
+    // Word-level changes come from an LLM, which the library does not call, so
+    // stub them the way `test_similarities` does. Two amendments are given the
+    // same change, which is the real case this covers: one strikes and another
+    // inserts at the same subsection, so both explain it.
+    let shared_change = vec![BillDiff {
+        removed: vec!["specified".to_string()],
+        added: vec!["foreign".to_string()],
+    }];
+    let mut scoring_ids: Vec<String> = amendment_data.amendments.keys().take(2).cloned().collect();
+    scoring_ids.sort();
+    assert_eq!(scoring_ids.len(), 2, "The bill should hold two amendments");
+    for id in &scoring_ids {
+        amendment_data
+            .amendments
+            .get_mut(id)
+            .expect("amendment id came from the map")
+            .changes = shared_change.clone();
+    }
+
+    let similarities = diff.calculate_amendment_similarities(&amendment_data);
+    let at_174a = similarities
+        .get(S174A)
+        .expect("Section 174(a) should score against these amendments");
+
+    let scored_ids: Vec<&str> = at_174a.iter().map(|s| s.amendment_id.as_str()).collect();
+    assert_eq!(
+        scored_ids.len(),
+        2,
+        "Both amendments explain this path, so both should survive, got {scored_ids:?}"
+    );
+    for id in &scoring_ids {
+        assert!(
+            scored_ids.contains(&id.as_str()),
+            "Amendment {id} scores above zero here and should not be discarded"
+        );
+    }
+}
+
+#[test]
+fn should_order_similarities_by_score_then_amendment_id_when_several_score_at_one_path() {
+    let doc_old = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+        .expect("Error running parser");
+    let doc_new = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+    let diff = TreeDiff::from_elements(&doc_old, &doc_new);
+
+    let mut amendment_data = parse_bill_amendments("119-21", PL_XML_PATH).unwrap();
+
+    // A weaker and a stronger explanation of the same change, plus a tie, so
+    // both halves of the ordering rule are exercised.
+    let strong = vec![BillDiff {
+        removed: vec!["specified".to_string()],
+        added: vec!["foreign".to_string()],
+    }];
+    let weak = vec![BillDiff {
+        removed: vec!["specified".to_string()],
+        added: vec!["unrelated".to_string(), "wording".to_string()],
+    }];
+    let mut ids: Vec<String> = amendment_data.amendments.keys().take(3).cloned().collect();
+    ids.sort();
+    assert_eq!(ids.len(), 3, "The bill should hold three amendments");
+    amendment_data.amendments.get_mut(&ids[0]).unwrap().changes = strong.clone();
+    amendment_data.amendments.get_mut(&ids[1]).unwrap().changes = strong;
+    amendment_data.amendments.get_mut(&ids[2]).unwrap().changes = weak;
+
+    let similarities = diff.calculate_amendment_similarities(&amendment_data);
+    let at_174a = similarities
+        .get(S174A)
+        .expect("Section 174(a) should score against these amendments");
+
+    let ordering: Vec<(f32, &str)> = at_174a
+        .iter()
+        .map(|s| (s.score, s.amendment_id.as_str()))
+        .collect();
+    let mut expected = ordering.clone();
+    expected.sort_by(|a, b| b.0.total_cmp(&a.0).then_with(|| a.1.cmp(b.1)));
+    assert_eq!(
+        ordering, expected,
+        "Similarities at one path should run from best score down, ties broken by amendment id"
     );
 }
 

--- a/tests/matching_tests.rs
+++ b/tests/matching_tests.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 
 use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId};
 use words_to_data::diff::TreeDiff;
-use words_to_data::matching::build_matches;
+use words_to_data::legislature::BillDiff;
+use words_to_data::matching::{DEFAULT_SIMILARITY_CUTOFF, build_matches};
 use words_to_data::storage::InMemoryStorage;
 use words_to_data::uslm::bill_parser::parse_bill_amendments;
 
@@ -41,6 +42,77 @@ fn make_fixture() -> Dataset<InMemoryStorage> {
     let bill = parse_bill_amendments("119-21", PL_XML).expect("parse bill");
     dataset.add_bill(bill).expect("add bill");
     dataset
+}
+
+/// The same fixture, but with word-level changes stubbed onto every amendment
+/// so that the similarity channel actually produces scores.
+///
+/// Word-level changes come from an LLM, which the library does not call, so a
+/// dataset built here carries none and only the mention channel fires.
+fn fixture_with_scored_amendments() -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Matching Fixture".to_string(),
+        description: "Title 26, two release points".to_string(),
+        author: "Tester".to_string(),
+        source_urls: vec!["https://uscode.house.gov".to_string()],
+        license: "Public Domain".to_string(),
+        version: "1.0".to_string(),
+    });
+    dataset
+        .add_uslm_xml(USC26_18, "2025-07-18", Some("Before".to_string()))
+        .expect("add first version");
+    dataset
+        .add_uslm_xml(USC26_30, "2025-07-30", Some("After".to_string()))
+        .expect("add second version");
+
+    let mut bill = parse_bill_amendments("119-21", PL_XML).expect("parse bill");
+    for amendment in bill.amendments.values_mut() {
+        amendment.changes = vec![BillDiff {
+            removed: vec!["specified".to_string()],
+            added: vec!["foreign".to_string()],
+        }];
+    }
+    dataset.add_bill(bill).expect("add bill");
+    dataset
+}
+
+#[test]
+fn should_drop_candidates_at_or_below_the_similarity_cutoff_when_building_matches() {
+    let dataset = fixture_with_scored_amendments();
+    let diff = dataset
+        .compute_diff(&at("2025-07-18"), &at("2025-07-30"))
+        .expect("compute diff");
+
+    let permissive = build_matches(&dataset, &diff, 0.0);
+    let strict = build_matches(&dataset, &diff, 0.99);
+
+    let scored = |matches: &[words_to_data::matching::AmendmentMatch]| -> usize {
+        matches
+            .iter()
+            .flat_map(|m| m.candidates.iter())
+            .filter(|c| c.similarity.is_some())
+            .count()
+    };
+    assert!(
+        scored(&permissive) > scored(&strict),
+        "A higher cutoff should leave fewer scored candidates, got {} then {}",
+        scored(&permissive),
+        scored(&strict)
+    );
+
+    // Nothing at or below the cutoff should survive it.
+    for m in &strict {
+        for candidate in &m.candidates {
+            if let Some(similarity) = &candidate.similarity {
+                assert!(
+                    similarity.score > 0.99,
+                    "Candidate {} scored {} and should have been dropped",
+                    candidate.diff.root_path,
+                    similarity.score
+                );
+            }
+        }
+    }
 }
 
 /// Position of every diff node in a document-order walk of the tree.
@@ -76,8 +148,8 @@ fn should_order_candidates_identically_when_matches_are_built_twice() {
         .compute_diff(&at("2025-07-18"), &at("2025-07-30"))
         .expect("compute diff");
 
-    let first = build_matches(&dataset, &diff);
-    let second = build_matches(&dataset, &diff);
+    let first = build_matches(&dataset, &diff, DEFAULT_SIMILARITY_CUTOFF);
+    let second = build_matches(&dataset, &diff, DEFAULT_SIMILARITY_CUTOFF);
 
     // Only an amendment with more than one candidate can expose an ordering bug.
     assert!(
@@ -107,7 +179,7 @@ fn should_order_candidates_by_document_position_when_building_matches() {
         .expect("compute diff");
     let order = document_order(&diff);
 
-    let matches = build_matches(&dataset, &diff);
+    let matches = build_matches(&dataset, &diff, DEFAULT_SIMILARITY_CUTOFF);
     assert!(
         matches.iter().any(|m| m.candidates.len() > 1),
         "This test needs an amendment with more than one candidate to be meaningful"


### PR DESCRIPTION
Re-targets the work from #78 onto `vibes`. Closes #75.

**Why this exists.** #78 was stacked on `vibes-73-deterministic-diff-order` while #76 was in review. #76 merged into `vibes` first, and #78 then merged into its original base branch, which was by then already merged. The result is that #78 shows as merged but its commit never reached `vibes`:

```
$ git log --oneline origin/vibes..origin/vibes-75-multi-amendment-similarity
3563784 fix: keep every amendment that explains a change, not just the best one
```

`origin/vibes` contains neither the new return type nor the `--similarity-cutoff` flag. This PR carries exactly that one commit across. No content has changed since #78 was reviewed.

---

`calculate_amendment_similarities` returned one `AmendmentSimilarity` per code path. Every amendment scoring above zero there competed and only the highest survived, so **1203 of 1536 matches above the cutoff were discarded — 78%**. The worst path kept 1 of 26.

It now returns every amendment above zero at a path, best score first, ties broken by amendment id. The tie-break matters: amendments were walked in hash order, so on a tie whichever the run reached first was credited, and two runs of the same binary credited a different amendment at **60 paths, every one a tie**.

Per the triage decisions:

- Candidate gathering applies the cutoff itself, reusing the same `--similarity-cutoff` name and 0.4 default. Without it, removing the collapse would have let every non-zero score reach the model, since that path had no cutoff at all.
- `score-amendments` keeps 0.4 and its flat output shape, so nothing reading `similarity_scores.json` changes.

## Measured on `dataset.json`, cutoff 0.4

| Work | Before | After | |
|---|---|---|---|
| `uscode/title_26` | 210 | 746 | 3.6x |
| `uscode/title_7` | 98 | 739 | 7.5x |
| `uscode/title_20` | 25 | 51 | 2.0x |
| **total** | **333** | **1536** | **4.6x** |

The reporter's figures reproduce exactly — 746, 739 and 51 match their table cell for cell, as do the 78% discard rate, the 185 paths carrying more than one match, and the worst path keeping 1 of 26 at `uscode/title_7/chapter_115/subchapter_I/section_9016/subsection_d`.

`score-amendments` output is now byte-identical between runs; it previously sorted by score alone, leaving ties in hash order.

## Tests

Each confirmed to fail without the fix:

- `should_return_every_amendment_scoring_above_zero_when_two_amendments_touch_one_path`
- `should_order_similarities_by_score_then_amendment_id_when_several_score_at_one_path`
- `should_drop_candidates_at_or_below_the_similarity_cutoff_when_building_matches`
- `test_similarities` updated for the new shape, asserting the same scores, precision and matched word counts

Full suite passes, no regression against baseline.

## Needs a human decision

**The annotation pipeline wants re-running.** Candidate sets change, so existing annotations were produced against a narrower and partly arbitrary list. I have not re-run it: it costs model calls.

At 4.6x the scored candidates, `match-amendments` will send materially more to the model than the last run did. The lever is `--similarity-cutoff`, now on both commands.