### PR TITLE
fix: let score-amendments read a SQLite dataset, and say so when it cannot

### DIFF
--- a/src/bin/words_to_data/extract_changes.rs
+++ b/src/bin/words_to_data/extract_changes.rs
@@ -60,7 +60,11 @@ struct RawDiff {
 }
 
 pub fn run(args: Args) {
-    let mut dataset = Dataset::load(&args.dataset, Format::Compact).expect("Error loading dataset");
+    crate::load::refuse_sqlite(&args.dataset, "extract-changes");
+    let mut dataset = crate::fail::or_exit(
+        Dataset::load(&args.dataset, Format::Compact),
+        "Error loading dataset",
+    );
 
     // Amendments that already carry changes are done — don't re-extract or
     // re-apply them (applying twice would duplicate changes in the dataset).

--- a/src/bin/words_to_data/load.rs
+++ b/src/bin/words_to_data/load.rs
@@ -18,6 +18,22 @@ pub fn is_sqlite(path: &str) -> bool {
     path.ends_with(".sqlite") || path.ends_with(".db")
 }
 
+/// Stop, with an explanation, when a compact-JSON-only command is handed SQLite.
+///
+/// A command that writes back into the dataset cannot yet take a SQLite file.
+/// Without this check the path is read as JSON and the reader sees "stream did
+/// not contain valid UTF-8", which says nothing about what to do next.
+pub fn refuse_sqlite(path: &str, command: &str) {
+    if is_sqlite(path) {
+        eprintln!(
+            "{command} writes back into the dataset and needs a compact JSON file, \
+             but {path} is a SQLite database.\n\
+             Convert it first:\n    words_to_data convert-dataset {path}"
+        );
+        std::process::exit(1);
+    }
+}
+
 /// Open a dataset, choosing the backend from the file extension.
 pub fn open(path: &str) -> Result<OpenDataset, DatasetError> {
     if is_sqlite(path) {

--- a/src/bin/words_to_data/match_amendments.rs
+++ b/src/bin/words_to_data/match_amendments.rs
@@ -68,6 +68,7 @@ struct CandidatesOfWork {
 }
 
 pub fn run(args: Args) {
+    crate::load::refuse_sqlite(&args.dataset, "match-amendments");
     let mut dataset = crate::fail::or_exit(
         Dataset::load(&args.dataset, Format::Compact),
         "Error loading dataset",

--- a/src/bin/words_to_data/score_amendments.rs
+++ b/src/bin/words_to_data/score_amendments.rs
@@ -10,14 +10,16 @@ use std::path::{Path, PathBuf};
 
 use clap::Args as ClapArgs;
 use serde::Serialize;
-use words_to_data::dataset::{Dataset, Format};
+use words_to_data::dataset::Dataset;
 use words_to_data::diff::AmendmentSimilarity;
+use words_to_data::storage::Storage;
 
+use crate::load::{self, with_dataset};
 use crate::span::Span;
 
 #[derive(ClapArgs)]
 pub struct Args {
-    /// Dataset (compact JSON) with extracted amendment changes and the expressions to score
+    /// Dataset (`.json` compact or `.sqlite`) with extracted amendment changes and the expressions to score
     pub dataset: String,
 
     #[command(flatten)]
@@ -46,11 +48,33 @@ struct ScoredWork {
 }
 
 pub fn run(args: Args) {
-    let dataset = crate::fail::or_exit(
-        Dataset::load(&args.dataset, Format::Compact),
-        "Error loading dataset",
+    // Scoring only reads the dataset, so it runs over either backend.
+    let opened = crate::fail::or_exit(load::open(&args.dataset), "Error loading dataset");
+    let (scored, total) = with_dataset!(opened, dataset => score(&args, &dataset));
+
+    let scores_path = args
+        .output
+        .as_deref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| sibling(&args.dataset, "similarity_scores.json"));
+    crate::fail::or_exit(
+        fs::write(
+            &scores_path,
+            serde_json::to_string_pretty(&scored).expect("Error serializing scores"),
+        ),
+        "Error writing scores",
     );
 
+    println!(
+        "Scored {total} amendment match(es) above cutoff across {} work(s)",
+        scored.len()
+    );
+    println!("Wrote {}", scores_path.display());
+}
+
+/// Score every expression pair the span resolves to, returning the per-work
+/// scores and the total kept above the cutoff.
+fn score(args: &Args, dataset: &Dataset<impl Storage>) -> (Vec<ScoredWork>, usize) {
     let bills: Vec<_> = crate::fail::or_exit(dataset.list_bill_ids(), "Error listing bills")
         .into_iter()
         .map(|id| {
@@ -62,7 +86,7 @@ pub fn run(args: Args) {
     let mut scored = Vec::new();
     let mut total = 0;
 
-    for (from, to) in args.span.resolve(&dataset) {
+    for (from, to) in args.span.resolve(dataset) {
         let diff = crate::fail::or_exit(dataset.compute_diff(&from, &to), "Error computing diff");
 
         let mut scores: Vec<AmendmentSimilarity> = bills
@@ -94,23 +118,7 @@ pub fn run(args: Args) {
         });
     }
 
-    let scores_path = args
-        .output
-        .map(PathBuf::from)
-        .unwrap_or_else(|| sibling(&args.dataset, "similarity_scores.json"));
-    crate::fail::or_exit(
-        fs::write(
-            &scores_path,
-            serde_json::to_string_pretty(&scored).expect("Error serializing scores"),
-        ),
-        "Error writing scores",
-    );
-
-    println!(
-        "Scored {total} amendment match(es) above cutoff across {} work(s)",
-        scored.len()
-    );
-    println!("Wrote {}", scores_path.display());
+    (scored, total)
 }
 
 /// Build a path to `filename` in the same directory as `dataset_path`.

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -772,3 +772,69 @@ fn should_report_and_succeed_when_a_valid_span_covers_no_work() {
         "it must say it did nothing"
     );
 }
+
+#[test]
+fn should_score_amendments_when_the_dataset_is_sqlite() {
+    let output = run(&[
+        "score-amendments",
+        amended_fixture(),
+        "--from",
+        &expression(AMENDED_WORK, EARLY),
+        "--to",
+        &expression(AMENDED_WORK, LATE),
+        "--output",
+        &format!("{}/sqlite_scores.json", env!("CARGO_TARGET_TMPDIR")),
+    ]);
+
+    // Scoring only reads the dataset, so it must work over either backend.
+    // Handing it SQLite used to read the database as JSON and report
+    // "stream did not contain valid UTF-8", which named neither cause nor cure.
+    assert!(
+        output.status.success(),
+        "score-amendments should accept a SQLite dataset, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn should_explain_the_conversion_when_a_writing_command_is_given_sqlite() {
+    // These two write back into the dataset, which SQLite does not yet support.
+    // Refusing is fine; refusing without saying what to do next is not.
+    let from = expression(AMENDED_WORK, EARLY);
+    let to = expression(AMENDED_WORK, LATE);
+    let invocations: [Vec<&str>; 2] = [
+        vec![
+            "match-amendments",
+            amended_fixture(),
+            "--from",
+            &from,
+            "--to",
+            &to,
+        ],
+        vec!["extract-changes", amended_fixture()],
+    ];
+
+    for args in invocations {
+        let command = args[0];
+        let output = run(&args);
+
+        assert!(
+            !output.status.success(),
+            "{command} should refuse a SQLite dataset"
+        );
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("SQLite database"),
+            "{command} should say the file is a SQLite database, got: {stderr}"
+        );
+        assert!(
+            stderr.contains("convert-dataset"),
+            "{command} should name the command that converts it, got: {stderr}"
+        );
+        assert!(
+            !stderr.contains("valid UTF-8"),
+            "{command} should not leak the raw decoding error, got: {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #80. Found while testing #73 and #75 against `dataset.sqlite`.

**Pre-existing, not a regression.** The unconditional compact-JSON load is present in `13a6839`, before that work.

## What happened

```
$ words_to_data score-amendments dataset.sqlite --between 2025-07-18 2025-07-30
Error loading dataset: IO error: stream did not contain valid UTF-8
```

The SQLite file was read as JSON and failed at the first non-UTF-8 byte. Three commands shared the pattern; the read-only commands already accept either backend through `load::open`:

| Command | Before | After | Reads or writes |
|---|---|---|---|
| `score-amendments` | opaque UTF-8 error | **works** | reads only |
| `match-amendments` | opaque UTF-8 error | clear refusal | writes back |
| `extract-changes` | **panicked** | clear refusal | writes back |

## What changed

`score-amendments` only reads, so it opens either backend through the existing helper.

`match-amendments` and `extract-changes` write the dataset back. Where those writes should go for a SQLite input is a design question, not a bug, so this PR does not answer it — they refuse and name the way out:

```
match-amendments writes back into the dataset and needs a compact JSON file,
but dataset.sqlite is a SQLite database.
Convert it first:
    words_to_data convert-dataset dataset.sqlite
```

`extract-changes` previously panicked, because it used `expect()` rather than the `fail::or_exit` helper every other command uses. It now exits 1 with a message.

## Verified on the real dataset

```
$ words_to_data score-amendments dataset.sqlite --between 2025-07-18 2025-07-30
Scored 1666 amendment match(es) above cutoff across 58 work(s)
```

The two backends agree byte for byte — `sha256` of the scores written from `dataset.sqlite` and from `dataset.json` is identical (`f0aa536bf0198efb…`).

## Tests

Two added to the CLI suite, which drives the binary as a subprocess:

- `should_score_amendments_when_the_dataset_is_sqlite`
- `should_explain_the_conversion_when_a_writing_command_is_given_sqlite` — asserts the refusal names the database and `convert-dataset`, and that the raw decoding error no longer leaks

Full suite passes, no regression against baseline.

## Still open

Whether `match-amendments` and `extract-changes` should accept SQLite properly. They would need somewhere to put their writes, which is your call, not something to settle inside a bug fix.