### PR TITLE
fix: search every text field on SQLite, not the heading and content alone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ required-features = ["tools"]
 
 [dev-dependencies]
 rstest = "0.18"
+# Tests forge a dataset written by an older build, which needs raw SQL: the
+# public API can only produce files this build considers current.
+rusqlite = { version = "0.35", features = ["bundled", "serialize"] }

--- a/src/bin/words_to_data/convert_dataset.rs
+++ b/src/bin/words_to_data/convert_dataset.rs
@@ -22,20 +22,28 @@ pub fn run(args: Args) {
     match (is_sqlite(&args.input), is_sqlite(&output)) {
         (false, true) => {
             println!("Converting compact JSON -> SQLite...");
-            let dataset =
-                Dataset::load(&args.input, Format::Compact).expect("Error loading dataset");
-            dataset
-                .save_to_sqlite(&output)
-                .expect("Error saving SQLite");
+            let dataset = crate::fail::or_exit(
+                Dataset::load(&args.input, Format::Compact),
+                "Error loading dataset",
+            );
+            // Start from an empty file. Writing into an existing database keeps
+            // whatever it already held: rows of a different dataset that share
+            // no key survive, and a table from an older build keeps its narrower
+            // shape. Converting names an output, so producing that output rather
+            // than a mixture of it and its predecessor is the whole job.
+            crate::fail::or_exit(
+                remove_existing(&output),
+                "Error replacing the output dataset",
+            );
+            crate::fail::or_exit(dataset.save_to_sqlite(&output), "Error saving SQLite");
         }
         (true, false) => {
             println!("Converting SQLite -> compact JSON...");
-            let dataset = Dataset::open_sqlite(&args.input).expect("Error opening SQLite");
-            dataset
-                .to_memory()
-                .expect("Error reading SQLite")
-                .save(&output, Format::Compact)
-                .expect("Error saving JSON");
+            let dataset =
+                crate::fail::or_exit(Dataset::open_sqlite(&args.input), "Error opening SQLite");
+            let memory = crate::fail::or_exit(dataset.to_memory(), "Error reading SQLite");
+            // Writing JSON truncates, so this direction already replaces.
+            crate::fail::or_exit(memory.save(&output, Format::Compact), "Error saving JSON");
         }
         _ => {
             eprintln!(
@@ -48,6 +56,16 @@ pub fn run(args: Args) {
     }
 
     println!("{output}");
+}
+
+/// Delete the output file if it is already there, so the conversion starts clean.
+///
+/// A missing file is the normal case and not an error.
+fn remove_existing(path: &str) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        other => other,
+    }
 }
 
 /// Swap a `.json` input for `.sqlite` output and vice versa.

--- a/src/dataset/error.rs
+++ b/src/dataset/error.rs
@@ -34,4 +34,11 @@ pub enum DatasetError {
          {expected}. Datasets are rebuilt rather than migrated, so regenerate it."
     )]
     SchemaVersionMismatch { found: i32, expected: i32 },
+
+    #[error(
+        "This dataset's search index was written before this build and covers only some of the \
+         text fields, so a search over it would report law as absent. Regenerate the dataset: \
+         `words_to_data convert-dataset <source> {path}`."
+    )]
+    StaleSearchIndex { path: String },
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -44,6 +44,13 @@ use crate::uslm::bill_parser::Bill;
 /// 3 is the work-scoped schema: an expression is `(work, date)` with its own
 /// tree, and annotations are keyed by a pair of expressions
 /// (`docs/adr/0003-storage-is-keyed-by-work.md`).
+///
+/// One number covering both forms cannot describe a change to only one of
+/// them. Widening the SQLite search index (#82) left the compact JSON
+/// untouched, because its element trees always carried every text field, so
+/// bumping this would have rejected valid JSON datasets to fix a SQLite table.
+/// That case is caught where it happens, when the database is opened, rather
+/// than here. A change that alters both forms still belongs to this number.
 pub const SCHEMA_VERSION: i32 = 3;
 
 /// Reading the documents a dataset holds.

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 use rusqlite::{Connection, params};
 
@@ -24,6 +25,49 @@ use crate::uslm::bill_parser::Bill;
 pub struct SqliteStorage {
     conn: Connection,
     metadata: DatasetMetadata,
+}
+
+/// The columns of `element_index`, in the order the insert takes them.
+const ELEMENT_INDEX_INSERT: &str = "INSERT OR REPLACE INTO element_index \
+     (work, date, path, element_type, heading, chapeau, content, proviso, continuation, ordinal) \
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)";
+
+/// One row of the element index: every searchable field of one element, plus
+/// where it sits in a document-order walk.
+///
+/// A struct rather than a tuple because two call sites write these rows, and a
+/// positional tuple let the two drift apart without the compiler noticing.
+struct ElementRow<'a> {
+    path: &'a str,
+    element_type: String,
+    heading: Option<&'a str>,
+    chapeau: Option<&'a str>,
+    content: Option<&'a str>,
+    proviso: Option<&'a str>,
+    continuation: Option<&'a str>,
+    ordinal: i64,
+}
+
+impl ElementRow<'_> {
+    fn execute(
+        &self,
+        stmt: &mut rusqlite::Statement,
+        id: &ExpressionId,
+    ) -> Result<(), DatasetError> {
+        stmt.execute(params![
+            id.work.as_str(),
+            &id.at,
+            self.path,
+            self.element_type,
+            self.heading,
+            self.chapeau,
+            self.content,
+            self.proviso,
+            self.continuation,
+            self.ordinal,
+        ])?;
+        Ok(())
+    }
 }
 
 /// Refuse a dataset this build cannot read.
@@ -51,13 +95,53 @@ fn check_schema_version(conn: &Connection) -> Result<(), DatasetError> {
     }
 }
 
+/// Refuse a search index that predates the columns this build searches.
+///
+/// `CREATE TABLE IF NOT EXISTS` leaves an existing table alone, so a file built
+/// before the index covered every text field keeps its narrower table. Reading
+/// it would answer a search from two fields out of five and say nothing about
+/// the other three, which is the silence #82 exists to stop. The schema version
+/// does not catch this, because the compact JSON shares that number and its own
+/// contents are unaffected.
+fn check_search_index(conn: &Connection, path: &str) -> Result<(), DatasetError> {
+    let table_exists: bool = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'element_index'",
+            [],
+            |row| row.get::<_, i32>(0),
+        )
+        .is_ok();
+    if !table_exists {
+        return Ok(());
+    }
+
+    let mut stmt = conn.prepare("PRAGMA table_info(element_index)")?;
+    let columns: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<_, _>>()?;
+
+    let complete = ["chapeau", "proviso", "continuation", "ordinal"]
+        .iter()
+        .all(|wanted| columns.iter().any(|held| held == wanted));
+
+    if complete {
+        Ok(())
+    } else {
+        Err(DatasetError::StaleSearchIndex {
+            path: path.to_string(),
+        })
+    }
+}
+
 impl SqliteStorage {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, DatasetError> {
+        let shown = path.as_ref().display().to_string();
         let conn = Connection::open(path)?;
         // Check before init_schema, which would otherwise add this build's
         // tables to an older file and leave a hybrid that answers queries with
         // nothing rather than saying it cannot read them.
         check_schema_version(&conn)?;
+        check_search_index(&conn, &shown)?;
         let mut storage = Self {
             conn,
             metadata: DatasetMetadata::default(),
@@ -129,8 +213,18 @@ impl SqliteStorage {
                 date TEXT NOT NULL,
                 path TEXT NOT NULL,
                 element_type TEXT,
+                -- One column per variant of TextContentField. Indexing only
+                -- some of them made their text unfindable, and silently, which
+                -- reads to a searcher as the law not being there (#82).
                 heading TEXT,
+                chapeau TEXT,
                 content TEXT,
+                proviso TEXT,
+                continuation TEXT,
+                -- Position in a document-order walk, so search results can come
+                -- back in the order a reader meets the provisions, matching the
+                -- in-memory backend.
+                ordinal INTEGER NOT NULL,
                 PRIMARY KEY (work, date, path)
             );
 
@@ -257,21 +351,12 @@ impl SqliteStorage {
 
         // Save element index for each expression (batch collect then insert)
         {
-            let mut stmt = tx.prepare(
-                "INSERT OR REPLACE INTO element_index (work, date, path, element_type, heading, content) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            )?;
+            let mut stmt = tx.prepare(ELEMENT_INDEX_INSERT)?;
             for expression in storage.all_expressions() {
                 let mut rows = Vec::new();
                 Self::collect_element_rows(&expression.element, &mut rows);
-                for (path, elem_type, heading, content) in rows {
-                    stmt.execute(params![
-                        expression.id.work.as_str(),
-                        &expression.id.at,
-                        path,
-                        elem_type,
-                        heading,
-                        content
-                    ])?;
+                for row in rows {
+                    row.execute(&mut stmt, &expression.id)?;
                 }
             }
         }
@@ -391,14 +476,18 @@ impl SqliteStorage {
 
     /// Collect element data into rows for batch insert (no recursion overhead per-insert)
     #[allow(clippy::type_complexity)]
-    fn collect_element_rows<'a>(
-        element: &'a USLMElement,
-        rows: &mut Vec<(&'a str, String, Option<&'a str>, Option<&'a str>)>,
-    ) {
-        let element_type = format!("{:?}", element.data.element_type);
-        let heading = element.data.heading.as_ref().map(|s| s.as_ref());
-        let content = element.data.content.as_ref().map(|s| s.as_ref());
-        rows.push((element.data.path.as_ref(), element_type, heading, content));
+    fn collect_element_rows<'a>(element: &'a USLMElement, rows: &mut Vec<ElementRow<'a>>) {
+        let text = |field: &'a Option<Arc<str>>| field.as_ref().map(|s| s.as_ref());
+        rows.push(ElementRow {
+            path: element.data.path.as_ref(),
+            element_type: format!("{:?}", element.data.element_type),
+            heading: text(&element.data.heading),
+            chapeau: text(&element.data.chapeau),
+            content: text(&element.data.content),
+            proviso: text(&element.data.proviso),
+            continuation: text(&element.data.continuation),
+            ordinal: rows.len() as i64,
+        });
 
         for child in &element.children {
             Self::collect_element_rows(child, rows);
@@ -412,15 +501,8 @@ impl SqliteStorage {
     ) -> Result<(), DatasetError> {
         let mut rows = Vec::new();
         Self::collect_element_rows(element, &mut rows);
-        for (path, elem_type, heading, content) in rows {
-            stmt.execute(params![
-                id.work.as_str(),
-                &id.at,
-                path,
-                elem_type,
-                heading,
-                content
-            ])?;
+        for row in rows {
+            row.execute(stmt, id)?;
         }
         Ok(())
     }
@@ -889,12 +971,29 @@ impl DocumentReader for SqliteStorage {
     }
 
     fn search_text(&self, query: &str) -> Result<Vec<SearchResult>, DatasetError> {
-        // Search using element_index table
+        // Every text field, not a chosen few: a field left out of this query is
+        // a field whose text reads as absent from the law (#82).
+        //
+        // The ordering reproduces the in-memory walk exactly, so the two
+        // backends answer alike: work, then date, then document position, then
+        // the field order that backend declares.
         let query_pattern = format!("%{}%", query.to_lowercase());
         let mut stmt = self.conn.prepare(
-            "SELECT work, date, path, 'heading', heading FROM element_index WHERE LOWER(heading) LIKE ?1
+            "SELECT work, date, path, ordinal, 0 AS field_rank, 'heading' AS field, heading AS snippet
+                 FROM element_index WHERE LOWER(heading) LIKE ?1
              UNION ALL
-             SELECT work, date, path, 'content', content FROM element_index WHERE LOWER(content) LIKE ?1",
+             SELECT work, date, path, ordinal, 1, 'chapeau', chapeau
+                 FROM element_index WHERE LOWER(chapeau) LIKE ?1
+             UNION ALL
+             SELECT work, date, path, ordinal, 2, 'content', content
+                 FROM element_index WHERE LOWER(content) LIKE ?1
+             UNION ALL
+             SELECT work, date, path, ordinal, 3, 'proviso', proviso
+                 FROM element_index WHERE LOWER(proviso) LIKE ?1
+             UNION ALL
+             SELECT work, date, path, ordinal, 4, 'continuation', continuation
+                 FROM element_index WHERE LOWER(continuation) LIKE ?1
+             ORDER BY work, date, ordinal, field_rank",
         )?;
         let mut rows = stmt.query(params![query_pattern])?;
 
@@ -903,8 +1002,8 @@ impl DocumentReader for SqliteStorage {
             let work: String = row.get(0)?;
             let date: String = row.get(1)?;
             let path: String = row.get(2)?;
-            let field: String = row.get(3)?;
-            let snippet: Option<String> = row.get(4)?;
+            let field: String = row.get(5)?;
+            let snippet: Option<String> = row.get(6)?;
             if let Some(snippet) = snippet {
                 results.push(SearchResult {
                     expression: ExpressionId::new(WorkId::new(work), date),
@@ -1315,9 +1414,7 @@ impl DocumentWriter for SqliteStorage {
         )?;
 
         // Index elements
-        let mut stmt = self.conn.prepare(
-            "INSERT OR REPLACE INTO element_index (work, date, path, element_type, heading, content) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        )?;
+        let mut stmt = self.conn.prepare(ELEMENT_INDEX_INSERT)?;
         Self::index_element(&mut stmt, &expression.id, &expression.element)?;
 
         Ok(())

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -838,3 +838,52 @@ fn should_explain_the_conversion_when_a_writing_command_is_given_sqlite() {
         );
     }
 }
+
+/// Forge the element index an older build wrote, at a chosen path.
+fn forge_stale_sqlite(name: &str) -> String {
+    let path = format!("{}/{name}.sqlite", env!("CARGO_TARGET_TMPDIR"));
+    let _ = std::fs::remove_file(&path);
+    let conn = rusqlite::Connection::open(&path).expect("open forged db");
+    conn.execute_batch(
+        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+         INSERT INTO schema_version (version) VALUES (3);
+         CREATE TABLE element_index (
+             work TEXT NOT NULL, date TEXT NOT NULL, path TEXT NOT NULL,
+             element_type TEXT, heading TEXT, content TEXT,
+             PRIMARY KEY (work, date, path)
+         );",
+    )
+    .expect("forge the older index");
+    drop(conn);
+    path
+}
+
+#[test]
+fn should_replace_the_output_when_converting_onto_an_existing_database() {
+    // Converting names an output. Writing into whatever sits at that path
+    // leaves a mixture of two datasets, and an index from an older build cannot
+    // even accept the rows — it failed with a raw SQL error about a missing
+    // column, which is the state a reader reaches by refreshing their database.
+    let occupied = forge_stale_sqlite("convert_onto_existing");
+
+    let output = run(&["convert-dataset", both_works_json_fixture(), &occupied]);
+    assert!(
+        output.status.success(),
+        "converting onto an existing database should replace it, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The result must be a usable dataset, not a hybrid of the two.
+    let info = run(&["info", &occupied, "--json"]);
+    assert!(
+        info.status.success(),
+        "the converted database should open, stderr: {}",
+        String::from_utf8_lossy(&info.stderr)
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&info.stdout).expect("info --json should emit json");
+    assert!(
+        parsed["expression_count"].as_i64().unwrap_or(0) > 0,
+        "the converted database should hold the source's expressions"
+    );
+}

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -1,0 +1,215 @@
+//! Search must give the same answer whichever backend holds the dataset.
+//!
+//! A reader asks a search "is this text in the law". A backend that answers
+//! "no" because it never indexed the field the text sits in is worse than one
+//! that errors: the reader is told the law is absent (#82).
+
+use words_to_data::dataset::{Dataset, DatasetMetadata, SearchResult};
+use words_to_data::inspect;
+use words_to_data::storage::{InMemoryStorage, SqliteStorage};
+
+const USC09_18: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
+const USC09_30: &str = "tests/test_data/usc/2025-07-30/usc09.xml";
+const USC26_18: &str = "tests/test_data/usc/2025-07-18/usc26.xml";
+
+/// Text that appears in a `chapeau` in title 9.
+const CHAPEAU_TEXT: &str = "In any of the following cases the United States court";
+
+fn metadata() -> DatasetMetadata {
+    DatasetMetadata {
+        name: "Search Fixture".to_string(),
+        description: "Real USC text, for search parity".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "Public Domain".to_string(),
+        version: "1.0".to_string(),
+    }
+}
+
+/// Title 9 at both release points. Small, and it carries heading, chapeau and
+/// content text.
+fn title_9() -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(metadata());
+    for (xml, date) in [(USC09_18, "2025-07-18"), (USC09_30, "2025-07-30")] {
+        dataset
+            .add_uslm_xml(xml, date, None)
+            .expect("the fixture should parse");
+    }
+    dataset
+}
+
+/// One expression of title 26. It is the only fixture carrying `proviso` and
+/// `continuation` text, and one expression is enough to search.
+fn title_26() -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(metadata());
+    dataset
+        .add_uslm_xml(USC26_18, "2025-07-18", None)
+        .expect("the fixture should parse");
+    dataset
+}
+
+fn to_sqlite(fixture: &Dataset<InMemoryStorage>, name: &str) -> Dataset<SqliteStorage> {
+    let dir = std::path::Path::new("target/search_test_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let path = dir.join(format!("{name}.sqlite"));
+    std::fs::remove_file(&path).ok();
+    fixture.save_to_sqlite(&path).expect("save to sqlite");
+    Dataset::open_sqlite(&path).expect("open sqlite")
+}
+
+/// The comparable shape of a hit: which field of which path matched.
+fn hits(results: &[SearchResult]) -> Vec<(String, String, String)> {
+    results
+        .iter()
+        .map(|r| (r.expression.to_string(), r.path.clone(), r.field.clone()))
+        .collect()
+}
+
+#[test]
+fn should_find_chapeau_text_on_both_backends_when_searching() {
+    let memory = title_9();
+    let sqlite = to_sqlite(&memory, "chapeau");
+
+    let from_memory = inspect::search(&memory, CHAPEAU_TEXT).expect("search memory");
+    let from_sqlite = inspect::search(&sqlite, CHAPEAU_TEXT).expect("search sqlite");
+
+    assert!(
+        from_memory.iter().any(|r| r.field == "chapeau"),
+        "the fixture should hold this text in a chapeau, got {:?}",
+        hits(&from_memory)
+    );
+    assert_eq!(
+        hits(&from_sqlite),
+        hits(&from_memory),
+        "both backends should return the same hits for the same query"
+    );
+}
+
+#[test]
+fn should_find_proviso_and_continuation_text_on_both_backends_when_searching() {
+    let memory = title_26();
+    let sqlite = to_sqlite(&memory, "proviso_continuation");
+
+    // Real text from title 26. The proviso is the only one in the title.
+    for (field, query) in [
+        (
+            "proviso",
+            "Provided however, That an individual not a citizen",
+        ),
+        (
+            "continuation",
+            "a tax determined in accordance with the following table",
+        ),
+    ] {
+        let from_memory = inspect::search(&memory, query).expect("search memory");
+        let from_sqlite = inspect::search(&sqlite, query).expect("search sqlite");
+
+        assert!(
+            from_memory.iter().any(|r| r.field == field),
+            "the fixture should hold this text in a {field}, got {:?}",
+            hits(&from_memory)
+        );
+        assert_eq!(
+            hits(&from_sqlite),
+            hits(&from_memory),
+            "both backends should agree on a {field} match"
+        );
+    }
+}
+
+#[test]
+fn should_return_results_in_the_same_order_on_both_backends_when_a_query_matches_widely() {
+    let memory = title_9();
+    let sqlite = to_sqlite(&memory, "ordering");
+
+    // Title 9 is the Federal Arbitration Act, so this matches throughout it.
+    let from_memory = inspect::search(&memory, "arbitration").expect("search memory");
+    let from_sqlite = inspect::search(&sqlite, "arbitration").expect("search sqlite");
+
+    assert!(
+        from_memory.len() > 5,
+        "this test needs a broad match to be meaningful, got {}",
+        from_memory.len()
+    );
+    assert_eq!(
+        hits(&from_sqlite),
+        hits(&from_memory),
+        "both backends should return the same hits in the same order"
+    );
+}
+
+#[test]
+fn should_return_the_same_results_when_the_same_query_runs_twice() {
+    let memory = title_9();
+    let sqlite = to_sqlite(&memory, "repeatable");
+
+    for (label, first, second) in [
+        (
+            "memory",
+            inspect::search(&memory, "arbitration").expect("search"),
+            inspect::search(&memory, "arbitration").expect("search"),
+        ),
+        (
+            "sqlite",
+            inspect::search(&sqlite, "arbitration").expect("search"),
+            inspect::search(&sqlite, "arbitration").expect("search"),
+        ),
+    ] {
+        assert_eq!(
+            hits(&first),
+            hits(&second),
+            "{label} should answer the same query the same way every time"
+        );
+    }
+}
+
+/// Forge the element index an older build wrote: heading and content only, and
+/// no document position. The public API cannot produce one, because this build
+/// always writes the full shape.
+fn stale_index_dataset(name: &str) -> std::path::PathBuf {
+    let dir = std::path::Path::new("target/search_test_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let path = dir.join(format!("{name}.sqlite"));
+    std::fs::remove_file(&path).ok();
+
+    let conn = rusqlite::Connection::open(&path).expect("open forged db");
+    conn.execute_batch(
+        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+         INSERT INTO schema_version (version) VALUES (3);
+         CREATE TABLE element_index (
+             work TEXT NOT NULL, date TEXT NOT NULL, path TEXT NOT NULL,
+             element_type TEXT, heading TEXT, content TEXT,
+             PRIMARY KEY (work, date, path)
+         );",
+    )
+    .expect("forge the older index");
+    drop(conn);
+    path
+}
+
+#[test]
+fn should_refuse_a_dataset_whose_search_index_predates_this_build() {
+    let path = stale_index_dataset("stale");
+
+    let opened = Dataset::open_sqlite(&path);
+
+    let error = opened
+        .err()
+        .expect("a dataset with the older index should not open");
+    let message = error.to_string();
+
+    // Answering from two fields of five would report law as absent, which is
+    // the failure this refusal exists to prevent. It must also say what to do.
+    assert!(
+        message.contains("search index"),
+        "the error should name the search index, got: {message}"
+    );
+    assert!(
+        message.contains("convert-dataset"),
+        "the error should name the command that regenerates it, got: {message}"
+    );
+    assert!(
+        !message.contains("no such column"),
+        "the raw SQL error should not reach the reader, got: {message}"
+    );
+}


### PR DESCRIPTION
Closes #82.

## The bug

The SQLite element index held columns for `heading` and `content` only, while an element carries five text fields. `chapeau`, `proviso` and `continuation` were never indexed, so their text was unfindable in a SQLite dataset — silently.

```
$ words_to_data search dataset.json   "In the case of a taxpayer's foreign research" | jq length
1
$ words_to_data search dataset.sqlite "In the case of a taxpayer's foreign research" | jq length
0
```

For a project that defines **scope** so a reader can answer "out of scope" rather than "not found", answering "not found" about law that is present is the sharpest failure available.

## Verified on the real dataset

| Query | Before (json / sqlite) | After (json / sqlite) |
|---|---|---|
| `"In the case of a taxpayer's foreign research"` | 1 / **0** | 1 / **1** |
| `"foreign research"` | 19 / **18** | 19 / **19** |

Field breakdown now matches exactly on both backends: `content` 13, `heading` 5, `chapeau` 1. Results are identical **including order**.

## What changed

- The index holds a column per text field, and an `ordinal` recording each element's position in a document-order walk.
- Search reads every field, ordered by work, date, document position, then the same field order the in-memory backend declares. SQLite previously grouped by field, because its query was a UNION of one pass per column, while the in-memory backend walked the document — so even the two backends' ordering disagreed.
- The two index writers now share one prepared statement and a named row struct. They had drifted apart as positional tuples, which is how the columns came to disagree in the first place.

## A decision that changed during implementation

**The brief said to bump `SCHEMA_VERSION`. That was wrong, and running it is how I found out.** The compact JSON shares that constant, and its contents are unaffected — its element trees always carried all five fields. Bumping rejected `dataset.json`:

```
$ words_to_data convert-dataset dataset.json out.sqlite
Error loading dataset: SchemaVersionMismatch { found: 3, expected: 4 }
```

That would cost a rebuild of a valid 855 MB dataset from source XML to fix a SQLite-only index. So the version is **not** bumped. Instead, opening a SQLite file whose index predates this build fails where the problem actually is:

```
This dataset's search index was written before this build and covers only some of
the text fields, so a search over it would report law as absent. Regenerate the
dataset: `words_to_data convert-dataset <source> dataset.sqlite`.
```

## A second bug found on the way

`convert-dataset` wrote **into** an existing output database rather than replacing it. Rows of a previous dataset that shared no key survived, leaving a hybrid; against an older index it panicked with a raw SQL error. That is precisely what a reader does to refresh their database:

```
$ words_to_data convert-dataset dataset.json dataset.sqlite
thread 'main' panicked at convert_dataset.rs:29:18:
Error saving SQLite: ... "table element_index has no column named chapeau"
```

Converting now replaces its output, and both directions report failure through the usual handler instead of unwinding.

## Tests

Six added. Each of the parity tests was confirmed to fail without the fix:

- `should_find_chapeau_text_on_both_backends_when_searching`
- `should_find_proviso_and_continuation_text_on_both_backends_when_searching`
- `should_return_results_in_the_same_order_on_both_backends_when_a_query_matches_widely`
- `should_return_the_same_results_when_the_same_query_runs_twice`
- `should_refuse_a_dataset_whose_search_index_predates_this_build`
- `should_replace_the_output_when_converting_onto_an_existing_database`

`rusqlite` is added as a dev-dependency, because forging a database written by an older build needs raw SQL — the public API only produces current files.

Full suite passes, no regression against baseline.

## After merging

Existing `.sqlite` datasets carry the old index and will refuse to open until regenerated. `dataset.json` is unaffected:

```
words_to_data convert-dataset dataset.json dataset.sqlite
```

That took 13 seconds on the 855 MB dataset.

## Out of scope

Search quality — ranking, stemming, tokenising. This is a substring match and stays one.