### PR TITLE
fix: keep quoted amendment text out of the provision tree

### DIFF
--- a/src/uslm/parser.rs
+++ b/src/uslm/parser.rs
@@ -67,6 +67,26 @@ pub enum ParseError {
     /// placeholders, they are currently not supported.
     #[error("Reserved element")]
     ReservedElement,
+
+    /// Quoted statutory text encountered outside a `quotedContent` wrapper
+    ///
+    /// Amendment language quotes the text it enacts. That quoted text is not
+    /// law in force, and the publisher almost always wraps it in
+    /// `quotedContent`, which this parser does not descend into. Nine elements
+    /// in title 26 carry no wrapper and are marked only by a quotation mark
+    /// opening the number. Without this they enter the tree as provisions that
+    /// the U.S. Code website does not render, and become searchable, diffable
+    /// locations an annotation can name (#86).
+    ///
+    /// The subtree goes with the element. In title 26 that costs one real
+    /// provision, 1563(f)(5)(B), which sits inside a quoted block because the
+    /// publisher closed the paragraph it belongs to before opening the quote.
+    /// Every identifier in that block is generated from position rather than
+    /// asserted, and the position is wrong, so there is no sound home to move
+    /// it to. Dropping it is the decision; #87 records what was lost and the
+    /// signals a future rule could use to recover it.
+    #[error("Quoted amendment text")]
+    QuotedContent,
 }
 
 struct TextContents {
@@ -239,7 +259,8 @@ pub fn parse_from_str(xml_str: &str, date: &str) -> Result<USLMElement> {
                     Ok(e) => children.push(e),
                     Err(ParseError::UnknownElement)
                     | Err(ParseError::RepealedElement)
-                    | Err(ParseError::ReservedElement) => {}
+                    | Err(ParseError::ReservedElement)
+                    | Err(ParseError::QuotedContent) => {}
                     Err(other) => return Err(other),
                 }
             }
@@ -382,6 +403,20 @@ fn extract_source_credits(node: &roxmltree::Node) -> Vec<SourceCredit> {
     result
 }
 
+/// True when a number opens with a quotation mark, marking quoted text.
+///
+/// The publisher writes the enacted text of an amendment inside quotation
+/// marks. Where the surrounding `quotedContent` wrapper is missing, the opening
+/// mark on the number is the only thing that distinguishes `“(2)` — text a bill
+/// proposes — from `(2)`, the provision in force beside it.
+fn is_quoted_number(display: &str) -> bool {
+    matches!(
+        display.trim_start().chars().next(),
+        // Curly and straight, since the source uses both.
+        Some('\u{201C}') | Some('"')
+    )
+}
+
 fn parse_element(
     node: roxmltree::Node,
     document_type: &DocumentType,
@@ -406,6 +441,9 @@ fn parse_element(
     let uslm_uuid = rewrap_str(node.attribute("id"));
 
     let number = extract_number(element_type, &node)?;
+    if is_quoted_number(&number.display) {
+        return Err(ParseError::QuotedContent);
+    }
     // TODO
     // Source Credits
     let verbose_name = match parent_name {
@@ -523,6 +561,7 @@ fn parse_element(
                 ParseError::UnknownElement => {}
                 ParseError::RepealedElement => {}
                 ParseError::ReservedElement => {}
+                ParseError::QuotedContent => {}
                 // All other errors should cause the parser to stop and propogate the issue
                 other => {
                     return Err(other);

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -150,3 +150,124 @@ fn test_parse_text_fields() {
     assert!(s174b.data.heading.is_some());
     assert!(s174b.data.content.is_some());
 }
+
+/// Every element in the tree, depth first.
+fn walk<'a>(
+    element: &'a words_to_data::uslm::USLMElement,
+    out: &mut Vec<&'a words_to_data::uslm::USLMElement>,
+) {
+    out.push(element);
+    for child in &element.children {
+        walk(child, out);
+    }
+}
+
+#[test]
+fn should_exclude_quoted_amendment_text_when_it_carries_no_quoted_content_wrapper() {
+    let doc = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+
+    let mut all = Vec::new();
+    walk(&doc, &mut all);
+
+    // Quoted statutory text is amendment language, not law in force. The
+    // publisher usually wraps it in `quotedContent`, which the parser skips,
+    // but nine elements in this title carry no wrapper and are marked only by
+    // a quotation mark opening the number (#86).
+    let quoted: Vec<String> = all
+        .iter()
+        .filter(|e| {
+            let n = e.data.number_display.trim_start();
+            n.starts_with('\u{201C}') || n.starts_with('"')
+        })
+        .map(|e| format!("{} num={}", e.data.path, e.data.number_display))
+        .collect();
+
+    assert!(
+        quoted.is_empty(),
+        "quoted text should not become a provision, found {}: {:#?}",
+        quoted.len(),
+        quoted
+    );
+}
+
+#[test]
+fn should_keep_the_real_provision_when_quoted_text_shares_its_number() {
+    let doc = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+
+    let mut all = Vec::new();
+    walk(&doc, &mut all);
+
+    // Section 1563(f)(2): the U.S. Code website renders one paragraph (2),
+    // "Operating rules". The quoted "Brother-sister controlled group" beside it
+    // is amendment text and must not survive, but the real one must.
+    const F2: &str = "uscode/title_26/subtitle_A/chapter_6/subchapter_B/part_II/section_1563/subsection_f/paragraph_2";
+    let paragraphs: Vec<&&words_to_data::uslm::USLMElement> =
+        all.iter().filter(|e| &*e.data.path == F2).collect();
+
+    assert_eq!(
+        paragraphs.len(),
+        1,
+        "the site renders one paragraph (2) here, got {:?}",
+        paragraphs
+            .iter()
+            .map(|e| e.data.heading.as_deref())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        paragraphs[0].data.heading.as_deref(),
+        Some(" Operating rules"),
+        "the surviving paragraph should be the real provision"
+    );
+}
+
+#[test]
+fn should_drop_a_real_provision_the_publisher_nested_inside_a_quoted_block() {
+    // A deliberate, known loss, recorded so it is not mistaken for an accident.
+    //
+    // 26 U.S.C. 1563(f)(5)(B) "Applicable provision" is law, and the U.S. Code
+    // website renders it. The publisher nested it inside the quoted block that
+    // (f)(5)(A) introduces, and stamped it `/us/usc/t26/s1563/f/2/B`, an
+    // identifier for a paragraph it has nothing to do with. Its position and
+    // its identifier are both wrong, so there is no sound place to put it.
+    //
+    // Skipping quoted text takes this with it, because it sits under a quoted
+    // parent. That was decided knowingly: salvaging it would mean inventing a
+    // location the source does not give. Tracked in #87.
+    //
+    // If this test starts failing, the parser has begun keeping it. That may be
+    // right, but it is a change of decision and wants saying out loud.
+    let doc = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
+        .expect("Error running parser");
+
+    let mut all = Vec::new();
+    walk(&doc, &mut all);
+
+    let applicable_provision_in_1563 = all.iter().any(|e| {
+        e.data.path.contains("section_1563")
+            && e.data
+                .heading
+                .as_deref()
+                .is_some_and(|h| h.contains("Applicable provision"))
+    });
+    assert!(
+        !applicable_provision_in_1563,
+        "1563(f)(5)(B) is dropped with the quoted block it was nested inside; see #87"
+    );
+
+    // The same heading elsewhere is untouched: only the misplaced one goes.
+    let elsewhere = all
+        .iter()
+        .filter(|e| {
+            e.data
+                .heading
+                .as_deref()
+                .is_some_and(|h| h.contains("Applicable provision"))
+        })
+        .count();
+    assert_eq!(
+        elsewhere, 1,
+        "the well-formed 'Applicable provision' at 414(s)(4) should survive"
+    );
+}


### PR DESCRIPTION
Closes #86. Records a known loss in #87.

## The bug

Amendment language quotes the text it enacts, and that quoted text is not law in force. The publisher wraps it in `quotedContent`, which the parser does not descend into — and that works **12,334 times out of 12,343** in title 26. Nine elements carry no wrapper. The only marker is a quotation mark opening the number:

```xml
<num class="bold">(2)</num>   <heading> Operating rules</heading>                 <!-- renders -->
<num class="bold">“(2)</num>  <heading> Brother-sister controlled group</heading>  <!-- does not -->
```

Both claim `identifier="/us/usc/t26/s1563/f/2"`. Confirmed against the U.S. Code website: it renders one subparagraph (B) under § 1563(f)(2); our tree held three.

A phantom provision is not inert — it carries text, so it is searchable and diffable, and an annotation can name it as the location a bill amended. It also manufactured duplicate structural paths that are not real, which obscured the genuine collisions behind #77 and #85.

## The fix

A number opening with a quotation mark marks quoted content, and the element is skipped — alongside the repealed and reserved cases the parser already skips.

Effect on title 26:

| | before | after |
|---|---|---|
| elements, 2025-07-30 | 58,490 | 58,480 |
| duplicate-path groups | 12 | 10 |

The two groups that went are the false ones. Every remaining collision is real law, each carrying the Code's own footnote — *"So in original. There are two pars. (4)."* — and the site renders both, as you confirmed for § 45X(d)(4).

## A real provision is dropped, knowingly

`26 U.S.C. § 1563(f)(5)(B)` "Applicable provision" leaves the tree. The site renders it, so this is a deliberate loss, and #87 records it in full.

The source is broken four ways at that spot:

1. `(f)(5)` closes after its `(A)`, so the quoted text it introduces is a **sibling** rather than content.
2. The real `(B)` is placed inside that quoted block.
3. It carries `identifier="/us/usc/t26/s1563/f/2/B"`, already used by the quoted `“(B)` above it.
4. The quoted block is a rewrite of **`(a)(2)`**, not `(f)(2)` — `(f)(5)(A)` says "subsection (a)(2) … as if it read as follows:", and the real `(a)(2)` carries the same heading.

So every identifier in that block is generated from position rather than asserted, and the position is wrong. There is no well-formed parent to reattach the provision to, because `(f)(5)` has already ended. Salvaging it would mean inventing a location.

A test pins the loss, so a future change of mind is deliberate rather than accidental. #87 notes the presentational signals — indent class, bold num, the closing quote position — that a recovery rule could use.

## Tests

Three added, each confirmed to fail without the fix:

- `should_exclude_quoted_amendment_text_when_it_carries_no_quoted_content_wrapper`
- `should_keep_the_real_provision_when_quoted_text_shares_its_number`
- `should_drop_a_real_provision_the_publisher_nested_inside_a_quoted_block` — pins the known loss

Full suite passes, no regression against baseline.

## What this unblocks

#77 and #85 both waited on whether duplicate structural paths are legitimate. They are — the law numbers two provisions alike and the site shows both. This clears the false collisions out of the way, so those two can be fixed and tested against data where every remaining duplicate is real.