### PR TITLE
fix: let a structural path name more than one provision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,7 +49,7 @@ A unit of law that stays the same thing across versions, even when its text chan
 _Avoid_: Section, node, element
 
 **Structural path**:
-The address of an element, derived from the hierarchy that the parser found. It does not depend on the source document to supply an identifier. It locates a provision at one point in time. It does not identify one.
+The address of an element, derived from the hierarchy that the parser found. It does not depend on the source document to supply an identifier. It locates a provision at one point in time. It does not identify one. Two provisions can share one path: the law sometimes numbers two provisions alike, and the document records both.
 _Avoid_: Path, breadcrumb
 
 **USLM ID**:

--- a/docs/adr/0001-structural-paths-locate-not-identify.md
+++ b/docs/adr/0001-structural-paths-locate-not-identify.md
@@ -10,6 +10,10 @@ We therefore give each provision a stable identity that is carried across versio
 
 Without this, three things break quietly. A `Move` reads as a delete plus an add, so the diff reports a change to law that did not change. Human-confirmed annotations, which point at path strings today (`ChangeAnnotation.paths`), silently attach to different text after a parser change, and the party who receives the file cannot detect it. And "is this the same provision as last year", which is the question a legal researcher actually asks, has no answer.
 
+A locator is not only stale across versions; it can be ambiguous within one. The law sometimes numbers two provisions alike — `26 U.S.C. § 45X(d)(4)` is two paragraphs (4), which the Code footnotes as "So in original" and the official site renders in full — so one path names both. Code that treats a path as unique within an expression does not fail loudly. It picks one and discards the other, which is the confident false statement this decision exists to avoid.
+
+Where a path names more than one provision, the document's order decides which is which. We inherit the order the source gives and pair provisions by position, so the first (4) of one version answers to the first of the next. Order therefore carries meaning: if the source swaps two provisions that share a path, that is a real change and is reported as one. The alternatives are worse. Pairing by content similarity invents a judgement the source did not make, and treating a collision as an error refuses to hold law that genuinely exists.
+
 The cost is one more identifier to mint and carry. We already do this for amendments, where `amendment_id` is a content hash, so the mechanism is not new.
 
 ## Considered and rejected

--- a/src/bin/words_to_data/path.rs
+++ b/src/bin/words_to_data/path.rs
@@ -51,7 +51,7 @@ pub fn run(args: Args) {
         if report.present_in.is_empty() {
             "(no expression)".to_string()
         } else {
-            report.present_in.join(", ")
+            describe_presence(&report.present_in)
         }
     );
 
@@ -66,4 +66,30 @@ pub fn run(args: Args) {
     for a in &report.annotations {
         crate::annotations::print_annotation(a);
     }
+}
+
+/// Name each expression once, saying how many provisions sit at the path there.
+///
+/// A path can name more than one provision, so an expression can appear more
+/// than once in the report. Repeating the same `work@date` reads as a bug;
+/// counting it says what is actually true.
+fn describe_presence(present_in: &[String]) -> String {
+    let mut counted: Vec<(&str, usize)> = Vec::new();
+    for id in present_in {
+        match counted.last_mut() {
+            Some((seen, n)) if *seen == id.as_str() => *n += 1,
+            _ => counted.push((id.as_str(), 1)),
+        }
+    }
+    counted
+        .into_iter()
+        .map(|(id, n)| {
+            if n == 1 {
+                id.to_string()
+            } else {
+                format!("{id} ({n} provisions)")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -262,6 +262,18 @@ impl TreeDiff {
             && self.child_diffs.is_empty()
     }
 
+    /// Group an element's children by path, keeping document order within each.
+    ///
+    /// A path can name more than one child, so the value is every child that
+    /// carries it rather than one of them.
+    fn children_by_path(element: &USLMElement) -> HashMap<&str, Vec<&USLMElement>> {
+        let mut by_path: HashMap<&str, Vec<&USLMElement>> = HashMap::new();
+        for child in &element.children {
+            by_path.entry(&child.data.path).or_default().push(child);
+        }
+        by_path
+    }
+
     pub fn from_elements(from_element: &USLMElement, to_element: &USLMElement) -> TreeDiff {
         assert!(from_element.data.path == to_element.data.path);
         let root_path = from_element.data.path.clone();
@@ -269,37 +281,34 @@ impl TreeDiff {
         let changes = diff_elements(from_element, to_element);
 
         // 2. Build HashMaps of children by path
-        let children_a: HashMap<String, &USLMElement> = from_element
-            .children
-            .iter()
-            .map(|child| (child.data.path.to_string(), child))
-            .collect();
-        let children_b: HashMap<String, &USLMElement> = to_element
-            .children
-            .iter()
-            .map(|child| (child.data.path.to_string(), child))
-            .collect();
+        // A path can name more than one child: the law sometimes numbers two
+        // provisions alike and the document records both (`docs/adr/0001`). So
+        // each path maps to the children that carry it, in document order,
+        // rather than to a single element. Keying by path alone made the second
+        // provision invisible — a change to it could not be reported at all.
+        let children_a = Self::children_by_path(from_element);
+        let children_b = Self::children_by_path(to_element);
 
         // 3. Find added, removed, matched
         let mut added = vec![];
         let mut removed = vec![];
         let mut child_diffs = vec![];
-        // Walk the children themselves, not the maps built from them. The maps
-        // answer "is this path on the other side?"; the child vectors carry
-        // source document order, so `removed` and `child_diffs` come out in the
-        // order the provisions appear in the law. Iterating the maps instead let
+        // Walk the children themselves, not the maps built from them. The child
+        // vectors carry source document order, so all three lists come out in
+        // the order the provisions appear in the law. Iterating the maps let
         // hash order decide, which changed between runs (#73).
         //
-        // A handful of siblings share a path (11 of ~58,000 in title 26, where
-        // the parser generates the same path twice). The maps hold one element
-        // per path, so we skip any child the map does not hold. That keeps one
-        // entry per path, exactly as before; only the order is new.
+        // Where a path names several provisions, they pair by position: the
+        // first on one side answers to the first on the other. Order therefore
+        // carries meaning, and a swap in the source is a real change.
+        let mut seen: HashMap<&str, usize> = HashMap::new();
         for child_a in &from_element.children {
             let path = &*child_a.data.path;
-            if !std::ptr::eq(children_a[path], child_a) {
-                continue;
-            }
-            match children_b.get(path) {
+            let occurrence = seen.entry(path).or_insert(0);
+            let index = *occurrence;
+            *occurrence += 1;
+
+            match children_b.get(path).and_then(|kin| kin.get(index)) {
                 Some(child_b) => {
                     // Matched - recurse
                     // Keep any child that records something. Testing only
@@ -312,19 +321,25 @@ impl TreeDiff {
                     }
                 }
                 None => {
-                    // Removed
+                    // Removed: nothing on the other side holds this position.
                     removed.push(child_a.data.clone()); //ElementSnapshot::from(child_a));
                 }
             }
         }
 
         // Iterate through B for added only, again in document order.
+        let mut seen = HashMap::new();
         for child_b in &to_element.children {
             let path = &*child_b.data.path;
-            if !std::ptr::eq(children_b[path], child_b) {
-                continue;
-            }
-            if !children_a.contains_key(path) {
+            let occurrence = seen.entry(path).or_insert(0);
+            let index = *occurrence;
+            *occurrence += 1;
+
+            if children_a
+                .get(path)
+                .and_then(|kin| kin.get(index))
+                .is_none()
+            {
                 added.push(child_b.data.clone()); //ElementSnapshot::from(child_b));
             }
         }
@@ -355,25 +370,36 @@ impl TreeDiff {
     /// Returns `Some(&TreeDiff)` if an element with the matching path is found,
     /// or `None` if no such element exists in this tree.
     pub fn find(&self, path: &str) -> Option<&TreeDiff> {
-        if path == self.root_path.as_str() {
-            return Some(self);
-        }
-        let remaining_path = path.strip_prefix(self.root_path.as_str())?;
-        let next_step: Vec<&str> = remaining_path.split("/").collect();
-        assert!(next_step.len() > 1);
+        self.find_all(path).into_iter().next()
+    }
 
-        let child_id = next_step[1];
-        let child_vec: Vec<&TreeDiff> = self
-            .child_diffs
-            .iter()
-            .filter(|c| c.root_path.ends_with(child_id))
-            .collect();
-        if child_vec.is_empty() {
-            None
-        } else {
-            assert!(child_vec.len() == 1);
-            child_vec[0].find(path)
+    /// Every diff node at this structural path, in document order
+    ///
+    /// A path can name more than one provision, so it can name more than one
+    /// diff node. Prefer this over [`TreeDiff::find`] wherever taking the first
+    /// would quietly drop a change to the others.
+    pub fn find_all(&self, path: &str) -> Vec<&TreeDiff> {
+        if path == self.root_path.as_str() {
+            return vec![self];
         }
+        // Requiring the separator keeps a shared prefix from reading as a
+        // descendant, and leaves nothing to assert about.
+        let Some(remaining) = path
+            .strip_prefix(self.root_path.as_str())
+            .and_then(|rest| rest.strip_prefix('/'))
+        else {
+            return Vec::new();
+        };
+
+        let segment = remaining.split('/').next().unwrap_or(remaining);
+        let child_path = format!("{}/{segment}", self.root_path);
+
+        self.child_diffs
+            .iter()
+            // Whole path, not a suffix of it.
+            .filter(|child| child.root_path == child_path)
+            .flat_map(|child| child.find_all(path))
+            .collect()
     }
 
     /// Calculate the similarity of diffs in the TreeDiff with the amendment data from a bill

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -132,21 +132,28 @@ pub fn path_report<S: Storage>(
         .collect();
     present_in.sort();
 
+    // A path can name more than one provision, so it can name more than one
+    // diff node. Report every node's changes: taking the first would hide a
+    // change to the second, which is the silent loss `docs/adr/0001` warns of.
+    //
+    // No committed expression pair reaches this today. Duplicated paths in the
+    // corpus are one provision against two, or two against one, so a duplicate
+    // is always an addition or a removal rather than two matched provisions
+    // that both changed. The corpus cannot exercise it, and inventing data to
+    // do so would prove nothing about real documents.
     let changes = match pair {
         Some((from, to)) => dataset
             .compute_diff(from, to)?
-            .find(path)
-            .map(|node| {
-                node.changes
-                    .iter()
-                    .map(|c| PathFieldChange {
-                        field: field_str(&c.field_name),
-                        old_value: c.old_value.clone(),
-                        new_value: c.new_value.clone(),
-                    })
-                    .collect()
+            .find_all(path)
+            .into_iter()
+            .flat_map(|node| {
+                node.changes.iter().map(|c| PathFieldChange {
+                    field: field_str(&c.field_name),
+                    old_value: c.old_value.clone(),
+                    new_value: c.new_value.clone(),
+                })
             })
-            .unwrap_or_default(),
+            .collect(),
         None => Vec::new(),
     };
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -228,12 +228,16 @@ impl DocumentReader for InMemoryStorage {
     }
 
     fn find_element(&self, path: &str) -> Result<Vec<(ExpressionId, USLMElement)>, DatasetError> {
+        // A path can name more than one provision, so an expression can answer
+        // with several. Taking the first would drop law that is really there.
         Ok(self
             .all_expressions()
-            .filter_map(|e| {
+            .flat_map(|e| {
                 e.element
-                    .find(path)
+                    .find_all(path)
+                    .into_iter()
                     .map(|found| (e.id.clone(), found.clone()))
+                    .collect::<Vec<_>>()
             })
             .collect())
     }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -124,7 +124,19 @@ fn check_search_index(conn: &Connection, path: &str) -> Result<(), DatasetError>
         .iter()
         .all(|wanted| columns.iter().any(|held| held == wanted));
 
-    if complete {
+    // An index keyed by path holds one row per path, so it is missing a row for
+    // every provision that shares one. The columns alone cannot show that, and
+    // the remedy is the same: rebuild it.
+    let keyed_by_position: bool = conn
+        .query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'element_index'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .map(|sql| sql.contains("PRIMARY KEY (work, date, ordinal)"))
+        .unwrap_or(false);
+
+    if complete && keyed_by_position {
         Ok(())
     } else {
         Err(DatasetError::StaleSearchIndex {
@@ -225,7 +237,11 @@ impl SqliteStorage {
                 -- back in the order a reader meets the provisions, matching the
                 -- in-memory backend.
                 ordinal INTEGER NOT NULL,
-                PRIMARY KEY (work, date, path)
+                -- Keyed by position, not by path. A path can name more than one
+                -- provision (`docs/adr/0001`), and keying by path meant the
+                -- second silently replaced the first: 16 of ~57,000 rows lost
+                -- per title 26 expression, and its text unfindable (#77).
+                PRIMARY KEY (work, date, ordinal)
             );
 
             CREATE TABLE IF NOT EXISTS bills (
@@ -1034,10 +1050,11 @@ impl DocumentReader for SqliteStorage {
 
         let mut results = Vec::new();
         for id in wanted {
-            if let Some(expression) = self.get_expression(&id)?
-                && let Some(found) = expression.element.find(path)
-            {
-                results.push((id, found.clone()));
+            if let Some(expression) = self.get_expression(&id)? {
+                // A path can name more than one provision within an expression.
+                for found in expression.element.find_all(path) {
+                    results.push((id.clone(), found.clone()));
+                }
             }
         }
 

--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -507,25 +507,50 @@ impl USLMElement {
     /// assert!(missing.is_none());
     /// ```
     pub fn find(&self, path: &str) -> Option<&USLMElement> {
-        if *path == *self.data.path {
-            return Some(self);
-        }
-        let remaining_path = path.strip_prefix(self.data.path.as_ref())?;
-        let next_step: Vec<&str> = remaining_path.split("/").collect();
-        assert!(next_step.len() > 1);
+        self.find_all(path).into_iter().next()
+    }
 
-        let child_id = next_step[1];
-        let child_vec: Vec<&USLMElement> = self
-            .children
-            .iter()
-            .filter(|c| c.data.path.ends_with(child_id))
-            .collect();
-        if child_vec.is_empty() {
-            None
-        } else {
-            assert!(child_vec.len() == 1);
-            child_vec[0].find(path)
+    /// Every element at this structural path, in document order
+    ///
+    /// A path can name more than one provision: the law sometimes numbers two
+    /// provisions alike, and the document records both. `26 U.S.C. § 45X(d)(4)`
+    /// is two paragraphs (4), and the U.S. Code renders both. Prefer this over
+    /// [`USLMElement::find`] wherever discarding the others would be a silent
+    /// loss rather than a convenience.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use words_to_data::uslm::parser::parse;
+    /// # let element = parse("tests/test_data/usc/2025-07-18/usc07.xml", "2025-07-18").unwrap();
+    /// let found = element.find_all("uscode/title_7/chapter_1/section_2");
+    /// assert_eq!(found.len(), 1);
+    /// ```
+    pub fn find_all(&self, path: &str) -> Vec<&USLMElement> {
+        if *path == *self.data.path {
+            return vec![self];
         }
+        // A near miss is a question with an answer. Requiring the separator
+        // keeps `uscode/title_26x` from reading as a descendant of
+        // `uscode/title_26`, and leaves nothing to assert about.
+        let Some(remaining) = path
+            .strip_prefix(self.data.path.as_ref())
+            .and_then(|rest| rest.strip_prefix('/'))
+        else {
+            return Vec::new();
+        };
+
+        let segment = remaining.split('/').next().unwrap_or(remaining);
+        let child_path = format!("{}/{segment}", self.data.path);
+
+        self.children
+            .iter()
+            // Compare the whole path, not a suffix of it: `ends_with` asks
+            // whether a child's address happens to end this way, which is a
+            // different question from whether it is the child named here.
+            .filter(|child| *child.data.path == *child_path)
+            .flat_map(|child| child.find_all(path))
+            .collect()
     }
 
     /// Merge the children of one node into another

--- a/tests/diff_tests.rs
+++ b/tests/diff_tests.rs
@@ -428,89 +428,84 @@ fn should_order_diff_children_identically_when_the_same_diff_is_built_twice() {
 /// document, then recurse. `removed` and `child_diffs` follow the older
 /// expression; `added` follows the newer one.
 fn assert_document_order(diff: &TreeDiff, from: &USLMElement, to: &USLMElement) {
-    // A few siblings share a path. One element represents each path, and it is
-    // the last one, so resolve from the back to match what the diff records.
-    let position_in = |element: &USLMElement, path: &str| -> usize {
-        element
-            .children
-            .iter()
-            .rposition(|child| &*child.data.path == path)
-            .unwrap_or_else(|| panic!("{path} is not a child of {}", element.data.path))
-    };
+    // A path can name more than one child, so a path maps to every position it
+    // occupies. A list is in document order when its entries can be laid onto
+    // those positions strictly increasing, taking the earliest that still fits.
+    fn positions(element: &USLMElement) -> std::collections::HashMap<&str, Vec<usize>> {
+        let mut by_path: std::collections::HashMap<&str, Vec<usize>> =
+            std::collections::HashMap::new();
+        for (at, child) in element.children.iter().enumerate() {
+            by_path.entry(&child.data.path).or_default().push(at);
+        }
+        by_path
+    }
 
-    let ascending = |positions: &[usize]| positions.windows(2).all(|pair| pair[0] < pair[1]);
+    fn walk_in_order(
+        paths: impl Iterator<Item = String>,
+        index: &std::collections::HashMap<&str, Vec<usize>>,
+    ) -> Option<Vec<usize>> {
+        let mut cursor: Option<usize> = None;
+        let mut chosen = Vec::new();
+        for path in paths {
+            let next = index
+                .get(path.as_str())?
+                .iter()
+                .copied()
+                .find(|at| cursor.is_none_or(|last| *at > last))?;
+            cursor = Some(next);
+            chosen.push(next);
+        }
+        Some(chosen)
+    }
 
-    let child_positions: Vec<usize> = diff
-        .child_diffs
-        .iter()
-        .map(|child| position_in(from, &child.root_path))
-        .collect();
-    assert!(
-        ascending(&child_positions),
-        "child_diffs of {} are not in document order: {:?}",
-        diff.root_path,
-        diff.child_diffs
-            .iter()
-            .map(|c| c.root_path.as_str())
-            .collect::<Vec<_>>()
+    let from_positions = positions(from);
+    let to_positions = positions(to);
+
+    let matched = walk_in_order(
+        diff.child_diffs.iter().map(|c| c.root_path.clone()),
+        &from_positions,
     );
+    let matched = matched.unwrap_or_else(|| {
+        panic!(
+            "child_diffs of {} are not in document order: {:?}",
+            diff.root_path,
+            diff.child_diffs
+                .iter()
+                .map(|c| c.root_path.as_str())
+                .collect::<Vec<_>>()
+        )
+    });
 
-    let removed_positions: Vec<usize> = diff
-        .removed
-        .iter()
-        .map(|element| position_in(from, &element.path))
-        .collect();
     assert!(
-        ascending(&removed_positions),
+        walk_in_order(
+            diff.removed.iter().map(|e| e.path.to_string()),
+            &from_positions
+        )
+        .is_some(),
         "removed of {} is not in document order",
         diff.root_path
     );
-
-    let added_positions: Vec<usize> = diff
-        .added
-        .iter()
-        .map(|element| position_in(to, &element.path))
-        .collect();
     assert!(
-        ascending(&added_positions),
+        walk_in_order(diff.added.iter().map(|e| e.path.to_string()), &to_positions).is_some(),
         "added of {} is not in document order",
         diff.root_path
     );
 
-    for child in &diff.child_diffs {
-        let from_child = &from.children[position_in(from, &child.root_path)];
-        let to_child = &to.children[position_in(to, &child.root_path)];
-        assert_document_order(child, from_child, to_child);
-    }
-}
-
-#[test]
-fn should_order_mentions_identically_when_scanning_the_same_bill_twice() {
-    let doc_old = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
-        .expect("Error running parser");
-    let doc_new = parse("tests/test_data/usc/2025-07-30/usc26.xml", "2025-07-30")
-        .expect("Error running parser");
-    let diff = TreeDiff::from_elements(&doc_old, &doc_new);
-    let amendment_data = parse_bill_amendments("119-21", PL_XML_PATH).unwrap();
-
-    let first = diff.scan_for_mentions(&amendment_data);
-    let second = diff.scan_for_mentions(&amendment_data);
-
-    // Only amendments with more than one mention can expose an ordering bug.
-    let multi = first.values().filter(|m| m.len() > 1).count();
-    assert!(
-        multi > 0,
-        "This test needs an amendment with more than one mention to be meaningful"
-    );
-
-    for (amendment_id, mentions) in &first {
-        let other = second
-            .get(amendment_id)
-            .expect("both scans should cover the same amendments");
-        assert_eq!(
-            mentions, other,
-            "Mentions for amendment {amendment_id} should come back in the same order every scan"
-        );
+    // Recurse against the children each matched diff actually came from.
+    let mut to_cursor: Option<usize> = None;
+    for (child, at) in diff.child_diffs.iter().zip(matched) {
+        let from_child = &from.children[at];
+        let to_at = to_positions
+            .get(child.root_path.as_str())
+            .and_then(|places| {
+                places
+                    .iter()
+                    .copied()
+                    .find(|place| to_cursor.is_none_or(|last| *place > last))
+            })
+            .expect("a matched child should exist in the newer expression");
+        to_cursor = Some(to_at);
+        assert_document_order(child, from_child, &to.children[to_at]);
     }
 }
 

--- a/tests/duplicate_path_tests.rs
+++ b/tests/duplicate_path_tests.rs
@@ -1,0 +1,198 @@
+//! A structural path can name more than one provision (#77).
+//!
+//! The law sometimes numbers two provisions alike. `26 U.S.C. § 45X(d)(4)` is
+//! two paragraphs (4); the Code footnotes it "So in original" and the official
+//! site renders both. Code that assumes a path is unique within an expression
+//! does not fail loudly — it picks one and discards the other.
+
+use words_to_data::uslm::{USLMElement, parser::parse};
+
+const USC26_30: &str = "tests/test_data/usc/2025-07-30/usc26.xml";
+
+/// Both paragraphs (4) of § 45X(d), which the U.S. Code renders in full.
+const DUPLICATED: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_A/part_IV/subpart_D/section_45X/subsection_d/paragraph_4";
+
+fn title_26() -> USLMElement {
+    parse(USC26_30, "2025-07-30").expect("Error running parser")
+}
+
+#[test]
+fn should_return_every_provision_sharing_a_path_when_finding_by_path() {
+    let doc = title_26();
+
+    let found = doc.find_all(DUPLICATED);
+
+    assert_eq!(
+        found.len(),
+        2,
+        "the law numbers two paragraphs (4) here and both should come back, got {:?}",
+        found
+            .iter()
+            .map(|e| e.data.heading.as_deref())
+            .collect::<Vec<_>>()
+    );
+    // Document order decides which is which, so the order must be the source's.
+    assert!(
+        found[0]
+            .data
+            .heading
+            .as_deref()
+            .is_some_and(|h| h.contains("Sale of")),
+        "the first should be the one the document puts first, got {:?}",
+        found[0].data.heading.as_deref()
+    );
+    assert!(
+        found[1]
+            .data
+            .heading
+            .as_deref()
+            .is_some_and(|h| h.contains("prohibited foreign entities")),
+        "the second should be the one the document puts second, got {:?}",
+        found[1].data.heading.as_deref()
+    );
+}
+
+#[test]
+fn should_not_panic_when_finding_a_path_that_names_two_provisions() {
+    let doc = title_26();
+
+    // `words_to_data path` passes user input straight through, and this
+    // aborted the process rather than answering.
+    let found = doc.find(DUPLICATED);
+
+    assert!(found.is_some(), "the path exists and should be found");
+}
+
+#[test]
+fn should_answer_none_when_a_path_merely_shares_a_prefix() {
+    let doc = title_26();
+
+    // A near miss is a question with an answer, not a reason to abort. The
+    // prefix check used to strip "uscode" and split on "/", leaving one
+    // segment, and assert that there were more.
+    assert!(doc.find("uscodex").is_none());
+    assert!(doc.find("uscode/title_26x").is_none());
+    assert!(doc.find("").is_none());
+}
+
+#[test]
+fn should_match_a_whole_segment_rather_than_a_path_suffix_when_finding() {
+    let doc = title_26();
+
+    // The lookup filtered children with `path.ends_with(segment)`, which asks a
+    // different question than "is this the child named by this segment".
+    let real = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a";
+    assert!(
+        doc.find(real).is_some(),
+        "the real path should still resolve"
+    );
+
+    // A segment that is a suffix of a sibling's name must not match it.
+    assert!(doc.find("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174/subsection_a/paragraph_").is_none());
+}
+
+/// Collect every added element in the diff tree, with the path it sits at.
+fn added_paths(diff: &words_to_data::diff::TreeDiff, out: &mut Vec<String>) {
+    for element in &diff.added {
+        out.push(element.path.to_string());
+    }
+    for child in &diff.child_diffs {
+        added_paths(child, out);
+    }
+}
+
+#[test]
+fn should_report_a_new_provision_that_shares_a_path_with_an_existing_one() {
+    use words_to_data::diff::TreeDiff;
+
+    let before = parse("tests/test_data/usc/2025-07-18/usc26.xml", "2025-07-18")
+        .expect("Error running parser");
+    let after = title_26();
+
+    // The earlier expression holds one paragraph (4) at 45X(d); the later holds
+    // two. The second is new law, and a diff that keys children by path alone
+    // never sees it.
+    assert_eq!(
+        before.find_all(DUPLICATED).len(),
+        1,
+        "the earlier expression should hold one paragraph (4)"
+    );
+    assert_eq!(
+        after.find_all(DUPLICATED).len(),
+        2,
+        "the later expression should hold two"
+    );
+
+    let diff = TreeDiff::from_elements(&before, &after);
+    let mut added = Vec::new();
+    added_paths(&diff, &mut added);
+
+    assert!(
+        added.iter().any(|p| p == DUPLICATED),
+        "the new paragraph (4) should be reported as added"
+    );
+}
+
+/// Title 26 at one release point, held both ways.
+fn dataset_both_backends(
+    name: &str,
+) -> (
+    words_to_data::dataset::Dataset<words_to_data::storage::InMemoryStorage>,
+    words_to_data::dataset::Dataset<words_to_data::storage::SqliteStorage>,
+) {
+    use words_to_data::dataset::{Dataset, DatasetMetadata};
+
+    let mut memory = Dataset::new(DatasetMetadata {
+        name: "Duplicate Path Fixture".to_string(),
+        description: "Title 26, one release point".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "Public Domain".to_string(),
+        version: "1.0".to_string(),
+    });
+    memory
+        .add_uslm_xml(USC26_30, "2025-07-30", None)
+        .expect("the fixture should parse");
+
+    let dir = std::path::Path::new("target/duplicate_path_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let file = dir.join(format!("{name}.sqlite"));
+    std::fs::remove_file(&file).ok();
+    memory.save_to_sqlite(&file).expect("save to sqlite");
+    let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
+
+    (memory, sqlite)
+}
+
+#[test]
+fn should_hold_every_provision_sharing_a_path_on_both_backends() {
+    let (memory, sqlite) = dataset_both_backends("find_element");
+
+    let from_memory = memory.find_element(DUPLICATED).expect("find in memory");
+    let from_sqlite = sqlite.find_element(DUPLICATED).expect("find in sqlite");
+
+    // Both paragraphs (4) are law and both must be reachable. Keying storage by
+    // path alone dropped one of them, silently.
+    assert_eq!(
+        from_memory.len(),
+        2,
+        "the in-memory backend should hold both provisions"
+    );
+    assert_eq!(
+        from_sqlite.len(),
+        2,
+        "the SQLite backend should hold both provisions"
+    );
+
+    let headings = |found: &[(words_to_data::dataset::ExpressionId, USLMElement)]| -> Vec<String> {
+        found
+            .iter()
+            .map(|(_, e)| e.data.heading.as_deref().unwrap_or("<none>").to_string())
+            .collect()
+    };
+    assert_eq!(
+        headings(&from_sqlite),
+        headings(&from_memory),
+        "both backends should answer alike, in document order"
+    );
+}


### PR DESCRIPTION
Closes #77.

## The fact

The law sometimes numbers two provisions alike. `26 U.S.C. § 45X(d)(4)` is two paragraphs (4) — the Code footnotes it *"So in original. There are two pars. (4)."* and the official site renders both, as you confirmed. Three places assumed a path was unique within an expression, and none of them failed loudly.

## What changed, and what it cost

| Site | Was | Now |
|---|---|---|
| `USLMElement::find` | `assert!(len == 1)` — **aborted the process** | `find_all` returns every match; `find` takes the first |
| SQLite element index | `PRIMARY KEY (work, date, path)` — **16 rows lost** per title 26 expression | keyed by document position; nothing dropped |
| `TreeDiff::from_elements` | one element per path — **the second provision was invisible** | children pair by position among same-path siblings |

The diff was the most serious, because legislative change tracking is the point. The second `45X(d)(4)` exists only in the 2025-07-30 expression — it is new law — and the diff did not report it as added **at all**. There is now a test for exactly that.

Two further faults in `find` went with the assertion: it compared a path *suffix* (`ends_with`) rather than a whole segment, and a path that merely shared a prefix hit a second assertion instead of answering `None`. `words_to_data path` passes user input straight in, so that was a second abort on a near miss. `TreeDiff::find` carried a copy of all three.

## Measured on `dataset.json`

```
$ words_to_data path dataset.json .../section_45X/subsection_d/paragraph_4
PATH: .../section_45X/subsection_d/paragraph_4
Present in: uscode/title_26@2025-07-18, uscode/title_26@2025-07-30 (2 provisions)
```

Before: `thread 'main' panicked at src/uslm/mod.rs:526: assertion failed: child_vec.len() == 1`.

Index rows after rebuilding, against elements in the stored tree:

| Expression | Rows before | Rows now | Elements |
|---|---|---|---|
| `uscode/title_26@2025-07-18` | 57,386 | **57,401** | 57,401 |
| `uscode/title_26@2025-07-30` | 58,473 | **58,489** | 58,489 |

## The model, recorded

Per your call, no new ADR — this is a fact about the domain and a decision about ordering, and both belong where the existing model lives:

- **`CONTEXT.md`**, the *Structural path* entry, gains the fact: two provisions can share one path.
- **ADR-0001** gains two consequences. Its premise already held that a path locates rather than identifies, but only *across versions*; it now also covers ambiguity *within* one. And it states the decision you made: document order decides which provision is which, we pair by position, and a swap in the source is therefore a real change — with the rejected alternatives (pairing by content similarity, or treating a collision as an error) and their costs.

## After merging

A `.sqlite` built before this holds one row per path rather than per element. The stale-index check refuses it and names `convert-dataset`, exactly as it already did for the narrower index. `dataset.json` is unaffected.

```
words_to_data convert-dataset dataset.json dataset.sqlite
```

## Tests

Six new in `tests/duplicate_path_tests.rs`, all against real committed data, each confirmed to fail without the fix:

- `should_return_every_provision_sharing_a_path_when_finding_by_path`
- `should_not_panic_when_finding_a_path_that_names_two_provisions`
- `should_answer_none_when_a_path_merely_shares_a_prefix`
- `should_match_a_whole_segment_rather_than_a_path_suffix_when_finding`
- `should_report_a_new_provision_that_shares_a_path_with_an_existing_one`
- `should_hold_every_provision_sharing_a_path_on_both_backends`

The #73 ordering test needed rewriting: it resolved a duplicated path to the last occurrence to match the old one-per-path behaviour, which is no longer what the diff does. It now checks that each list can be laid onto document positions strictly increasing, which holds with duplicates present.

Full suite passes, no regression against baseline.