### PR TITLE
feat: list the bills a dataset holds

### DIFF
--- a/src/bin/words_to_data/bills.rs
+++ b/src/bin/words_to_data/bills.rs
@@ -1,0 +1,59 @@
+//! `words_to_data bills` — list every bill a dataset holds.
+//!
+//! `show-bill` takes an id, and until this existed nothing would tell you what
+//! ids there were: `info` reports a count, and annotations carry ids but a
+//! dataset has none until `match-amendments` has run (#83).
+
+use clap::Args as ClapArgs;
+use words_to_data::inspect;
+
+use crate::load::{self, with_dataset};
+
+#[derive(ClapArgs)]
+pub struct Args {
+    /// Dataset file (`.json` compact or `.sqlite`)
+    pub dataset: String,
+
+    /// Emit JSON instead of human-readable text
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub fn run(args: Args) {
+    let ds = crate::fail::or_exit(load::open(&args.dataset), "Error opening dataset");
+    let bills = crate::fail::or_exit(
+        with_dataset!(ds, d => inspect::bills(&d)),
+        "Error reading bills",
+    );
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&bills).unwrap());
+        return;
+    }
+
+    // The id is the column that goes straight back in to `show-bill`.
+    let width = bills
+        .iter()
+        .map(|b| b.bill_id.len())
+        .max()
+        .unwrap_or(0)
+        .max("BILL".len());
+
+    println!(
+        "{:<width$}  {:>10}  {:>12}",
+        "BILL", "AMENDMENTS", "WITH CHANGES"
+    );
+    for b in &bills {
+        println!(
+            "{:<width$}  {:>10}  {:>12}",
+            b.bill_id, b.amendment_count, b.amendments_with_changes
+        );
+    }
+    println!("{} bill(s)", bills.len());
+
+    // Scoring and matching both read the extracted changes, so a dataset where
+    // every bill reports zero is one where `extract-changes` has not run.
+    if !bills.is_empty() && bills.iter().all(|b| b.amendments_with_changes == 0) {
+        println!("\nNo amendment carries extracted changes yet. Run `extract-changes` first.");
+    }
+}

--- a/src/bin/words_to_data/main.rs
+++ b/src/bin/words_to_data/main.rs
@@ -4,6 +4,7 @@
 use clap::{Parser, Subcommand};
 
 mod annotations;
+mod bills;
 mod build_dataset;
 mod convert_dataset;
 mod coverage;
@@ -48,6 +49,9 @@ enum Command {
     Info(info::Args),
     /// List every expression (`work@date`) with its size
     Expressions(expressions::Args),
+    /// List every bill the dataset holds
+    Bills(bills::Args),
+
     /// Show a bill's amendments
     ShowBill(show_bill::Args),
     /// Full-text search across every expression
@@ -73,6 +77,7 @@ fn main() {
         Command::MatchAmendments(args) => match_amendments::run(args),
         Command::Info(args) => info::run(args),
         Command::Expressions(args) => expressions::run(args),
+        Command::Bills(args) => bills::run(args),
         Command::ShowBill(args) => show_bill::run(args),
         Command::Search(args) => search::run(args),
         Command::Diff(args) => diff::run(args),

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -52,6 +52,50 @@ pub struct ExpressionSummary {
     pub element_count: usize,
 }
 
+/// One bill's headline facts, for listing many at once.
+///
+/// Distinct from [`BillSummary`], which carries every amendment and is what
+/// `show-bill` returns for one bill.
+#[derive(Debug, Clone, Serialize)]
+pub struct BillListing {
+    /// The identifier `show-bill` takes, such as `119-hr-1`.
+    pub bill_id: String,
+    /// How many amendments the bill carries.
+    pub amendment_count: usize,
+    /// How many of those carry extracted word-level changes.
+    ///
+    /// Zero across the board means `extract-changes` has not run, which is the
+    /// difference between a dataset that can be scored and one that cannot.
+    pub amendments_with_changes: usize,
+}
+
+/// List every bill, ordered by id.
+///
+/// Without this a bill id could only be learned from outside the tool:
+/// `show-bill` demands one, `info` reports a count, and annotations carry ids
+/// but a dataset has none until `match-amendments` has run (#83).
+pub fn bills<S: Storage>(dataset: &S) -> Result<Vec<BillListing>, DatasetError> {
+    let mut ids = dataset.list_bill_ids()?;
+    ids.sort();
+
+    let mut summaries = Vec::new();
+    for id in ids {
+        let Some(bill) = dataset.get_bill(&id)? else {
+            continue;
+        };
+        summaries.push(BillListing {
+            bill_id: bill.bill_id,
+            amendment_count: bill.amendments.len(),
+            amendments_with_changes: bill
+                .amendments
+                .values()
+                .filter(|amendment| !amendment.changes.is_empty())
+                .count(),
+        });
+    }
+    Ok(summaries)
+}
+
 /// Count every element in a tree, including the root.
 fn count_elements(element: &USLMElement) -> usize {
     1 + element.children.iter().map(count_elements).sum::<usize>()

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -887,3 +887,85 @@ fn should_replace_the_output_when_converting_onto_an_existing_database() {
         "the converted database should hold the source's expressions"
     );
 }
+
+/// A dataset holding one work and one real public law, in both file formats.
+///
+/// `show-bill` needs a bill id, so something has to be able to hand one over.
+fn bill_fixtures() -> &'static (String, String) {
+    static FIXTURE: OnceLock<(String, String)> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let sqlite = format!("{}/cli_bills.sqlite", env!("CARGO_TARGET_TMPDIR"));
+        let json = format!("{}/cli_bills.json", env!("CARGO_TARGET_TMPDIR"));
+        let _ = std::fs::remove_file(&sqlite);
+
+        let mut dataset = Dataset::new(DatasetMetadata {
+            name: "Bills Fixture".to_string(),
+            description: "One title and one public law".to_string(),
+            author: "words_to_data tests".to_string(),
+            source_urls: vec![],
+            license: "MIT".to_string(),
+            version: "1.0.0".to_string(),
+        });
+        dataset
+            .add_uslm_xml(
+                &format!("tests/test_data/usc/{EARLY}/{UNCHANGED_TITLE}.xml"),
+                EARLY,
+                None,
+            )
+            .expect("the corpus should parse");
+        let bill = words_to_data::uslm::bill_parser::parse_bill_amendments(
+            "119-hr-1",
+            "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml",
+        )
+        .expect("the bill should parse");
+        dataset.add_bill(bill).expect("add bill");
+
+        dataset.save_to_sqlite(&sqlite).expect("save sqlite");
+        dataset.save(&json, Format::Compact).expect("save json");
+        (sqlite, json)
+    })
+}
+
+#[test]
+fn should_list_bill_ids_so_show_bill_can_be_used() {
+    let (sqlite, json) = bill_fixtures();
+
+    for dataset in [sqlite, json] {
+        let output = run(&["bills", dataset, "--json"]);
+        assert!(
+            output.status.success(),
+            "bills should exit zero for {dataset}, stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let listed: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("bills --json should emit json");
+        let bills = listed.as_array().expect("a list of bills");
+        assert_eq!(bills.len(), 1, "the fixture holds one bill");
+        assert_eq!(bills[0]["bill_id"], "119-hr-1");
+        assert!(
+            bills[0]["amendment_count"].as_u64().unwrap_or(0) > 0,
+            "a real public law carries amendments"
+        );
+    }
+}
+
+#[test]
+fn should_hand_show_bill_an_id_it_accepts() {
+    let (sqlite, _) = bill_fixtures();
+
+    // The point of the listing: an id read from it must work as an argument.
+    let listed = run(&["bills", sqlite, "--json"]);
+    let parsed: serde_json::Value = serde_json::from_slice(&listed.stdout).expect("json");
+    let id = parsed[0]["bill_id"]
+        .as_str()
+        .expect("a bill id")
+        .to_string();
+
+    let shown = run(&["show-bill", sqlite, &id]);
+    assert!(
+        shown.status.success(),
+        "show-bill should accept an id that `bills` listed, stderr: {}",
+        String::from_utf8_lossy(&shown.stderr)
+    );
+}


### PR DESCRIPTION
Closes #83.

## The gap

`show-bill` takes a bill id, and nothing would tell you what ids existed. `info` reports a count and no more. `annotations` carries ids, but a dataset has none until `match-amendments` has run — which is exactly the state you are in when you want to look at its bills.

So on a freshly built dataset the bills were unreachable through the CLI without knowing an id from outside the tool. `Storage::list_bill_ids` already existed and both backends implemented it; nothing exposed it.

## What it does

```
$ words_to_data bills dataset.json
BILL         AMENDMENTS  WITH CHANGES
119-hr-1            603           570
119-hr-2215           0             0
119-hr-42             1             1
119-hr-43             1             1
119-hr-618            1             1
5 bill(s)
```

Identical from `dataset.sqlite`. Follows the shape `expressions` already set: a command per collection, ordered by id, `--json` for an agent and a table for a person.

The second column is there because it is the difference between a dataset that can be scored and one that cannot. Where every bill reports zero, the command says to run `extract-changes` rather than leaving a reader to infer it from a column of noughts.

## Tests

Two, driving the binary as a subprocess, over both a `.sqlite` and a `.json` dataset:

- `should_list_bill_ids_so_show_bill_can_be_used`
- `should_hand_show_bill_an_id_it_accepts` — reads an id out of the listing and feeds it straight to `show-bill`, which is the whole point of the ticket

Full suite passes, no regression against baseline.

## One thing it surfaced

`119-hr-2215` holds **0 amendments**, confirmed by `show-bill`. Every other bill in the dataset has at least one. That is either a public law that amends nothing, or a gap in bill parsing — I have not chased it, and it is out of scope here. Worth a look, since a bill contributing no amendments contributes nothing to matching either.

`119-hr-1` also shows 603 amendments against 570 with changes, so 33 have no extracted changes.