### PR TITLE
docs: record how a stored link is shaped and named

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,8 +29,12 @@ An instruction in a bill that tells a reader how to change existing law.
 _Avoid_: Edit, modification, revision
 
 **Link**:
-A statement that connects one provision to something else. It carries a subject, a namespaced kind, an object, and its provenance. Every reader can read a link, even a reader that does not know the kind.
+A statement that connects one provision to something else. It carries a subject, a namespaced kind, an object, and its provenance. Every reader can read a link, even a reader that does not know the kind. Its identity comes from its subject, its kind, and its object, so restating the same fact updates one link rather than making a second one.
 _Avoid_: Relation, edge, reference
+
+**Kind payload**:
+The facts about a link that only the extension defining its kind understands, such as the amending action behind a change annotation. The core stores it, hands it back unchanged, and never reads it. Nothing a reader needs in order to report a link may live here.
+_Avoid_: Extra, metadata, blob
 
 **Change annotation**:
 The link of kind `legislature.amended_by`. It connects one change in a diff to the amendment that caused it.

--- a/docs/adr/0002-links-live-in-the-core.md
+++ b/docs/adr/0002-links-live-in-the-core.md
@@ -14,7 +14,7 @@ Keeping the kind open, rather than an enum, is what lets another party add a lin
 
 ## The shape of a link
 
-**A link points at a closed set of things.** The object is a provision identity, an expression, a document, or an external reference (a URI with display text). An extension type, such as an amendment, is reached as an external reference into that extension's namespace. This keeps one property that matters: a reader who does not know the legislature extension can still report "this change was caused by something, and here is its name", and a reader can still tell a reference inside the file from a reference to a web page, because only the first can be checked.
+**A link points at a closed set of things.** The object is a provision identity, an expression, a document, a change (a provision as it read across two dates), or an external reference (a URI with display text). An extension type, such as an amendment, is reached as an external reference into that extension's namespace. The set is closed but it is ours, so it widens when the core needs to say something new: the change target was added because a link whose subject is a bare provision cannot say *when* the provision was amended (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`). This keeps one property that matters: a reader who does not know the legislature extension can still report "this change was caused by something, and here is its name", and a reader can still tell a reference inside the file from a reference to a web page, because only the first can be checked.
 
 **Links are directed and stored once.** The reverse reading, "what did this amendment change", is a query. Two records for one fact can disagree, and after an edit one of them will.
 

--- a/docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md
+++ b/docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md
@@ -1,0 +1,63 @@
+# Links are stored, and identified by what they say
+
+Status: accepted
+
+`docs/adr/0002-links-live-in-the-core.md` put one `Link` type in the core: subject, namespaced kind, object, provenance. It is a projection. `Link::from_annotation` reads the `annotations` and `annotation_paths` tables and builds links as they are asked for, and nothing stores one. A schema whose only link table carries columns for `bill_id` and `amendment_id` holds exactly one kind, so the promise of ADR 0002 — that another party defines `westlaw.headnote` and our reader carries it — cannot be kept by the storage beneath it.
+
+We therefore store links directly. `annotations` and `annotation_paths` go, and `ChangeAnnotation` becomes a projection *out of* links rather than the thing they are projected from. This ADR records how a stored link is shaped and named, which are the parts that are expensive to change later.
+
+## A target is a tag and a JSON value, with the queried parts promoted
+
+`Target` variants no longer hold one value each: a provision holds a path, an expression holds a work and a date, an external reference holds a reference and a display string, and a change holds a work, a path, and two dates. A column per part does not fit a set that grows, so a target is stored as its variant tag beside the whole value as JSON.
+
+JSON cannot be indexed into, and every query `LinkReader` answers reads into a target: by path, by expression pair, the distinct pair list, by kind, by namespace. Those parts are therefore promoted to their own indexed columns beside the JSON. The promoted columns are a denormalised index of the value, which is two places holding one fact, and ADR 0002 warns against exactly that. It is deliberate here and it is one-directional: the JSON is the record, the columns are derived from it on write, and nothing reads a promoted column as the truth.
+
+A namespace gets no column of its own. It is a prefix of the kind, so one index on `kind` serves both queries.
+
+## The subject of an amendment link is a change, not a provision
+
+`annotations` is keyed by an expression pair, and `get_annotations(from, to)` is what coverage and validation are built on. A link whose subject is a bare provision path cannot answer that question, and the projection we ship today silently drops the pair.
+
+So the core gains a target that names a change: a work, a path, and the two dates it changed between. This widens the closed set ADR 0002 lists, which is the point of the set being ours. It carries one work rather than two expression ids, because two copies of one work can disagree and after an edit one of them will; the public API still takes two expression ids and refuses a mismatch, as `compute_diff` already does.
+
+Several amendments can cause one change. That is not a conflict to resolve: it is several links sharing a subject, and a reader asking what caused a change gets them all. The table therefore carries no uniqueness constraint on subject and kind.
+
+## A link is identified by what it says, not by where it is stored
+
+A link's identity is a content hash of its subject, kind, and object. A row id is meaningless outside one file, and datasets are rebuilt rather than migrated, so an identity that does not survive a rebuild cannot be pointed at, confirmed, or deduplicated. We already mint `amendment_id` as a content hash, so the mechanism is not new.
+
+Provenance is not part of the hash. Re-running a model against a fact it has already stated updates one link instead of accumulating a second, which is what makes a rebuild idempotent. The cost is that two parties independently asserting the same fact collapse into one record, and only the surviving provenance says who. We accept that until a second asserter actually exists.
+
+**A human-touched provenance survives a machine re-write.** When a write collides with a stored link whose verification is `HumanConfirmed`, `Disputed`, or `Refuted`, the stored provenance stays. Otherwise the new one replaces it. Without this rule, re-running the pipeline destroys human review, quietly, and the loss is invisible until someone looks for a confirmation that is no longer there.
+
+## Facts that only one kind understands live in a payload the core never reads
+
+An amending action, a free-text note, and a bill id have no honest home in the core. They are legislature concepts, and today the action is crammed into `Provenance.method` as a `Debug` string, which round-trips only because the enum happens to carry no data.
+
+A link therefore carries a namespaced payload that the core stores, hands back unchanged, and never interprets. This is what ADR 0002 asks for — a reader preserves what it does not understand — made storable.
+
+Two rules keep it from becoming a dumping ground. The core never reads it. And nothing needed to *report* a link may live there, because a reader that cannot read the payload must still be able to say what the link is, who said it, and how far it can be trusted.
+
+A timestamp is the exception that proves the rule: every statement has a when, so it belongs in `Provenance` beside the source, not in a payload that only one extension can open.
+
+## Consequences
+
+`ChangeAnnotation` is reconstructed by grouping links on the amendment, the expression pair, and the source. Grouping without the source would merge two annotators' accounts of one amendment into a single record with one provenance, which loses who said what.
+
+`LinkWriter::add_annotation` is replaced by `add_link` rather than kept beside it. Two ways to write one fact means the convenient one is used, and the convenient one can only express the single kind we own.
+
+An external reference is fully qualified — the bill and the amendment, not the amendment alone — so a reader that does not know the legislature extension can still resolve what it points at. The `bill_id` column that exists today is a leftover from before the core and the extensions were separated.
+
+`SCHEMA_VERSION` goes up. Datasets are rebuilt, never migrated, and `#68` makes the break loud.
+
+## Considered and rejected
+
+**Keep `annotations` and add a second table for other kinds.** The kind we own stays cheap and every other kind is a second-class citizen, which is the arrangement ADR 0002 exists to end.
+
+**A column per target part.** Fits today and breaks on the next variant, and it makes the meaning of a column depend on the tag anyway.
+
+**A UUID minted at write time.** Unique, and useless: it changes on every rebuild, so nothing outside the file can point at a link and no rebuild can tell an old fact from a new one.
+
+**Provenance in the identity hash.** Nothing collapses and nothing is lost, but every re-run of the pipeline grows the table by the number of facts it restated, and a reader asking what caused a change gets the same answer many times over.
+
+**A list of provenances on one link.** The most honest model, since several parties really can assert one fact. Rejected for now because every reader would handle a list to ask a single question, and no second asserter exists yet. This is the decision to revisit first when one does.


### PR DESCRIPTION
Decisions only, no code. Groundwork for #70, from a grilling session during triage.

`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md` is new. `docs/adr/0002` gains the widened target set. `CONTEXT.md` gains one term and one clause.

## Why an ADR before the code

#70 replaces `annotations` / `annotation_paths` with a generic `links` table and inverts `ChangeAnnotation` from the stored form into a projection. Five of those choices are expensive to change once a dataset is written, so they are worth recording before rather than after.

## What the grilling turned up

`Link::from_annotation` is **lossy today**, which means "`ChangeAnnotation` becomes a projection out of links" does not work with the current `Link` shape:

| `ChangeAnnotation` | Survives the projection? |
| --- | --- |
| the expression pair | **no** |
| `source_bill.bill_id` | **no** |
| `metadata.timestamp` | **no** |
| `metadata.notes` | **no** |
| `operation` | only as a `Debug` string in `Provenance.method` |

That is what drove most of the decisions below.

## The decisions

- **A target is a variant tag beside its JSON value.** Variants no longer hold one value each — the new change target holds four. The parts every `LinkReader` query reads into (`kind`, and the subject's `work`, `path`, `from_date`, `to_date`) are promoted to indexed columns. That is deliberately two places holding one fact, and the ADR says so and says which one is the record.
- **The subject of an amendment link is a change, not a provision.** `get_annotations(from, to)` underpins coverage and validation, and a bare provision path cannot answer it. The target carries one work and two dates rather than two expression ids, because two copies of one work can disagree.
- **Identity is a content hash of subject, kind, and object.** A row id does not survive a rebuild, and datasets are rebuilt rather than migrated. `amendment_id` already works this way.
- **Provenance is not hashed**, so re-running a model updates one link instead of accumulating a second. The cost — two independent asserters of one fact collapse into one record — is written down as the thing to revisit when a second asserter appears.
- **A human-touched provenance survives a machine re-write.** Without this, re-running the pipeline destroys human review quietly. This is the rule I would most want a second opinion on.
- **Kind-specific facts move to a payload the core never reads**, with two rules: the core never reads it, and nothing needed to *report* a link may live in it. `timestamp` is explicitly *not* in it — every statement has a when, so it belongs in `Provenance`.

## Consequences recorded

`LinkWriter::add_annotation` is replaced by `add_link` rather than kept beside it. `ChangeAnnotation` is regrouped from links on `(amendment, pair, source)` — dropping `source` would merge two annotators into one record. External references become fully qualified, so a reader that does not know the legislature extension can resolve them; the `bill_id` column is leftover from before the core and extensions were separated.

## Note on sequencing

#70 is **not** the next thing to land. #71 goes first, and it should carry a namespace list in its declaration — ADR 0002 promises the scope declares which namespaces a dataset uses, and #71 is already touching every `DatasetMetadata` literal. Adding it later would break that type twice inside one release window.

Each of #71, #70, and #58 bumps `SCHEMA_VERSION` separately rather than sharing one bump, so a dataset built between two merges cannot claim a version whose shape it does not have. Users still rebuild once, after the window.

`CONTEXT.md` also changed on the #90 branch (a sentence on structural paths). Different section, but worth knowing if the merge order surprises you.