### PR TITLE
feat: let a dataset declare what it means to cover

### DIFF
--- a/src/bin/words_to_data/build_dataset.rs
+++ b/src/bin/words_to_data/build_dataset.rs
@@ -3,7 +3,7 @@
 
 use clap::Args as ClapArgs;
 use words_to_data::congress::CongressClient;
-use words_to_data::dataset::{Dataset, DatasetMetadata, Format};
+use words_to_data::dataset::{Dataset, DatasetMetadata, Declaration, Format};
 use words_to_data::uscode;
 
 /// Default mirror manifest (release-point date -> zip URL).
@@ -30,6 +30,28 @@ pub struct Args {
     /// (default: the shared `<user cache dir>/words_to_data`)
     #[arg(long)]
     pub cache_dir: Option<String>,
+
+    /// JSON file declaring what this dataset is meant to cover
+    ///
+    /// A declaration is a statement someone should have to look at, so it is a
+    /// file that can be committed and reviewed rather than a flag. Without one
+    /// the dataset reports only what it holds.
+    #[arg(long)]
+    pub declaration: Option<String>,
+}
+
+/// Read a declaration file, or `None` when none was given.
+///
+/// A declaration that will not parse is fatal rather than skipped. Building a
+/// dataset that silently declares nothing is how a gap goes unreported, which
+/// is the failure this whole feature exists to prevent.
+fn read_declaration(path: Option<&String>) -> Option<Declaration> {
+    let path = path?;
+    let text = crate::fail::or_exit(std::fs::read_to_string(path), "Error reading declaration");
+    Some(crate::fail::or_exit(
+        serde_json::from_str(&text),
+        "Error parsing declaration",
+    ))
 }
 
 pub fn run(args: Args) {
@@ -52,6 +74,7 @@ pub fn run(args: Args) {
         source_urls: vec![args.mirror_index.clone()],
         license: "Public Domain".to_string(),
         version: "1.0".to_string(),
+        declaration: read_declaration(args.declaration.as_ref()),
     });
 
     for date in &dates {

--- a/src/bin/words_to_data/info.rs
+++ b/src/bin/words_to_data/info.rs
@@ -62,4 +62,32 @@ pub fn run(args: Args) {
             }
         }
     }
+
+    // A dataset that declared nothing prints exactly what it always printed.
+    let Some(declared) = &info.scope.declared else {
+        return;
+    };
+
+    if !declared.intends.is_empty() {
+        println!("Declared:    {}", declared.intends.join(", "));
+    }
+    if let Some(dates) = &declared.dates {
+        println!("Dates:       {} to {}", dates.from, dates.to);
+    }
+    if !declared.namespaces.is_empty() {
+        println!("Namespaces:  {}", declared.namespaces.join(", "));
+    }
+
+    // A stated hole is not a fault, but a reader seeing "title 26" has to know
+    // section 174 is deliberately absent, and why.
+    for hole in &declared.excludes {
+        println!("Excluded:    {} — {}", hole.path, hole.reason);
+    }
+
+    // Only printed when there is one. A gap means the build did not do what it
+    // said it would, which is the one thing here a reader must not miss.
+    let gaps = info.scope.gaps();
+    if !gaps.is_empty() {
+        println!("INCOMPLETE:  declared but not held: {}", gaps.join(", "));
+    }
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -8,7 +8,7 @@ mod scope;
 mod work;
 
 pub use error::DatasetError;
-pub use scope::{Coverage, Scope, WorkCoverage};
+pub use scope::{Coverage, DateRange, Declaration, Exclusion, Scope, WorkCoverage};
 pub use work::{
     Expression, ExpressionId, ExpressionInfo, ParseExpressionIdError, WorkId, WorksBetween,
     work_roots, works_between,
@@ -56,6 +56,12 @@ pub struct DatasetMetadata {
     pub source_urls: Vec<String>,
     pub license: String,
     pub version: String,
+    /// What this dataset was meant to carry, when the producer said.
+    ///
+    /// `None` means nothing was declared, and every scope question is answered
+    /// from the contents alone.
+    #[serde(default)]
+    pub declaration: Option<Declaration>,
 }
 
 /// A search result from text search
@@ -551,6 +557,10 @@ impl Dataset<SqliteStorage> {
 // --- Implement traits for Dataset<S> ---
 
 impl<S: Storage> DocumentReader for Dataset<S> {
+    fn metadata(&self) -> &DatasetMetadata {
+        self.storage.metadata()
+    }
+
     fn works(&self) -> Result<Vec<WorkId>, DatasetError> {
         self.storage.works()
     }
@@ -640,10 +650,6 @@ impl<S: Storage> LegislatureReader for Dataset<S> {
 }
 
 impl<S: Storage> DocumentWriter for Dataset<S> {
-    fn metadata(&self) -> &DatasetMetadata {
-        self.storage.metadata()
-    }
-
     fn set_metadata(&mut self, metadata: DatasetMetadata) {
         self.storage.set_metadata(metadata)
     }

--- a/src/dataset/scope.rs
+++ b/src/dataset/scope.rs
@@ -14,11 +14,14 @@
 //! in July and title 51 in August holds both in both, which is a confident
 //! wrong answer of exactly the kind this type exists to prevent.
 //!
-//! Today the scope is **derived** from the contents. A producer cannot yet
-//! declare an intent, so "title 26 minus section 174, because the source
-//! failed" is not sayable, and neither is the gap between what a dataset meant
-//! to carry and what it does. That needs a declaration on the dataset, and it
-//! is the next step.
+//! A scope has two halves. The **held** half is derived from the contents. The
+//! **declared** half is what a producer says the dataset is meant to carry, and
+//! the difference between them is a gap: material that was intended, is not
+//! excluded, and is not here. A gap means the build did not do what it said.
+//!
+//! A hole the producer states, with its reason, is an [`Exclusion`] rather than
+//! a gap. "Title 26 except section 174, because the source failed" is a
+//! complete answer; an unexplained absence is not.
 
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +38,80 @@ pub enum Coverage {
     /// The dataset does not hold this material. An empty result says nothing
     /// about the law: we simply never had the text.
     OutOfScope,
+    /// The dataset was declared to hold this and does not.
+    ///
+    /// Distinct from `OutOfScope` on purpose: the dataset is incomplete rather
+    /// than out of its lane, so an empty result is a fault in the build and not
+    /// a statement about the law or about what this dataset set out to do.
+    Gap,
+}
+
+/// A hole the producer states, and why it is there.
+///
+/// An excluded path is not a gap. The reason is required because a hole with no
+/// reason cannot be told apart from an oversight, and telling a reader *why*
+/// the material is absent is the point of declaring it at all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Exclusion {
+    /// The structural path left out, as a prefix.
+    pub path: String,
+    /// Why it is absent, in the producer's words.
+    pub reason: String,
+}
+
+/// The release points a dataset means to carry.
+///
+/// Reported rather than checked: a declared range that is not held is not
+/// counted as a gap, because a date owns nothing and a work need not exist on
+/// every date in a range.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DateRange {
+    pub from: String,
+    pub to: String,
+}
+
+/// What a producer says a dataset is meant to carry.
+///
+/// Absent means nothing was declared, and every question about the scope is
+/// answered from the contents alone, exactly as before declarations existed.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Declaration {
+    /// Structural path prefixes this dataset means to hold.
+    pub intends: Vec<String>,
+    /// Holes inside `intends`, each with its reason.
+    pub excludes: Vec<Exclusion>,
+    /// The release points intended, when the producer wants to state them.
+    pub dates: Option<DateRange>,
+    /// The link namespaces a reader should expect to meet
+    /// (`docs/adr/0002-links-live-in-the-core.md`).
+    pub namespaces: Vec<String>,
+}
+
+impl Declaration {
+    /// Whether this dataset says it carries links in a namespace.
+    pub fn declares_namespace(&self, namespace: &str) -> bool {
+        self.namespaces.iter().any(|declared| declared == namespace)
+    }
+
+    /// Whether a path sits inside a stated hole.
+    fn is_excluded(&self, path: &str) -> bool {
+        self.excludes
+            .iter()
+            .any(|hole| covers_path(&hole.path, path))
+    }
+
+    /// Whether a path sits inside what this declaration intends.
+    fn intends_path(&self, path: &str) -> bool {
+        self.intends.iter().any(|want| covers_path(want, path))
+    }
+}
+
+/// Whether `prefix` names `path` or an ancestor of it.
+///
+/// Compares whole segments: `uscode/title_2` must not answer for
+/// `uscode/title_26`.
+fn covers_path(prefix: &str, path: &str) -> bool {
+    path == prefix || path.starts_with(&format!("{prefix}/"))
 }
 
 /// One work a dataset holds, and when it was published.
@@ -49,11 +126,13 @@ pub struct WorkCoverage {
     pub dates: Vec<String>,
 }
 
-/// What a dataset covers, derived from its contents.
+/// What a dataset covers: what it holds, and what it said it would.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Scope {
     /// Every work held, with its dates. In work order.
     pub held: Vec<WorkCoverage>,
+    /// What the producer said this dataset would carry, when they said anything.
+    pub declared: Option<Declaration>,
 }
 
 impl Scope {
@@ -71,7 +150,32 @@ impl Scope {
                 .collect();
             held.push(WorkCoverage { work, dates });
         }
-        Ok(Self { held })
+        Ok(Self {
+            held,
+            declared: reader.metadata().declaration.clone(),
+        })
+    }
+
+    /// Declared material that is not excluded and is not held, in declared order.
+    ///
+    /// Every entry is an *unexplained* absence, so a non-empty result means one
+    /// thing: the build did not do what it said it would. A hole the producer
+    /// stated is an [`Exclusion`] and is deliberately not reported here.
+    pub fn gaps(&self) -> Vec<String> {
+        let Some(declared) = &self.declared else {
+            return Vec::new();
+        };
+        declared
+            .intends
+            .iter()
+            .filter(|want| !declared.is_excluded(want) && !self.holds(want))
+            .cloned()
+            .collect()
+    }
+
+    /// Whether any held work sits at this path or beneath it.
+    fn holds(&self, path: &str) -> bool {
+        self.works().any(|work| covers_path(path, work.as_str()))
     }
 
     /// Every work held, in work order.
@@ -101,6 +205,14 @@ impl Scope {
     /// A path is in scope when it sits inside a held work, or when it names an
     /// ancestor of one: asking about `uscode` is in scope for a dataset holding
     /// `uscode/title_9`, because the dataset does hold part of it.
+    ///
+    /// Held material is always `InScope`, even when the declaration never
+    /// mentioned it. A producer who under-declares is careless, and answering
+    /// `OutOfScope` for material we demonstrably hold would be a false
+    /// statement about our own contents.
+    ///
+    /// A dataset that declared nothing answers exactly as it did before
+    /// declarations existed: held or not held, and no third answer.
     pub fn covers(&self, path: &str) -> Coverage {
         let inside_held = self
             .works()
@@ -110,9 +222,16 @@ impl Scope {
             .any(|work| work.as_str().starts_with(&format!("{path}/")));
 
         if inside_held || ancestor_of_held {
-            Coverage::InScope
-        } else {
-            Coverage::OutOfScope
+            return Coverage::InScope;
+        }
+
+        // Not held. Whether that is a gap or simply out of the lane is the
+        // question only a declaration can answer.
+        match &self.declared {
+            Some(declared) if declared.intends_path(path) && !declared.is_excluded(path) => {
+                Coverage::Gap
+            }
+            _ => Coverage::OutOfScope,
         }
     }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -29,6 +29,10 @@ use crate::diff::AmendmentSimilarity;
 pub struct LinkKind(pub String);
 
 impl LinkKind {
+    /// The namespace the legislature extension defines. A dataset declaring it
+    /// carries legislative material, whether or not any has arrived yet.
+    pub const LEGISLATURE: &'static str = "legislature";
+
     /// A change to the law, caused by an amendment in a bill.
     pub const AMENDED_BY: &'static str = "legislature.amended_by";
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -171,6 +171,10 @@ impl InMemoryStorage {
 }
 
 impl DocumentReader for InMemoryStorage {
+    fn metadata(&self) -> &DatasetMetadata {
+        &self.metadata
+    }
+
     fn works(&self) -> Result<Vec<WorkId>, DatasetError> {
         Ok(self.expressions.keys().cloned().collect())
     }
@@ -345,10 +349,6 @@ impl LegislatureReader for InMemoryStorage {
 }
 
 impl DocumentWriter for InMemoryStorage {
-    fn metadata(&self) -> &DatasetMetadata {
-        &self.metadata
-    }
-
     fn set_metadata(&mut self, metadata: DatasetMetadata) {
         self.metadata = metadata;
     }
@@ -401,10 +401,18 @@ impl LegislatureWriter for InMemoryStorage {
 
 impl Storage for InMemoryStorage {
     fn legislature(&self) -> Option<&dyn LegislatureReader> {
+        let declared = self
+            .metadata
+            .declaration
+            .as_ref()
+            .is_some_and(|d| d.declares_namespace(crate::link::LinkKind::LEGISLATURE));
         let holds_legislature = !self.bills.is_empty()
             || !self.members.is_empty()
             || !self.sponsors.is_empty()
             || !self.bill_votes.is_empty();
-        holds_legislature.then_some(self as &dyn LegislatureReader)
+        // Either answer is a yes. Declaring it covers a dataset that has not
+        // been given bills yet; holding it covers a producer who under-declared,
+        // and hiding material we demonstrably have would be the worse lie.
+        (declared || holds_legislature).then_some(self as &dyn LegislatureReader)
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -51,7 +51,7 @@ use crate::uslm::bill_parser::Bill;
 /// bumping this would have rejected valid JSON datasets to fix a SQLite table.
 /// That case is caught where it happens, when the database is opened, rather
 /// than here. A change that alters both forms still belongs to this number.
-pub const SCHEMA_VERSION: i32 = 3;
+pub const SCHEMA_VERSION: i32 = 4;
 
 /// Reading the documents a dataset holds.
 ///
@@ -62,6 +62,13 @@ pub const SCHEMA_VERSION: i32 = 3;
 /// name anything in a dataset whose documents share no release cycle, which is
 /// every dataset except a statutory one.
 pub trait DocumentReader {
+    /// What this dataset says about itself, including any declared scope.
+    ///
+    /// Reading metadata is a read. It sat on [`DocumentWriter`] until a scope
+    /// needed the declaration, which put a fact the reader depends on behind a
+    /// trait a reader has no reason to implement.
+    fn metadata(&self) -> &DatasetMetadata;
+
     /// Every work this dataset holds, in path order.
     fn works(&self) -> Result<Vec<WorkId>, DatasetError>;
 
@@ -161,10 +168,9 @@ pub trait LegislatureReader {
 }
 
 /// Writing documents and dataset metadata.
+///
+/// Reading metadata lives on [`DocumentReader`], not here.
 pub trait DocumentWriter {
-    /// Get metadata
-    fn metadata(&self) -> &DatasetMetadata;
-
     /// Set metadata
     fn set_metadata(&mut self, metadata: DatasetMetadata);
 
@@ -221,8 +227,11 @@ pub trait Storage:
     /// `impl DocumentReader + LegislatureReader` instead, and let the compiler
     /// enforce it.
     ///
-    /// Today the answer comes from the contents. Once a dataset declares its
-    /// scope, the declaration decides, and a mismatch between the two becomes
-    /// a reported gap.
+    /// A dataset that declares the `legislature` namespace holds a legislature,
+    /// whatever its contents. Deciding from contents alone reported that a
+    /// legislative dataset held no legislature until the first bill arrived,
+    /// which is absence mistaken for intent. A dataset that declares nothing
+    /// still answers from its contents, because that is every dataset written
+    /// before declarations existed.
     fn legislature(&self) -> Option<&dyn LegislatureReader>;
 }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -194,6 +194,11 @@ impl SqliteStorage {
         ])?;
         stmt.execute(params!["license", &self.metadata.license])?;
         stmt.execute(params!["version", &self.metadata.version])?;
+        // Only written when there is one, so "declared nothing" and "declared
+        // an empty scope" stay distinguishable on disk.
+        if let Some(declaration) = &self.metadata.declaration {
+            stmt.execute(params!["declaration", serde_json::to_string(declaration)?])?;
+        }
         Ok(())
     }
 
@@ -347,6 +352,9 @@ impl SqliteStorage {
             ])?;
             stmt.execute(params!["license", &storage.metadata.license])?;
             stmt.execute(params!["version", &storage.metadata.version])?;
+            if let Some(declaration) = &storage.metadata.declaration {
+                stmt.execute(params!["declaration", serde_json::to_string(declaration)?])?;
+            }
         }
 
         // Save expressions
@@ -597,6 +605,7 @@ impl SqliteStorage {
         let mut source_urls = Vec::new();
         let mut license = String::new();
         let mut version = String::new();
+        let mut declaration = None;
 
         while let Some(row) = rows.next()? {
             let key: String = row.get(0)?;
@@ -608,6 +617,7 @@ impl SqliteStorage {
                 "source_urls" => source_urls = serde_json::from_str(&value)?,
                 "license" => license = value,
                 "version" => version = value,
+                "declaration" => declaration = Some(serde_json::from_str(&value)?),
                 _ => {}
             }
         }
@@ -619,6 +629,7 @@ impl SqliteStorage {
             source_urls,
             license,
             version,
+            declaration,
         })
     }
 
@@ -919,6 +930,10 @@ impl SqliteStorage {
 }
 
 impl DocumentReader for SqliteStorage {
+    fn metadata(&self) -> &DatasetMetadata {
+        &self.metadata
+    }
+
     fn works(&self) -> Result<Vec<WorkId>, DatasetError> {
         let mut stmt = self
             .conn
@@ -1409,10 +1424,6 @@ impl LegislatureReader for SqliteStorage {
 }
 
 impl DocumentWriter for SqliteStorage {
-    fn metadata(&self) -> &DatasetMetadata {
-        &self.metadata
-    }
-
     fn set_metadata(&mut self, metadata: DatasetMetadata) {
         self.metadata = metadata;
         let _ = self.save_metadata();
@@ -1563,10 +1574,15 @@ impl SqliteStorage {
 
 impl Storage for SqliteStorage {
     fn legislature(&self) -> Option<&dyn LegislatureReader> {
+        let declared = self
+            .metadata
+            .declaration
+            .as_ref()
+            .is_some_and(|d| d.declares_namespace(crate::link::LinkKind::LEGISLATURE));
         // A database error here means we cannot show legislative material, so
-        // the honest answer is that this dataset offers none.
-        self.holds_legislature()
-            .unwrap_or(false)
-            .then_some(self as &dyn LegislatureReader)
+        // the honest answer is that this dataset offers none. A declaration
+        // still counts: it is a statement, not a read that can fail.
+        let holds_legislature = self.holds_legislature().unwrap_or(false);
+        (declared || holds_legislature).then_some(self as &dyn LegislatureReader)
     }
 }

--- a/tests/cli_llm_tests.rs
+++ b/tests/cli_llm_tests.rs
@@ -105,6 +105,7 @@ fn dataset_with_one_amendment(name: &str) -> String {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     });
     dataset.add_bill(bill).expect("the bill should be added");
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -41,6 +41,7 @@ fn build_fixture(title: &str) -> String {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     });
 
     for (date, label) in [(EARLY, "Before"), (LATE, "After")] {
@@ -86,6 +87,7 @@ fn two_works_fixture() -> &'static str {
             source_urls: vec![],
             license: "MIT".to_string(),
             version: "1.0.0".to_string(),
+            ..Default::default()
         });
 
         for (title, date) in [(UNCHANGED_TITLE, EARLY), (AMENDED_TITLE, LATE)] {
@@ -119,6 +121,7 @@ fn both_works_json_fixture() -> &'static str {
             source_urls: vec![],
             license: "MIT".to_string(),
             version: "1.0.0".to_string(),
+            ..Default::default()
         });
 
         for title in [UNCHANGED_TITLE, AMENDED_TITLE] {
@@ -150,6 +153,7 @@ fn two_works_json_fixture() -> &'static str {
             source_urls: vec![],
             license: "MIT".to_string(),
             version: "1.0.0".to_string(),
+            ..Default::default()
         });
 
         for (title, date) in [(UNCHANGED_TITLE, EARLY), (AMENDED_TITLE, LATE)] {
@@ -905,6 +909,7 @@ fn bill_fixtures() -> &'static (String, String) {
             source_urls: vec![],
             license: "MIT".to_string(),
             version: "1.0.0".to_string(),
+            ..Default::default()
         });
         dataset
             .add_uslm_xml(

--- a/tests/congress_tests.rs
+++ b/tests/congress_tests.rs
@@ -51,6 +51,7 @@ mod dataset_integration {
             source_urls: vec![],
             license: "MIT".into(),
             version: "1.0".into(),
+            ..Default::default()
         }
     }
     #[test]

--- a/tests/dataset_tests.rs
+++ b/tests/dataset_tests.rs
@@ -31,6 +31,7 @@ fn should_serialize_roundtrip_json() {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "0.1.0".to_string(),
+        ..Default::default()
     };
 
     let mut dataset = Dataset::new(metadata);
@@ -93,6 +94,7 @@ fn make_test_dataset() -> Dataset<InMemoryStorage> {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "0.1.0".to_string(),
+        ..Default::default()
     };
     Dataset::new(metadata)
 }

--- a/tests/declared_scope_tests.rs
+++ b/tests/declared_scope_tests.rs
@@ -1,0 +1,230 @@
+//! A dataset can declare what it means to cover, so a gap can be reported (#71).
+//!
+//! A derived scope says what a dataset holds. It cannot say what the dataset
+//! *meant* to hold, so "title 26 is missing" and "title 26 was never wanted"
+//! look the same. A declaration separates them, and the difference is the one a
+//! researcher needs told rather than left to discover.
+
+use words_to_data::dataset::{Coverage, Dataset, DatasetMetadata, Declaration, Exclusion};
+use words_to_data::storage::InMemoryStorage;
+
+const TITLE_9: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
+const EARLY: &str = "2025-07-18";
+
+/// A real dataset holding title 9 at one release point, declaring whatever the
+/// caller says. Only the declaration is authored; the law is the committed corpus.
+fn dataset_declaring(declaration: Option<Declaration>) -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Declared scope fixture".to_string(),
+        declaration,
+        ..Default::default()
+    });
+    dataset
+        .add_uslm_xml(TITLE_9, EARLY, None)
+        .expect("title 9 should parse");
+    dataset
+}
+
+#[test]
+fn should_report_a_declared_work_it_does_not_hold_as_a_gap() {
+    let dataset = dataset_declaring(Some(Declaration {
+        intends: vec!["uscode/title_9".to_string(), "uscode/title_26".to_string()],
+        ..Default::default()
+    }));
+
+    let scope = dataset.scope().expect("scope should derive");
+
+    assert_eq!(
+        scope.gaps(),
+        vec!["uscode/title_26".to_string()],
+        "title 26 was declared and is not held, so it is an unexplained absence"
+    );
+    assert_eq!(
+        scope.covers("uscode/title_26"),
+        Coverage::Gap,
+        "a declared work that is absent means the dataset is incomplete, \
+         which is a different answer from being out of its lane"
+    );
+    assert_eq!(scope.covers("uscode/title_9"), Coverage::InScope);
+}
+
+#[test]
+fn should_not_report_a_stated_hole_as_a_gap() {
+    let dataset = dataset_declaring(Some(Declaration {
+        intends: vec!["uscode/title_9".to_string(), "uscode/title_26".to_string()],
+        excludes: vec![Exclusion {
+            path: "uscode/title_26".to_string(),
+            reason: "the source failed to download".to_string(),
+        }],
+        ..Default::default()
+    }));
+
+    let scope = dataset.scope().expect("scope should derive");
+
+    assert!(
+        scope.gaps().is_empty(),
+        "a hole the producer stated, with a reason, is documented rather than \
+         a fault: {:?}",
+        scope.gaps()
+    );
+    assert_eq!(
+        scope.covers("uscode/title_26"),
+        Coverage::OutOfScope,
+        "deliberately left out is out of the lane, not an incomplete build"
+    );
+
+    // The reason has to survive, or the exclusion says no more than silence.
+    let declared = scope.declared.as_ref().expect("a declaration was made");
+    assert_eq!(declared.excludes[0].reason, "the source failed to download");
+}
+
+#[test]
+fn should_answer_in_scope_for_material_it_holds_but_never_declared() {
+    // Declares title 26 only, holds title 9. Under-declaring is careless, but
+    // saying we do not hold title 9 would be a false statement about our own
+    // contents.
+    let dataset = dataset_declaring(Some(Declaration {
+        intends: vec!["uscode/title_26".to_string()],
+        ..Default::default()
+    }));
+
+    let scope = dataset.scope().expect("scope should derive");
+
+    assert_eq!(scope.covers("uscode/title_9"), Coverage::InScope);
+    assert_eq!(scope.covers("uscode/title_26"), Coverage::Gap);
+}
+
+#[test]
+fn should_answer_exactly_as_before_when_nothing_is_declared() {
+    let dataset = dataset_declaring(None);
+
+    let scope = dataset.scope().expect("scope should derive");
+
+    // This feature must not change what an undeclared dataset says. Every
+    // dataset in existence is undeclared until it is rebuilt.
+    assert!(scope.declared.is_none());
+    assert!(scope.gaps().is_empty());
+    assert_eq!(scope.covers("uscode/title_9"), Coverage::InScope);
+    assert_eq!(
+        scope.covers("uscode/title_26"),
+        Coverage::OutOfScope,
+        "with nothing declared there is no third answer to give"
+    );
+}
+
+#[test]
+fn should_carry_the_declaration_through_sqlite() {
+    let declaration = Declaration {
+        intends: vec!["uscode/title_9".to_string(), "uscode/title_26".to_string()],
+        excludes: vec![Exclusion {
+            path: "uscode/title_26".to_string(),
+            reason: "the source failed to download".to_string(),
+        }],
+        dates: None,
+        namespaces: vec!["legislature".to_string()],
+    };
+    let memory = dataset_declaring(Some(declaration.clone()));
+
+    let dir = std::path::Path::new("target/declared_scope_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let file = dir.join("declaration.sqlite");
+    std::fs::remove_file(&file).ok();
+    memory.save_to_sqlite(&file).expect("save to sqlite");
+    let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
+
+    // A declaration that does not survive the file it travels in cannot be
+    // read by the party it was written for.
+    assert_eq!(
+        sqlite.metadata().declaration.as_ref(),
+        Some(&declaration),
+        "the declaration must round-trip unchanged"
+    );
+    assert_eq!(
+        sqlite.scope().expect("scope").gaps(),
+        memory.scope().expect("scope").gaps(),
+        "both backends must agree on what is missing"
+    );
+}
+
+#[test]
+fn should_hold_a_legislature_it_declared_before_it_has_any_bills() {
+    // Deciding from contents alone, a legislative dataset that has not been
+    // given bills yet reports that it holds no legislature at all. That is a
+    // wrong answer we shipped knowingly; the declaration is what fixes it.
+    let dataset = dataset_declaring(Some(Declaration {
+        namespaces: vec!["legislature".to_string()],
+        ..Default::default()
+    }));
+
+    assert!(
+        dataset.legislature().is_some(),
+        "a dataset that declares the legislature namespace holds a legislature, \
+         even before any bill is added"
+    );
+}
+
+#[test]
+fn should_hold_no_legislature_when_it_declares_none_and_has_none() {
+    let dataset = dataset_declaring(Some(Declaration {
+        intends: vec!["uscode/title_9".to_string()],
+        ..Default::default()
+    }));
+
+    assert!(
+        dataset.legislature().is_none(),
+        "declaring documents only, and holding no bills, means no legislature"
+    );
+}
+
+/// Save a dataset and run `info` against it the way a person or an agent would.
+fn info_output(dataset: &Dataset<InMemoryStorage>, name: &str) -> String {
+    let dir = std::path::Path::new("target/declared_scope_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let file = dir.join(format!("{name}.sqlite"));
+    std::fs::remove_file(&file).ok();
+    dataset.save_to_sqlite(&file).expect("save to sqlite");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args(["info", file.to_str().expect("a utf-8 path")])
+        .output()
+        .expect("the binary should run");
+    assert!(output.status.success(), "info should exit zero");
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+#[test]
+fn should_print_an_incomplete_line_when_the_build_left_a_gap() {
+    let dataset = dataset_declaring(Some(Declaration {
+        intends: vec!["uscode/title_9".to_string(), "uscode/title_26".to_string()],
+        ..Default::default()
+    }));
+
+    let stdout = info_output(&dataset, "gap");
+
+    // A silent gap is the failure mode this feature exists to remove, so the
+    // one thing `info` must not do is print a dataset like this as if it were
+    // whole.
+    assert!(
+        stdout.contains("INCOMPLETE"),
+        "info should say the dataset is incomplete, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("uscode/title_26"),
+        "it should name what is missing, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn should_print_no_declaration_lines_when_nothing_was_declared() {
+    let stdout = info_output(&dataset_declaring(None), "undeclared");
+
+    // Every dataset is undeclared until it is rebuilt, so this output is what
+    // almost every reader sees and it must not have changed.
+    for absent in ["INCOMPLETE", "Declared:", "Excluded:", "Namespaces:"] {
+        assert!(
+            !stdout.contains(absent),
+            "an undeclared dataset should not print {absent:?}, got:\n{stdout}"
+        );
+    }
+    assert!(stdout.contains("Covers:"), "it still reports what it holds");
+}

--- a/tests/duplicate_path_tests.rs
+++ b/tests/duplicate_path_tests.rs
@@ -146,6 +146,7 @@ fn title_26_both_expressions()
         source_urls: vec![],
         license: "Public Domain".to_string(),
         version: "1.0".to_string(),
+        ..Default::default()
     });
     dataset
         .add_uslm_xml(USC26_18, "2025-07-18", None)
@@ -368,6 +369,7 @@ fn dataset_both_backends(
         source_urls: vec![],
         license: "Public Domain".to_string(),
         version: "1.0".to_string(),
+        ..Default::default()
     });
     memory
         .add_uslm_xml(USC26_30, "2025-07-30", None)

--- a/tests/inspect_tests.rs
+++ b/tests/inspect_tests.rs
@@ -41,6 +41,7 @@ fn make_fixture() -> Dataset<InMemoryStorage> {
         source_urls: vec!["https://uscode.house.gov".to_string()],
         license: "Public Domain".to_string(),
         version: "1.0".to_string(),
+        ..Default::default()
     });
     dataset
         .add_uslm_xml(USC09_18, "2025-07-18", Some("Before".to_string()))
@@ -348,6 +349,7 @@ fn should_pass_validation_for_a_consistent_dataset() {
         source_urls: vec![],
         license: String::new(),
         version: "1.0".to_string(),
+        ..Default::default()
     });
     dataset
         .add_uslm_xml(USC09_18, "2025-07-18", None)
@@ -540,6 +542,7 @@ fn should_account_coverage_against_the_real_diff() {
         source_urls: vec![],
         license: String::new(),
         version: "1.0".to_string(),
+        ..Default::default()
     });
     dataset
         .add_uslm_xml(

--- a/tests/matching_tests.rs
+++ b/tests/matching_tests.rs
@@ -31,6 +31,7 @@ fn make_fixture() -> Dataset<InMemoryStorage> {
         source_urls: vec!["https://uscode.house.gov".to_string()],
         license: "Public Domain".to_string(),
         version: "1.0".to_string(),
+        ..Default::default()
     });
     dataset
         .add_uslm_xml(USC26_18, "2025-07-18", Some("Before".to_string()))
@@ -57,6 +58,7 @@ fn fixture_with_scored_amendments() -> Dataset<InMemoryStorage> {
         source_urls: vec!["https://uscode.house.gov".to_string()],
         license: "Public Domain".to_string(),
         version: "1.0".to_string(),
+        ..Default::default()
     });
     dataset
         .add_uslm_xml(USC26_18, "2025-07-18", Some("Before".to_string()))

--- a/tests/readme_example_tests.rs
+++ b/tests/readme_example_tests.rs
@@ -33,6 +33,7 @@ fn readme_example_dataset_workflow() {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     };
     let mut dataset = Dataset::new(metadata);
 
@@ -97,6 +98,7 @@ fn readme_example_dataset_workflow_results() {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     };
     let mut dataset = Dataset::new(metadata);
 

--- a/tests/schema_version_tests.rs
+++ b/tests/schema_version_tests.rs
@@ -29,6 +29,7 @@ fn metadata() -> DatasetMetadata {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     }
 }
 

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -23,6 +23,7 @@ fn metadata() -> DatasetMetadata {
         source_urls: vec![],
         license: "Public Domain".to_string(),
         version: "1.0".to_string(),
+        ..Default::default()
     }
 }
 
@@ -173,15 +174,18 @@ fn stale_index_dataset(name: &str) -> std::path::PathBuf {
     std::fs::remove_file(&path).ok();
 
     let conn = rusqlite::Connection::open(&path).expect("open forged db");
-    conn.execute_batch(
+    // The schema version must be current, or the version guard answers first
+    // and this test stops asking about the search index at all.
+    conn.execute_batch(&format!(
         "CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
-         INSERT INTO schema_version (version) VALUES (3);
+         INSERT INTO schema_version (version) VALUES ({});
          CREATE TABLE element_index (
              work TEXT NOT NULL, date TEXT NOT NULL, path TEXT NOT NULL,
              element_type TEXT, heading TEXT, content TEXT,
              PRIMARY KEY (work, date, path)
          );",
-    )
+        words_to_data::storage::SCHEMA_VERSION
+    ))
     .expect("forge the older index");
     drop(conn);
     path

--- a/tests/sqlite_tests.rs
+++ b/tests/sqlite_tests.rs
@@ -31,6 +31,7 @@ fn make_test_dataset() -> Dataset<InMemoryStorage> {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "0.1.0".to_string(),
+        ..Default::default()
     };
     Dataset::new(metadata)
 }

--- a/tests/storage_traits_tests.rs
+++ b/tests/storage_traits_tests.rs
@@ -30,6 +30,10 @@ const BILL_ID: &str = "119-21";
 struct DocumentsOnly(InMemoryStorage);
 
 impl DocumentReader for DocumentsOnly {
+    fn metadata(&self) -> &DatasetMetadata {
+        self.0.metadata()
+    }
+
     fn works(&self) -> Result<Vec<WorkId>, DatasetError> {
         self.0.works()
     }
@@ -95,6 +99,7 @@ fn should_read_documents_from_a_backend_that_implements_no_legislature_methods()
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     });
     storage
         .add_expression(title_9_expression(Some("Only".to_string())))
@@ -127,6 +132,7 @@ fn dataset_holding(bill: bool) -> Dataset<InMemoryStorage> {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     });
     dataset
         .add_uslm_xml(TITLE_9, EARLY, None)

--- a/tests/website_example_tests.rs
+++ b/tests/website_example_tests.rs
@@ -285,6 +285,7 @@ fn website_example_dataset_workflow() {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     };
     let mut dataset = Dataset::new(metadata);
 

--- a/tests/work_tests.rs
+++ b/tests/work_tests.rs
@@ -23,6 +23,7 @@ fn empty_dataset() -> Dataset<words_to_data::storage::InMemoryStorage> {
         source_urls: vec![],
         license: "MIT".to_string(),
         version: "1.0.0".to_string(),
+        ..Default::default()
     })
 }
 


### PR DESCRIPTION
Closes #71. (PRs into `vibes` do not auto-close, so #71 needs closing by hand after merge.)

First of the three breaking changes in this window. #70 and #58 follow, in that order.

## What was missing

A derived scope says what a dataset **holds**. It cannot say what the dataset **meant** to hold, so "title 26 is missing" and "title 26 was never wanted" looked identical. A researcher had to discover the difference rather than be told it.

## What it does now

```
$ words_to_data info dataset.sqlite
Covers:
  uscode/title_9  2025-07-18
Declared:    uscode/title_9, uscode/title_26
Namespaces:  legislature
Excluded:    uscode/title_26 — the source failed to download
```

Drop the exclusion and the same dataset reports:

```
INCOMPLETE:  declared but not held: uscode/title_26
```

## The distinction the design turns on

A **gap** is an *unexplained* absence: declared, not excluded, not held. A hole the producer states is an **exclusion** and is deliberately not a gap, because it is already answered. The `reason` on an exclusion is **required** — a hole with no reason cannot be told from an oversight, which is the ambiguity `Scope` exists to remove.

So a non-empty `gaps()` means exactly one thing: the build did not do what it said it would.

## Two rules worth reviewing

**Held but never declared answers `InScope`.** Under-declaring is careless, but answering `OutOfScope` for material we demonstrably hold would be a false statement about our own contents.

**`legislature()` opens when the namespace is declared *or* when bills are present.** The grilling settled on "declaration decides when present", but implementing it showed that rule would *hide* bills from a dataset that under-declared. Either answer is a yes, for the same reason held material is always in scope. This is a deliberate refinement of what we agreed — flagging it because it is not what was written down.

**A dataset that declares nothing answers exactly as before.** That is every dataset in existence until it is rebuilt, and there is a test pinning it.

## Scope not taken

- **Gap *discovery*** — "meant to cover all of title 26 and is missing three sections" needs to know title 26 has N sections, which the dataset cannot know without an external manifest. Only *declared* holes are computable. The issue's own "Done when" describes the exclusion case, which is what shipped.
- **`validate`** — a gap is worth reporting, but #70 rewrites the validator, so teaching it a new class of finding now means writing it twice.
- **Declared dates are reported, not gap-checked.** A date owns nothing and a work need not exist on every date in a range.

## Incidental changes

`metadata()` moves from `DocumentWriter` to `DocumentReader`. Reading metadata is a read; it sat behind a trait a reader has no reason to implement, which is why `Scope::derive` could not see the declaration.

The 25 test metadata literals now end in `..Default::default()`, as the issue suggested, so the next field costs one line.

## Breaking

`SCHEMA_VERSION` 3 → 4. Both on-disk forms change and #68 makes the break loud. Per the sequencing agreed for this window, #70 and #58 each bump again rather than sharing this one: a dataset built from `vibes` between two merges must not claim a version whose shape it does not have. Users still rebuild once, after the window.

## Tests

**275 passed, 7 ignored, 0 failed**, against a baseline of 266 / 7. Clippy and fmt clean.

Nine new tests over the committed title 9 corpus. Only the declaration is authored — it is configuration, not legal text.

Covered: gap reported; stated hole not reported and its reason preserved; held-but-undeclared is in scope; undeclared dataset unchanged; declaration round-trips through SQLite with both backends agreeing on gaps; legislature opens on declaration alone; stays closed when neither declared nor held; `info` prints INCOMPLETE on a gap; `info` prints no declaration lines at all when nothing was declared.

The first cycle was RED before the types existed, and the SQLite round-trip and `legislature()` tests both failed for real before their implementations landed. The rest were written after, so I mutated `is_excluded` to always return false and `covers()` to drop the held-first rule — three tests failed, so they are wired to behaviour.

One pre-existing test needed a fix rather than a new expectation: `should_refuse_a_dataset_whose_search_index_predates_this_build` forged a database at hardcoded version 3, so the version guard now answered before the search-index check it was written to exercise. It reads `SCHEMA_VERSION` now and is version-agnostic.

## Still outstanding

Per your call to build first and do the paperwork after: `CONTEXT.md` has no **Gap** or **Exclusion** term yet, and the `covers()` precedence rule lives only in a doc comment. Say the word and I will land those.