### PR TITLE
docs: name a gap and an exclusion in the glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,9 +71,17 @@ One portable file that carries a Dataset to another party.
 _Avoid_: Export, dump, archive
 
 **Scope**:
-The statement of what a Dataset covers. A Dataset declares the scope it intends, and reports the scope it holds. A reader uses the scope to answer "out of scope" instead of "not found".
+The statement of what a Dataset covers. A Dataset declares the scope it intends, and reports the scope it holds. A reader uses the scope to answer "out of scope" instead of "not found". The difference between the two halves is a Gap.
 _Avoid_: Coverage, extent, contents
 
+**Gap**:
+Material a Dataset declared, did not exclude, and does not hold. A gap says the build did not do what it said it would, so it is a fault in the Dataset rather than a statement about the law. This is why it is a separate answer from "out of scope": one means incomplete, the other means out of its lane.
+_Avoid_: Missing, hole, omission
+
+**Exclusion**:
+A hole a producer states, together with the reason for it. An excluded path is answered rather than merely absent, so it is not a Gap. The reason is part of the statement: a hole with no reason cannot be told apart from an oversight, which is the ambiguity the Scope exists to remove.
+_Avoid_: Skip, filter, ignore
+
 **Verification state**:
-The trust level of one statement in a Dataset: `Asserted` by a source, `MachineSuggested`, `HumanConfirmed`, or `Disputed`. Every statement that a machine made carries this state and its evidence.
+The trust level of one statement in a Dataset: `Asserted` by a source, `MachineSuggested`, `HumanConfirmed`, `Disputed`, or `Refuted`. Every statement that a machine made carries this state and its evidence. `Disputed` means someone objects and it is unsettled; `Refuted` means it was checked and found wrong, which is settled.
 _Avoid_: Confidence, score, accuracy


### PR DESCRIPTION
The paperwork deferred from #71, which is merged as `263e253`.

Docs only.

- **Gap** — material a Dataset declared, did not exclude, and does not hold. A fault in the Dataset, not a statement about the law, which is why it is a separate answer from "out of scope".
- **Exclusion** — a hole the producer states with its reason, and therefore answered rather than absent. The reason is part of the statement.
- **Scope** gains one clause pointing at the difference between its two halves.

The `covers()` precedence rule needed nothing: it was already documented where it applies, so the outstanding item was smaller than I said when deferring it.

## One thing beyond the deferred scope

The **Verification state** entry listed four states while the code has had five since `Refuted` was added. I fixed it while in the file, and added the distinction ADR 0004 leans on: `Disputed` means someone objects and it is unsettled, `Refuted` means it was checked and found wrong. Flagging it because it is not part of what was deferred — say if you would rather it were separate.