### PR TITLE
feat: store links, so a kind we do not own can be carried

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@
 *.json
 parsed/
 
+# Committed test fixtures. `*.json` above is for data dumps, but the fixtures
+# under tests/ are the real data the suite runs against and must be tracked.
+# Without this a new fixture is skipped by `git add` in silence, and the tests
+# only fail once CI checks out a tree that never had it.
+!tests/test_data/processed/*.json
+
 # Main directories for dumping data while testing
 usc_data/
 bill_data/

--- a/src/bin/words_to_data/match_amendments.rs
+++ b/src/bin/words_to_data/match_amendments.rs
@@ -18,6 +18,7 @@ use words_to_data::annotation::{
 };
 use words_to_data::dataset::{Dataset, Format};
 use words_to_data::legislature::AmendingAction;
+use words_to_data::link::Link;
 use words_to_data::matching::{
     AmendmentMatch, Candidate, DEFAULT_SIMILARITY_CUTOFF, build_matches,
 };
@@ -134,10 +135,12 @@ pub fn run(args: Args) {
                         reasoning: ann.reasoning,
                     },
                 };
-                crate::fail::or_exit(
-                    dataset.add_annotation(&from, &to, annotation),
-                    "Error adding annotation",
-                );
+                // Links are what is stored, so this writes links rather than
+                // handing an annotation to a convenience that fans out. One
+                // annotation is one link per path it names.
+                for link in Link::from_annotation(&annotation, &from, &to) {
+                    crate::fail::or_exit(dataset.add_link(link), "Error adding link");
+                }
                 applied += 1;
             }
         }

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -6,42 +6,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
-/// Custom serializer for HashMap with tuple keys (JSON doesn't support non-string keys)
-mod tuple_key_map {
-    use super::*;
-    use crate::annotation::ChangeAnnotation;
-    use crate::dataset::ExpressionPair;
-
-    pub fn serialize<S>(
-        map: &HashMap<ExpressionPair, Vec<ChangeAnnotation>>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // Serialize as Vec of (key, value) pairs
-        let vec: Vec<_> = map.iter().collect();
-        vec.serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<HashMap<ExpressionPair, Vec<ChangeAnnotation>>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // Deserialize as Vec of (key, value) pairs
-        let vec: Vec<(ExpressionPair, Vec<ChangeAnnotation>)> = Vec::deserialize(deserializer)?;
-        Ok(vec.into_iter().collect())
-    }
-}
-
-use crate::annotation::ChangeAnnotation;
 use crate::congress::{BillVotes, Member, SponsorInfo};
-use crate::dataset::{DatasetMetadata, Expression, ExpressionId, ExpressionPair, WorkId};
+use crate::dataset::{DatasetMetadata, Expression, ExpressionId, WorkId};
 use crate::intern::StringInterner;
+/// Custom serializer for HashMap with tuple keys (JSON doesn't support non-string keys)
+use crate::link::Link;
 use crate::storage::{InMemoryStorage, SCHEMA_VERSION, memory::ExpressionsByWork};
 use crate::uslm::bill_parser::Bill;
 use crate::uslm::{DocumentType, ElementData, ElementType, RefPair, SourceCredit, USLMElement};
@@ -192,9 +163,9 @@ pub struct DatasetCompact {
     /// Bills (stored as-is, no dedup needed)
     #[serde(default)]
     pub bills: HashMap<String, Bill>,
-    /// Annotations per expression-pair (stored as-is)
-    #[serde(default, with = "tuple_key_map")]
-    pub diff_annotations: HashMap<ExpressionPair, Vec<ChangeAnnotation>>,
+    /// Every link, by its content-hash id (stored as-is)
+    #[serde(default)]
+    pub links: std::collections::BTreeMap<String, Link>,
     /// Congress members (stored as-is)
     #[serde(default)]
     pub members: HashMap<String, Member>,
@@ -251,7 +222,7 @@ impl DatasetCompact {
             metadata: storage.metadata.clone(),
             expressions,
             bills: storage.bills.clone(),
-            diff_annotations: storage.diff_annotations.clone(),
+            links: storage.links.clone(),
             members: storage.members.clone(),
             sponsors: storage.sponsors.clone(),
             bill_votes: storage.bill_votes.clone(),
@@ -330,7 +301,7 @@ impl DatasetCompact {
             self.metadata,
             expressions,
             self.bills,
-            self.diff_annotations,
+            self.links,
             self.members,
             self.sponsors,
             self.bill_votes,

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -24,6 +24,7 @@ use crate::congress::{
 };
 use crate::diff::TreeDiff;
 use crate::legislature::BillDiff;
+use crate::link::Link;
 use crate::storage::{
     DocumentReader, DocumentWriter, InMemoryStorage, LegislatureReader, LegislatureWriter,
     LinkReader, LinkWriter, SqliteStorage, Storage,
@@ -267,13 +268,14 @@ impl<S: Storage> Dataset<S> {
         self.storage.add_bill(bill)
     }
 
-    pub fn add_annotation(
-        &mut self,
-        from: &ExpressionId,
-        to: &ExpressionId,
-        annotation: ChangeAnnotation,
-    ) -> Result<(), DatasetError> {
-        self.storage.add_annotation(from, to, annotation)
+    /// Record one link.
+    ///
+    /// There is no annotation-shaped convenience beside this: two ways to write
+    /// one fact means the convenient one is used, and the convenient one can
+    /// only ever express the single kind we own
+    /// (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+    pub fn add_link(&mut self, link: Link) -> Result<(), DatasetError> {
+        self.storage.add_link(link)
     }
 
     pub fn add_member(&mut self, member: Member) -> Result<(), DatasetError> {
@@ -599,24 +601,32 @@ impl<S: Storage> DocumentReader for Dataset<S> {
 }
 
 impl<S: Storage> LinkReader for Dataset<S> {
-    fn get_annotations(
+    fn links_for_path(&self, path: &str) -> Result<Vec<Link>, DatasetError> {
+        self.storage.links_for_path(path)
+    }
+
+    fn links_for_pair(
         &self,
         from: &ExpressionId,
         to: &ExpressionId,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
-        self.storage.get_annotations(from, to)
+    ) -> Result<Vec<Link>, DatasetError> {
+        self.storage.links_for_pair(from, to)
     }
 
-    fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
-        self.storage.annotations_for_path(path)
+    fn links_by_kind(&self, kind: &str) -> Result<Vec<Link>, DatasetError> {
+        self.storage.links_by_kind(kind)
     }
 
-    fn annotations_for_bill(&self, bill_id: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
-        self.storage.annotations_for_bill(bill_id)
+    fn links_by_namespace(&self, namespace: &str) -> Result<Vec<Link>, DatasetError> {
+        self.storage.links_by_namespace(namespace)
     }
 
-    fn annotation_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
-        self.storage.annotation_pairs()
+    fn links_for_object_prefix(&self, prefix: &str) -> Result<Vec<Link>, DatasetError> {
+        self.storage.links_for_object_prefix(prefix)
+    }
+
+    fn link_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
+        self.storage.link_pairs()
     }
 }
 
@@ -660,13 +670,8 @@ impl<S: Storage> DocumentWriter for Dataset<S> {
 }
 
 impl<S: Storage> LinkWriter for Dataset<S> {
-    fn add_annotation(
-        &mut self,
-        from: &ExpressionId,
-        to: &ExpressionId,
-        annotation: ChangeAnnotation,
-    ) -> Result<(), DatasetError> {
-        self.storage.add_annotation(from, to, annotation)
+    fn add_link(&mut self, link: Link) -> Result<(), DatasetError> {
+        self.storage.add_link(link)
     }
 }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -21,7 +21,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::annotation::{AnnotationStatus, ChangeAnnotation};
-use crate::dataset::ExpressionId;
+use crate::dataset::{ExpressionId, WorkId};
 use crate::diff::AmendmentSimilarity;
 
 /// The kind of a link, namespaced by the extension that defines it.
@@ -73,6 +73,21 @@ pub enum Target {
     /// the dataset can actually be asked for. Two spellings of one concept
     /// would let a link name something no reader could resolve.
     Expression(ExpressionId),
+    /// A provision as it changed between two dates of one work.
+    ///
+    /// A bare provision cannot say *when* it was amended, so a link whose
+    /// subject was one could not answer "what changed between these two
+    /// expressions" — the question coverage and validation are built on.
+    ///
+    /// One work and two dates rather than two [`ExpressionId`]s: two copies of
+    /// one work can disagree, and after an edit one of them will
+    /// (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+    Change {
+        work: WorkId,
+        path: String,
+        from_date: String,
+        to_date: String,
+    },
     /// Something outside the core model, named in an extension's namespace.
     /// An amendment is reached this way, because amendments are legislature.
     External { reference: String, display: String },
@@ -101,6 +116,18 @@ pub enum VerificationState {
     Refuted,
 }
 
+impl VerificationState {
+    /// Whether a person has passed judgement on this statement.
+    ///
+    /// A machine restating a fact must not overwrite one of these. Re-running
+    /// the pipeline would otherwise destroy human review, and the loss is
+    /// invisible until somebody looks for a confirmation that is gone
+    /// (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+    pub fn is_human_touched(self) -> bool {
+        matches!(self, Self::HumanConfirmed | Self::Disputed | Self::Refuted)
+    }
+}
+
 /// Where a statement came from.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Provenance {
@@ -123,6 +150,12 @@ pub struct Provenance {
     /// Nobody can check it. The model asserted it about its own work, and
     /// running the model again may give a different number.
     pub raw_score: Option<f32>,
+    /// When the statement was made.
+    ///
+    /// Core provenance rather than a kind payload: every statement has a when,
+    /// and a reader that cannot open the payload still needs it to judge the
+    /// link. `None` means the maker did not record one.
+    pub timestamp: Option<time::OffsetDateTime>,
     /// A deterministic measurement supporting the statement.
     ///
     /// Unlike `raw_score`, this is reproducible: a receiver holding the same
@@ -168,6 +201,23 @@ impl From<&AmendmentSimilarity> for Corroboration {
     }
 }
 
+/// Facts about a link that only the extension defining its kind understands.
+///
+/// The core stores it, hands it back unchanged, and never reads it. This is
+/// ADR 0002's "a reader preserves what it does not understand" made storable.
+///
+/// Two rules keep it from becoming a dumping ground. The core never reads it.
+/// And nothing a reader needs in order to *report* a link may live here: a
+/// reader that cannot open the payload must still be able to say what the link
+/// is, who said it, and how far it can be trusted.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KindPayload {
+    /// The namespace that owns these facts, such as `legislature`.
+    pub namespace: String,
+    /// The facts themselves, opaque to the core.
+    pub value: serde_json::Value,
+}
+
 /// A statement connecting a provision to something else.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Link {
@@ -175,38 +225,107 @@ pub struct Link {
     pub kind: LinkKind,
     pub object: Target,
     pub provenance: Provenance,
+    /// Facts only this link's kind understands. `None` for a kind that needs
+    /// nothing beyond the core.
+    #[serde(default)]
+    pub payload: Option<KindPayload>,
+}
+
+/// How an amendment is named as a link object.
+///
+/// Fully qualified — the bill and the amendment — so a reader that does not
+/// know the legislature extension can still resolve what it points at. The
+/// amendment id alone needed a separate `bill_id` column to be useful, which is
+/// cruft from before the core and the extensions were separated.
+pub fn amendment_reference(bill_id: &str, amendment_id: &str) -> String {
+    format!("legislature.amendment:{bill_id}:{amendment_id}")
 }
 
 impl Link {
+    /// What this link says, hashed: its subject, its kind, and its object.
+    ///
+    /// A row id is meaningless outside one file, and datasets are rebuilt
+    /// rather than migrated, so an identity that does not survive a rebuild
+    /// cannot be pointed at, confirmed, or deduplicated. `amendment_id` is
+    /// already minted this way.
+    ///
+    /// Provenance is deliberately not hashed. Restating a fact updates one link
+    /// rather than growing the table, which is what makes a rebuild idempotent.
+    /// The cost is that two parties asserting one fact collapse into one record
+    /// (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+    pub fn id(&self) -> String {
+        use sha2::{Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        // Hash the serialized form rather than a hand-built string: a separator
+        // chosen by hand is a separator a value can contain.
+        for part in [
+            serde_json::to_string(&self.subject).unwrap_or_default(),
+            serde_json::to_string(&self.kind).unwrap_or_default(),
+            serde_json::to_string(&self.object).unwrap_or_default(),
+        ] {
+            hasher.update(part.as_bytes());
+            hasher.update([0u8]);
+        }
+        hex::encode(hasher.finalize())
+    }
+
     /// Project a stored annotation into links, one per path it covers.
     ///
     /// An annotation names several paths when one amendment changed several
     /// provisions. Each is its own statement, because each can be confirmed or
     /// disputed on its own.
-    pub fn from_annotation(annotation: &ChangeAnnotation) -> Vec<Link> {
+    ///
+    /// Takes the expression pair because the subject is a change, and a change
+    /// is not addressable without the dates it happened between.
+    pub fn from_annotation(
+        annotation: &ChangeAnnotation,
+        from: &ExpressionId,
+        to: &ExpressionId,
+    ) -> Vec<Link> {
         let provenance = Provenance {
             source: annotation.metadata.annotator.clone(),
-            method: Some(format!("{:?}", annotation.operation)),
+            method: None,
             verification: verification_of(annotation),
             evidence: annotation.metadata.reasoning.clone(),
             raw_score: annotation.metadata.confidence,
+            timestamp: Some(annotation.metadata.timestamp),
             corroboration: None,
+        };
+
+        // The amending action and the free-text note are legislature concepts.
+        // The action used to live in `Provenance.method` as a `Debug` string,
+        // which round-tripped only because the enum carries no data.
+        let payload = KindPayload {
+            namespace: LinkKind::LEGISLATURE.to_string(),
+            value: serde_json::json!({
+                "operation": annotation.operation,
+                "bill_id": annotation.source_bill.bill_id,
+                "amendment_id": annotation.source_bill.amendment_id,
+                "notes": annotation.metadata.notes,
+            }),
         };
 
         annotation
             .paths
             .iter()
             .map(|path| Link {
-                subject: Target::Provision(path.clone()),
+                subject: Target::Change {
+                    work: from.work.clone(),
+                    path: path.clone(),
+                    from_date: from.at.clone(),
+                    to_date: to.at.clone(),
+                },
                 kind: LinkKind::new(LinkKind::AMENDED_BY),
                 object: Target::External {
-                    reference: format!(
-                        "legislature.amendment:{}",
-                        annotation.source_bill.amendment_id
+                    reference: amendment_reference(
+                        &annotation.source_bill.bill_id,
+                        &annotation.source_bill.amendment_id,
                     ),
                     display: annotation.source_bill.causative_text.clone(),
                 },
                 provenance: provenance.clone(),
+                payload: Some(payload.clone()),
             })
             .collect()
     }
@@ -218,6 +337,98 @@ impl Link {
     pub fn with_corroboration(mut self, corroboration: Corroboration) -> Self {
         self.provenance.corroboration = Some(corroboration);
         self
+    }
+}
+
+/// Regroup links into the annotations they came from.
+///
+/// The reverse of [`Link::from_annotation`], and the direction that matters now
+/// that links are what is stored.
+///
+/// Links group by amendment, expression pair, and source. Dropping the source
+/// would merge two annotators' accounts of one amendment into a single record
+/// with one provenance, which loses who said what. Several amendments can cause
+/// one change, so the amendment cannot be dropped either.
+///
+/// A link of another kind is skipped: this is a legislature-shaped view, and a
+/// `judicial.cites` link is not an annotation.
+pub fn annotations_from_links(links: &[Link]) -> Vec<ChangeAnnotation> {
+    use crate::annotation::{AnnotationMetadata, BillReference};
+    use std::collections::BTreeMap;
+
+    let amended_by = LinkKind::new(LinkKind::AMENDED_BY);
+    let mut grouped: BTreeMap<(String, String, String, String), ChangeAnnotation> = BTreeMap::new();
+
+    for link in links.iter().filter(|l| l.kind == amended_by) {
+        let Target::Change {
+            path,
+            from_date,
+            to_date,
+            ..
+        } = &link.subject
+        else {
+            continue;
+        };
+        let Target::External { reference, display } = &link.object else {
+            continue;
+        };
+        let payload = link.payload.as_ref().map(|p| &p.value);
+        let field = |name: &str| -> Option<String> {
+            payload
+                .and_then(|v| v.get(name))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        };
+
+        let key = (
+            reference.clone(),
+            from_date.clone(),
+            to_date.clone(),
+            link.provenance.source.clone(),
+        );
+        grouped
+            .entry(key)
+            .or_insert_with(|| ChangeAnnotation {
+                operation: field("operation")
+                    .and_then(|op| op.parse().ok())
+                    .unwrap_or(crate::legislature::AmendingAction::Amend),
+                source_bill: BillReference {
+                    bill_id: field("bill_id").unwrap_or_default(),
+                    amendment_id: field("amendment_id").unwrap_or_default(),
+                    causative_text: display.clone(),
+                },
+                paths: Vec::new(),
+                metadata: AnnotationMetadata {
+                    status: status_of(link.provenance.verification),
+                    confidence: link.provenance.raw_score,
+                    annotator: link.provenance.source.clone(),
+                    timestamp: link
+                        .provenance
+                        .timestamp
+                        .unwrap_or(time::OffsetDateTime::UNIX_EPOCH),
+                    notes: field("notes"),
+                    reasoning: link.provenance.evidence.clone(),
+                },
+            })
+            .paths
+            .push(path.clone());
+    }
+
+    grouped.into_values().collect()
+}
+
+/// Map a verification state back onto a stored status.
+///
+/// The reverse of [`verification_of`], and lossy in one place: `Asserted` and
+/// `MachineSuggested` both came from `Pending`, and both go back to it.
+fn status_of(verification: VerificationState) -> AnnotationStatus {
+    match verification {
+        VerificationState::HumanConfirmed => AnnotationStatus::Verified,
+        VerificationState::Disputed => AnnotationStatus::Disputed,
+        VerificationState::Refuted => AnnotationStatus::Rejected,
+        VerificationState::Asserted | VerificationState::MachineSuggested => {
+            AnnotationStatus::Pending
+        }
     }
 }
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -2,9 +2,8 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
-use crate::annotation::ChangeAnnotation;
 use crate::congress::{BillVotes, HouseRollCall, Member, SponsorInfo, VotePosition};
 use crate::dataset::{
     DatasetError, DatasetMetadata, Expression, ExpressionId, ExpressionInfo, ExpressionPair,
@@ -12,38 +11,13 @@ use crate::dataset::{
 };
 use crate::diff::TreeDiff;
 use crate::intern::StringInterner;
+use crate::link::{Link, Target};
 use crate::storage::{
     DocumentReader, DocumentWriter, LegislatureReader, LegislatureWriter, LinkReader, LinkWriter,
     Storage,
 };
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
-
-/// Custom serializer for HashMap with tuple keys (JSON doesn't support non-string keys)
-mod tuple_key_map {
-    use super::*;
-
-    pub fn serialize<S>(
-        map: &HashMap<ExpressionPair, Vec<ChangeAnnotation>>,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let vec: Vec<_> = map.iter().collect();
-        vec.serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(
-        deserializer: D,
-    ) -> Result<HashMap<ExpressionPair, Vec<ChangeAnnotation>>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let vec: Vec<(ExpressionPair, Vec<ChangeAnnotation>)> = Vec::deserialize(deserializer)?;
-        Ok(vec.into_iter().collect())
-    }
-}
 
 /// Every expression a dataset holds, by work and then by date.
 ///
@@ -63,8 +37,9 @@ pub struct InMemoryStorage {
     pub metadata: DatasetMetadata,
     pub expressions: ExpressionsByWork,
     pub bills: HashMap<String, Bill>,
-    #[serde(with = "tuple_key_map")]
-    pub diff_annotations: HashMap<ExpressionPair, Vec<ChangeAnnotation>>,
+    /// Every link, by its content-hash id. Keying on the id is what makes
+    /// restating a fact update one link rather than grow the map.
+    pub links: BTreeMap<String, Link>,
     pub members: HashMap<String, Member>,
     pub sponsors: HashMap<String, SponsorInfo>,
     pub bill_votes: HashMap<String, BillVotes>,
@@ -78,7 +53,7 @@ impl InMemoryStorage {
             metadata,
             expressions: BTreeMap::new(),
             bills: HashMap::new(),
-            diff_annotations: HashMap::new(),
+            links: BTreeMap::new(),
             members: HashMap::new(),
             sponsors: HashMap::new(),
             bill_votes: HashMap::new(),
@@ -103,7 +78,7 @@ impl InMemoryStorage {
         metadata: DatasetMetadata,
         expressions: ExpressionsByWork,
         bills: HashMap<String, Bill>,
-        diff_annotations: HashMap<ExpressionPair, Vec<ChangeAnnotation>>,
+        links: BTreeMap<String, Link>,
         members: HashMap<String, Member>,
         sponsors: HashMap<String, SponsorInfo>,
         bill_votes: HashMap<String, BillVotes>,
@@ -113,7 +88,7 @@ impl InMemoryStorage {
             metadata,
             expressions,
             bills,
-            diff_annotations,
+            links,
             members,
             sponsors,
             bill_votes,
@@ -273,40 +248,92 @@ pub(crate) fn require_same_work<R: DocumentReader + ?Sized>(
 }
 
 impl LinkReader for InMemoryStorage {
-    fn get_annotations(
+    fn links_for_path(&self, path: &str) -> Result<Vec<Link>, DatasetError> {
+        Ok(self
+            .links
+            .values()
+            .filter(|link| subject_path(link).is_some_and(|p| p == path))
+            .cloned()
+            .collect())
+    }
+
+    fn links_for_pair(
         &self,
         from: &ExpressionId,
         to: &ExpressionId,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
-        let key = (from.clone(), to.clone());
-        Ok(self.diff_annotations.get(&key).cloned())
-    }
-
-    fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
+    ) -> Result<Vec<Link>, DatasetError> {
         Ok(self
-            .diff_annotations
+            .links
             .values()
-            .flatten()
-            .filter(|a| a.paths.iter().any(|p| p == path))
+            .filter(|link| about_pair(link, from, to))
             .cloned()
             .collect())
     }
 
-    fn annotations_for_bill(&self, bill_id: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
+    fn links_by_kind(&self, kind: &str) -> Result<Vec<Link>, DatasetError> {
         Ok(self
-            .diff_annotations
+            .links
             .values()
-            .flatten()
-            .filter(|a| a.source_bill.bill_id == bill_id)
+            .filter(|link| link.kind.0 == kind)
             .cloned()
             .collect())
     }
 
-    fn annotation_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
-        let mut pairs: Vec<ExpressionPair> = self.diff_annotations.keys().cloned().collect();
+    fn links_by_namespace(&self, namespace: &str) -> Result<Vec<Link>, DatasetError> {
+        Ok(self
+            .links
+            .values()
+            .filter(|link| link.kind.namespace() == namespace)
+            .cloned()
+            .collect())
+    }
+
+    fn links_for_object_prefix(&self, prefix: &str) -> Result<Vec<Link>, DatasetError> {
+        Ok(self
+            .links
+            .values()
+            .filter(|link| match &link.object {
+                Target::External { reference, .. } => reference.starts_with(prefix),
+                _ => false,
+            })
+            .cloned()
+            .collect())
+    }
+
+    fn link_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
+        let mut pairs: Vec<ExpressionPair> = self.links.values().filter_map(pair_of).collect();
         pairs.sort();
+        pairs.dedup();
         Ok(pairs)
     }
+}
+
+/// The structural path a link's subject names, when it names one.
+fn subject_path(link: &Link) -> Option<&str> {
+    match &link.subject {
+        Target::Change { path, .. } | Target::Provision(path) => Some(path),
+        _ => None,
+    }
+}
+
+/// The expression pair a link is about, when it is about a change.
+fn pair_of(link: &Link) -> Option<ExpressionPair> {
+    match &link.subject {
+        Target::Change {
+            work,
+            from_date,
+            to_date,
+            ..
+        } => Some((
+            ExpressionId::new(work.clone(), from_date),
+            ExpressionId::new(work.clone(), to_date),
+        )),
+        _ => None,
+    }
+}
+
+fn about_pair(link: &Link, from: &ExpressionId, to: &ExpressionId) -> bool {
+    pair_of(link).is_some_and(|(f, t)| &f == from && &t == to)
 }
 
 impl LegislatureReader for InMemoryStorage {
@@ -363,16 +390,15 @@ impl DocumentWriter for InMemoryStorage {
 }
 
 impl LinkWriter for InMemoryStorage {
-    fn add_annotation(
-        &mut self,
-        from: &ExpressionId,
-        to: &ExpressionId,
-        annotation: ChangeAnnotation,
-    ) -> Result<(), DatasetError> {
-        self.diff_annotations
-            .entry((from.clone(), to.clone()))
-            .or_default()
-            .push(annotation);
+    fn add_link(&mut self, link: Link) -> Result<(), DatasetError> {
+        let id = link.id();
+        // A human's verdict is not overwritten by a machine restating the fact.
+        if let Some(stored) = self.links.get(&id)
+            && stored.provenance.verification.is_human_touched()
+        {
+            return Ok(());
+        }
+        self.links.insert(id, link);
         Ok(())
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -32,6 +32,7 @@ use crate::dataset::{
     DatasetError, DatasetMetadata, Expression, ExpressionId, ExpressionInfo, SearchResult, WorkId,
 };
 use crate::diff::TreeDiff;
+use crate::link::Link;
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
 
@@ -41,8 +42,10 @@ use crate::uslm::bill_parser::Bill;
 /// break. Both on-disk forms carry this number and refuse a file that does not
 /// match, because a break that is not loud reads as an empty dataset.
 ///
-/// 3 is the work-scoped schema: an expression is `(work, date)` with its own
-/// tree, and annotations are keyed by a pair of expressions
+/// 5 stores links directly: one table for every kind, including kinds this
+/// build has never seen, with `ChangeAnnotation` projected out of them rather
+/// than stored (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+/// 4 added the declared scope; 3 was the work-scoped schema
 /// (`docs/adr/0003-storage-is-keyed-by-work.md`).
 ///
 /// One number covering both forms cannot describe a change to only one of
@@ -51,7 +54,7 @@ use crate::uslm::bill_parser::Bill;
 /// bumping this would have rejected valid JSON datasets to fix a SQLite table.
 /// That case is caught where it happens, when the database is opened, rather
 /// than here. A change that alters both forms still belongs to this number.
-pub const SCHEMA_VERSION: i32 = 4;
+pub const SCHEMA_VERSION: i32 = 5;
 
 /// Reading the documents a dataset holds.
 ///
@@ -121,21 +124,73 @@ pub trait DocumentReader {
 /// query by link object, and the bill id is an opaque string here: this trait
 /// does not need to know what a bill is.
 pub trait LinkReader {
-    /// Get annotations recorded for a pair of expressions of one work.
+    /// Every link whose subject names this structural path.
+    fn links_for_path(&self, path: &str) -> Result<Vec<Link>, DatasetError>;
+
+    /// Every link about a change between two expressions of one work.
+    fn links_for_pair(
+        &self,
+        from: &ExpressionId,
+        to: &ExpressionId,
+    ) -> Result<Vec<Link>, DatasetError>;
+
+    /// Every link of one kind, such as `legislature.amended_by`.
+    fn links_by_kind(&self, kind: &str) -> Result<Vec<Link>, DatasetError>;
+
+    /// Every link in one namespace, understood or not.
+    ///
+    /// This is the query a reader uses to report links it cannot interpret,
+    /// which is the whole point of the kind being an open string
+    /// (`docs/adr/0002-links-live-in-the-core.md`).
+    fn links_by_namespace(&self, namespace: &str) -> Result<Vec<Link>, DatasetError>;
+
+    /// Every link whose object reference starts with this prefix.
+    ///
+    /// An amendment reference is `legislature.amendment:<bill>:<amendment>`, so
+    /// a bill's links are a prefix query.
+    fn links_for_object_prefix(&self, prefix: &str) -> Result<Vec<Link>, DatasetError>;
+
+    /// Every expression pair that carries links.
+    fn link_pairs(&self) -> Result<Vec<crate::dataset::ExpressionPair>, DatasetError>;
+
+    // --- Projections ---
+    //
+    // `ChangeAnnotation` is a view of links, the reverse of how it once was.
+    // These are implemented once here rather than per backend: they are the
+    // same regrouping whatever holds the links.
+
+    /// Annotations recorded for a pair of expressions of one work.
     fn get_annotations(
         &self,
         from: &ExpressionId,
         to: &ExpressionId,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError>;
+    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
+        let links = self.links_for_pair(from, to)?;
+        if links.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(crate::link::annotations_from_links(&links)))
+    }
 
-    /// Find all annotations that include the given path (across all pairs)
-    fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError>;
+    /// Every annotation naming this path, across all pairs.
+    fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
+        Ok(crate::link::annotations_from_links(
+            &self.links_for_path(path)?,
+        ))
+    }
 
-    /// Find all annotations from a specific bill (across all pairs)
-    fn annotations_for_bill(&self, bill_id: &str) -> Result<Vec<ChangeAnnotation>, DatasetError>;
+    /// Every annotation from one bill, across all pairs.
+    fn annotations_for_bill(&self, bill_id: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
+        let prefix = format!("legislature.amendment:{bill_id}:");
+        Ok(crate::link::annotations_from_links(
+            &self.links_for_object_prefix(&prefix)?,
+        ))
+    }
 
-    /// List every expression pair that carries annotations
-    fn annotation_pairs(&self) -> Result<Vec<crate::dataset::ExpressionPair>, DatasetError>;
+    /// Every expression pair that carries annotations.
+    fn annotation_pairs(&self) -> Result<Vec<crate::dataset::ExpressionPair>, DatasetError> {
+        self.link_pairs()
+    }
 }
 
 /// Reading the legislature facts a dataset holds.
@@ -183,13 +238,20 @@ pub trait DocumentWriter {
 
 /// Writing links.
 pub trait LinkWriter {
-    /// Add an annotation for a pair of expressions of one work.
-    fn add_annotation(
-        &mut self,
-        from: &ExpressionId,
-        to: &ExpressionId,
-        annotation: ChangeAnnotation,
-    ) -> Result<(), DatasetError>;
+    /// Record one link.
+    ///
+    /// A link is identified by what it says, so writing the same subject, kind,
+    /// and object twice leaves one link. When the stored link has been touched
+    /// by a human — `HumanConfirmed`, `Disputed`, or `Refuted` — its provenance
+    /// survives, and the incoming one is dropped. Otherwise the new provenance
+    /// replaces the old. Without that rule, re-running the pipeline destroys
+    /// human review quietly
+    /// (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+    ///
+    /// There is deliberately no annotation-shaped convenience beside this. Two
+    /// ways to write one fact means the convenient one is used, and the
+    /// convenient one can only express the single kind we own.
+    fn add_link(&mut self, link: Link) -> Result<(), DatasetError>;
 }
 
 /// Writing legislature facts. An extension, like [`LegislatureReader`].

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use rusqlite::{Connection, params};
 
-use crate::annotation::ChangeAnnotation;
 use crate::congress::{BillVotes, HouseRollCall, Member, MemberVote, SponsorInfo, VotePosition};
 use crate::dataset::{
     DatasetError, DatasetMetadata, Expression, ExpressionId, ExpressionInfo, ExpressionPair,
@@ -14,6 +13,7 @@ use crate::dataset::{
 };
 use crate::diff::TreeDiff;
 use crate::intern::StringInterner;
+use crate::link::{Link, LinkKind, Provenance, Target};
 use crate::storage::memory::{ExpressionsByWork, require_same_work};
 use crate::storage::{
     DocumentReader, DocumentWriter, InMemoryStorage, LegislatureReader, LegislatureWriter,
@@ -67,6 +67,112 @@ impl ElementRow<'_> {
             self.ordinal,
         ])?;
         Ok(())
+    }
+}
+
+/// The name of a target's variant, for the tag column.
+fn target_tag(target: &Target) -> &'static str {
+    match target {
+        Target::Provision(_) => "provision",
+        Target::Expression(_) => "expression",
+        Target::Change { .. } => "change",
+        Target::External { .. } => "external",
+    }
+}
+
+/// One row of `links`: the record as JSON, plus the columns promoted out of it.
+///
+/// A struct rather than a tuple because two call sites write these rows — one
+/// link at a time, and the bulk save — and a positional tuple let the two drift
+/// apart without the compiler noticing, the same reason [`ElementRow`] exists.
+struct LinkRow {
+    id: String,
+    kind: String,
+    subject_tag: String,
+    subject_json: String,
+    object_tag: String,
+    object_json: String,
+    provenance_json: String,
+    payload_json: Option<String>,
+    subject_work: Option<String>,
+    subject_path: Option<String>,
+    subject_from_date: Option<String>,
+    subject_to_date: Option<String>,
+    object_reference: Option<String>,
+}
+
+const LINK_INSERT: &str = "INSERT OR REPLACE INTO links \
+     (id, kind, subject_tag, subject_json, object_tag, object_json, provenance_json, \
+      payload_json, subject_work, subject_path, subject_from_date, subject_to_date, \
+      object_reference) \
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)";
+
+impl LinkRow {
+    fn new(id: &str, link: &Link) -> Result<Self, DatasetError> {
+        // Promoted columns, derived from the subject on write. Only a change
+        // and a provision carry a path; only a change carries a pair.
+        let (work, path, from_date, to_date) = match &link.subject {
+            Target::Change {
+                work,
+                path,
+                from_date,
+                to_date,
+            } => (
+                Some(work.to_string()),
+                Some(path.clone()),
+                Some(from_date.clone()),
+                Some(to_date.clone()),
+            ),
+            Target::Provision(path) => (None, Some(path.clone()), None, None),
+            _ => (None, None, None, None),
+        };
+
+        Ok(Self {
+            id: id.to_string(),
+            kind: link.kind.0.clone(),
+            subject_tag: target_tag(&link.subject).to_string(),
+            subject_json: serde_json::to_string(&link.subject)?,
+            object_tag: target_tag(&link.object).to_string(),
+            object_json: serde_json::to_string(&link.object)?,
+            provenance_json: serde_json::to_string(&link.provenance)?,
+            payload_json: link
+                .payload
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()?,
+            subject_work: work,
+            subject_path: path,
+            subject_from_date: from_date,
+            subject_to_date: to_date,
+            object_reference: match &link.object {
+                Target::External { reference, .. } => Some(reference.clone()),
+                _ => None,
+            },
+        })
+    }
+
+    fn bind(&self, stmt: &mut rusqlite::Statement) -> Result<(), DatasetError> {
+        stmt.execute(params![
+            self.id,
+            self.kind,
+            self.subject_tag,
+            self.subject_json,
+            self.object_tag,
+            self.object_json,
+            self.provenance_json,
+            self.payload_json,
+            self.subject_work,
+            self.subject_path,
+            self.subject_from_date,
+            self.subject_to_date,
+            self.object_reference,
+        ])?;
+        Ok(())
+    }
+
+    fn execute(&self, conn: &Connection) -> Result<(), DatasetError> {
+        let mut stmt = conn.prepare(LINK_INSERT)?;
+        self.bind(&mut stmt)
     }
 }
 
@@ -264,39 +370,39 @@ impl SqliteStorage {
                 data_json TEXT NOT NULL
             );
 
-            -- Normalized annotations. Keyed by the work plus the two dates,
-            -- which together name the two expressions the diff ran between.
-            CREATE TABLE IF NOT EXISTS annotations (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                work TEXT NOT NULL,
-                from_date TEXT NOT NULL,
-                to_date TEXT NOT NULL,
-                operation TEXT NOT NULL,
-                bill_id TEXT NOT NULL,
-                amendment_id TEXT NOT NULL,
-                causative_text TEXT NOT NULL,
-                status TEXT NOT NULL,
-                confidence REAL,
-                annotator TEXT NOT NULL,
-                timestamp TEXT NOT NULL,
-                notes TEXT,
-                reasoning TEXT
-            );
-
-            CREATE TABLE IF NOT EXISTS annotation_paths (
-                annotation_id INTEGER NOT NULL,
-                path TEXT NOT NULL,
-                PRIMARY KEY (annotation_id, path),
-                FOREIGN KEY (annotation_id) REFERENCES annotations(id)
+            -- One table for every kind of link, including kinds this build
+            -- has never seen. A schema whose only link table has columns for
+            -- bills can hold exactly one kind, which is the limitation
+            -- docs/adr/0004 exists to remove.
+            CREATE TABLE IF NOT EXISTS links (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                subject_tag TEXT NOT NULL,
+                subject_json TEXT NOT NULL,
+                object_tag TEXT NOT NULL,
+                object_json TEXT NOT NULL,
+                provenance_json TEXT NOT NULL,
+                payload_json TEXT,
+                -- Promoted out of the JSON so the queries LinkReader answers
+                -- can be indexed. The JSON is the record; these are derived
+                -- from it on write and nothing reads them as the truth.
+                subject_work TEXT,
+                subject_path TEXT,
+                subject_from_date TEXT,
+                subject_to_date TEXT,
+                object_reference TEXT
             );
 
             CREATE INDEX IF NOT EXISTS idx_expr_work ON expressions(work);
             -- Finding a path is now a keyed lookup rather than a scan that
             -- deserializes one whole tree per date.
             CREATE INDEX IF NOT EXISTS idx_elem_path ON element_index(path);
-            CREATE INDEX IF NOT EXISTS idx_ann_pair ON annotations(work, from_date, to_date);
-            CREATE INDEX IF NOT EXISTS idx_ann_bill ON annotations(bill_id);
-            CREATE INDEX IF NOT EXISTS idx_ann_paths_path ON annotation_paths(path);
+            -- A namespace is a prefix of a kind, so one index serves both.
+            CREATE INDEX IF NOT EXISTS idx_links_kind ON links(kind);
+            CREATE INDEX IF NOT EXISTS idx_links_subject_path ON links(subject_path);
+            CREATE INDEX IF NOT EXISTS idx_links_pair
+                ON links(subject_work, subject_from_date, subject_to_date);
+            CREATE INDEX IF NOT EXISTS idx_links_object_ref ON links(object_reference);
 
             -- Normalized votes
             CREATE TABLE IF NOT EXISTS roll_calls (
@@ -416,47 +522,14 @@ impl SqliteStorage {
             }
         }
 
-        // Save annotations (normalized)
+        // Save links
         {
-            tx.execute("DELETE FROM annotation_paths", [])?;
-            tx.execute("DELETE FROM annotations", [])?;
-
-            let mut ann_stmt = tx.prepare(
-                "INSERT INTO annotations (work, from_date, to_date, operation, bill_id, amendment_id, causative_text, status, confidence, annotator, timestamp, notes, reasoning) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-            )?;
-            let mut path_stmt =
-                tx.prepare("INSERT INTO annotation_paths (annotation_id, path) VALUES (?1, ?2)")?;
-
-            for ((from, to), annotations) in &storage.diff_annotations {
-                for ann in annotations {
-                    let operation = format!("{:?}", ann.operation);
-                    let status = format!("{:?}", ann.metadata.status);
-                    let timestamp = ann.metadata.timestamp.to_string();
-
-                    ann_stmt.execute(params![
-                        from.work.as_str(),
-                        &from.at,
-                        &to.at,
-                        operation,
-                        &ann.source_bill.bill_id,
-                        &ann.source_bill.amendment_id,
-                        &ann.source_bill.causative_text,
-                        status,
-                        ann.metadata.confidence,
-                        &ann.metadata.annotator,
-                        timestamp,
-                        &ann.metadata.notes,
-                        &ann.metadata.reasoning,
-                    ])?;
-
-                    let ann_id = tx.last_insert_rowid();
-                    for path in &ann.paths {
-                        path_stmt.execute(params![ann_id, path])?;
-                    }
-                }
+            tx.execute("DELETE FROM links", [])?;
+            let mut stmt = tx.prepare(LINK_INSERT)?;
+            for (id, link) in &storage.links {
+                LinkRow::new(id, link)?.bind(&mut stmt)?;
             }
         }
-
         // Save bill_votes (normalized)
         {
             tx.execute("DELETE FROM member_votes", [])?;
@@ -531,9 +604,9 @@ impl SqliteStorage {
         Ok(())
     }
 
-    /// Load a window of two expressions with their annotations
+    /// Load a window of two expressions with the links about them
     ///
-    /// Returns InMemoryStorage with only the specified expressions and their annotations.
+    /// Returns InMemoryStorage with only the specified expressions and their links.
     /// Bills, members, sponsors are NOT loaded - query them from storage as needed.
     pub fn load_window(
         &self,
@@ -549,17 +622,18 @@ impl SqliteStorage {
         by_date.insert(from_e.id.at.clone(), from_e);
         by_date.insert(to_e.id.at.clone(), to_e);
 
-        // Load annotations for this pair only
-        let mut diff_annotations = HashMap::new();
-        if let Some(anns) = self.get_annotations(from, to)? {
-            diff_annotations.insert((from.clone(), to.clone()), anns);
-        }
+        // Load links about this pair only
+        let links = self
+            .links_for_pair(from, to)?
+            .into_iter()
+            .map(|link| (link.id(), link))
+            .collect();
 
         let mut storage = InMemoryStorage::from_parts(
             metadata,
             expressions,
             HashMap::new(), // bills - query from storage
-            diff_annotations,
+            links,
             HashMap::new(), // members - query from storage
             HashMap::new(), // sponsors - query from storage
             HashMap::new(), // bill_votes - query from storage
@@ -577,14 +651,14 @@ impl SqliteStorage {
         let bills = self.load_bills()?;
         let members = self.load_members()?;
         let sponsors = self.load_sponsors()?;
-        let diff_annotations = self.load_annotations()?;
+        let links = self.load_links()?;
         let bill_votes = self.load_bill_votes()?;
 
         let mut storage = InMemoryStorage::from_parts(
             metadata,
             expressions,
             bills,
-            diff_annotations,
+            links,
             members,
             sponsors,
             bill_votes,
@@ -706,109 +780,17 @@ impl SqliteStorage {
         Ok(sponsors)
     }
 
-    fn load_annotations(
-        &self,
-    ) -> Result<HashMap<ExpressionPair, Vec<ChangeAnnotation>>, DatasetError> {
-        use crate::annotation::{AnnotationMetadata, AnnotationStatus, BillReference};
-        use crate::legislature::AmendingAction;
-        use std::str::FromStr;
-
-        // Load all annotations with their paths
-        let mut stmt = self.conn.prepare(
-            "SELECT a.id, a.work, a.from_date, a.to_date, a.operation, a.bill_id, a.amendment_id,
-                    a.causative_text, a.status, a.confidence, a.annotator, a.timestamp,
-                    a.notes, a.reasoning
-             FROM annotations a
-             ORDER BY a.work, a.from_date, a.to_date, a.id",
-        )?;
-        let mut rows = stmt.query([])?;
-
-        let mut annotations: HashMap<ExpressionPair, Vec<ChangeAnnotation>> = HashMap::new();
-        let mut ann_ids: Vec<(i64, ExpressionPair)> = Vec::new();
-
-        while let Some(row) = rows.next()? {
-            let id: i64 = row.get(0)?;
-            let work: String = row.get(1)?;
-            let from_date: String = row.get(2)?;
-            let to_date: String = row.get(3)?;
-            let operation_str: String = row.get(4)?;
-            let bill_id: String = row.get(5)?;
-            let amendment_id: String = row.get(6)?;
-            let causative_text: String = row.get(7)?;
-            let status_str: String = row.get(8)?;
-            let confidence: Option<f32> = row.get(9)?;
-            let annotator: String = row.get(10)?;
-            let timestamp_str: String = row.get(11)?;
-            let notes: Option<String> = row.get(12)?;
-            let reasoning: Option<String> = row.get(13)?;
-
-            let operation =
-                AmendingAction::from_str(&operation_str).unwrap_or(AmendingAction::Amend);
-            let status = match status_str.as_str() {
-                "Verified" => AnnotationStatus::Verified,
-                "Disputed" => AnnotationStatus::Disputed,
-                "Rejected" => AnnotationStatus::Rejected,
-                _ => AnnotationStatus::Pending,
-            };
-            let timestamp = time::OffsetDateTime::parse(
-                &timestamp_str,
-                &time::format_description::well_known::Rfc3339,
-            )
-            .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
-
-            let ann = ChangeAnnotation {
-                operation,
-                source_bill: BillReference {
-                    bill_id,
-                    amendment_id,
-                    causative_text,
-                },
-                paths: Vec::new(), // Fill in below
-                metadata: AnnotationMetadata {
-                    status,
-                    confidence,
-                    annotator,
-                    timestamp,
-                    notes,
-                    reasoning,
-                },
-            };
-
-            let work = WorkId::new(work);
-            let key = (
-                ExpressionId::new(work.clone(), from_date),
-                ExpressionId::new(work, to_date),
-            );
-            annotations.entry(key.clone()).or_default().push(ann);
-            ann_ids.push((id, key));
-        }
-
-        // Load paths for each annotation
-        let mut path_stmt = self
+    /// Every link in the database, by id.
+    fn load_links(&self) -> Result<std::collections::BTreeMap<String, Link>, DatasetError> {
+        let mut stmt = self
             .conn
-            .prepare("SELECT path FROM annotation_paths WHERE annotation_id = ?1")?;
-
-        for (id, key) in ann_ids {
-            let mut path_rows = path_stmt.query(params![id])?;
-            let mut paths = Vec::new();
-            while let Some(row) = path_rows.next()? {
-                let path: String = row.get(0)?;
-                paths.push(path);
-            }
-
-            // Find the annotation and set paths
-            if let Some(anns) = annotations.get_mut(&key) {
-                // Find the annotation with matching id (it's the one with empty paths)
-                for ann in anns.iter_mut() {
-                    if ann.paths.is_empty() {
-                        ann.paths = paths;
-                        break;
-                    }
-                }
-            }
-        }
-
-        Ok(annotations)
+            .prepare(&format!("SELECT {LINK_COLUMNS} FROM links"))?;
+        let links = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>("id")?, link_from_row(row)?))
+            })?
+            .collect::<Result<std::collections::BTreeMap<_, _>, _>>()?;
+        Ok(links)
     }
 
     fn load_bill_votes(&self) -> Result<HashMap<String, BillVotes>, DatasetError> {
@@ -1077,202 +1059,121 @@ impl DocumentReader for SqliteStorage {
     }
 }
 
+/// Rebuild a link from one row of `links`.
+///
+/// The JSON columns are the record. The promoted columns exist only so the
+/// queries can be indexed, and are never read back here.
+fn link_from_row(row: &rusqlite::Row) -> Result<Link, rusqlite::Error> {
+    let subject_json: String = row.get("subject_json")?;
+    let object_json: String = row.get("object_json")?;
+    let provenance_json: String = row.get("provenance_json")?;
+    let payload_json: Option<String> = row.get("payload_json")?;
+    let kind: String = row.get("kind")?;
+
+    // A function rather than a closure: it is called at four different types,
+    // and a closure fixes itself to the first one.
+    fn parse<T: serde::de::DeserializeOwned>(
+        text: &str,
+        column: &str,
+    ) -> Result<T, rusqlite::Error> {
+        serde_json::from_str(text).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::other(format!("{column}: {e}"))),
+            )
+        })
+    }
+
+    Ok(Link {
+        subject: parse(&subject_json, "subject_json")?,
+        kind: LinkKind::new(kind),
+        object: parse(&object_json, "object_json")?,
+        provenance: parse(&provenance_json, "provenance_json")?,
+        payload: match payload_json {
+            Some(text) => Some(parse(&text, "payload_json")?),
+            None => None,
+        },
+    })
+}
+
+impl SqliteStorage {
+    /// Run one link query and collect the rows.
+    fn query_links<P: rusqlite::Params>(
+        &self,
+        sql: &str,
+        params: P,
+    ) -> Result<Vec<Link>, DatasetError> {
+        let mut stmt = self.conn.prepare(sql)?;
+        let links = stmt
+            .query_map(params, link_from_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(links)
+    }
+}
+
+const LINK_COLUMNS: &str =
+    "id, kind, subject_tag, subject_json, object_tag, object_json, provenance_json, payload_json";
+
 impl LinkReader for SqliteStorage {
-    fn get_annotations(
+    fn links_for_path(&self, path: &str) -> Result<Vec<Link>, DatasetError> {
+        self.query_links(
+            &format!("SELECT {LINK_COLUMNS} FROM links WHERE subject_path = ?1"),
+            params![path],
+        )
+    }
+
+    fn links_for_pair(
         &self,
         from: &ExpressionId,
         to: &ExpressionId,
-    ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
-        let all = self.load_annotations()?;
-        let key = (from.clone(), to.clone());
-        Ok(all.get(&key).cloned())
+    ) -> Result<Vec<Link>, DatasetError> {
+        self.query_links(
+            &format!(
+                "SELECT {LINK_COLUMNS} FROM links \
+                 WHERE subject_work = ?1 AND subject_from_date = ?2 AND subject_to_date = ?3"
+            ),
+            params![from.work.as_str(), &from.at, &to.at],
+        )
     }
 
-    fn annotations_for_path(&self, path: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
-        use crate::annotation::{AnnotationMetadata, AnnotationStatus, BillReference};
-        use crate::legislature::AmendingAction;
-        use std::str::FromStr;
-
-        // Find annotation IDs that have this path
-        let mut id_stmt = self
-            .conn
-            .prepare("SELECT DISTINCT annotation_id FROM annotation_paths WHERE path = ?1")?;
-        let mut id_rows = id_stmt.query(params![path])?;
-
-        let mut ann_ids: Vec<i64> = Vec::new();
-        while let Some(row) = id_rows.next()? {
-            ann_ids.push(row.get(0)?);
-        }
-
-        if ann_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Load those annotations
-        let placeholders: String = ann_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-        let query = format!(
-            "SELECT id, from_date, to_date, operation, bill_id, amendment_id, causative_text,
-                    status, confidence, annotator, timestamp, notes, reasoning
-             FROM annotations WHERE id IN ({})",
-            placeholders
-        );
-
-        let mut stmt = self.conn.prepare(&query)?;
-        let mut rows = stmt.query(rusqlite::params_from_iter(ann_ids.iter()))?;
-
-        let mut annotations = Vec::new();
-        let mut loaded_ids = Vec::new();
-
-        while let Some(row) = rows.next()? {
-            let id: i64 = row.get(0)?;
-            let operation_str: String = row.get(3)?;
-            let bill_id: String = row.get(4)?;
-            let amendment_id: String = row.get(5)?;
-            let causative_text: String = row.get(6)?;
-            let status_str: String = row.get(7)?;
-            let confidence: Option<f32> = row.get(8)?;
-            let annotator: String = row.get(9)?;
-            let timestamp_str: String = row.get(10)?;
-            let notes: Option<String> = row.get(11)?;
-            let reasoning: Option<String> = row.get(12)?;
-
-            let operation =
-                AmendingAction::from_str(&operation_str).unwrap_or(AmendingAction::Amend);
-            let status = match status_str.as_str() {
-                "Verified" => AnnotationStatus::Verified,
-                "Disputed" => AnnotationStatus::Disputed,
-                "Rejected" => AnnotationStatus::Rejected,
-                _ => AnnotationStatus::Pending,
-            };
-            let timestamp = time::OffsetDateTime::parse(
-                &timestamp_str,
-                &time::format_description::well_known::Rfc3339,
-            )
-            .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
-
-            annotations.push(ChangeAnnotation {
-                operation,
-                source_bill: BillReference {
-                    bill_id,
-                    amendment_id,
-                    causative_text,
-                },
-                paths: Vec::new(),
-                metadata: AnnotationMetadata {
-                    status,
-                    confidence,
-                    annotator,
-                    timestamp,
-                    notes,
-                    reasoning,
-                },
-            });
-            loaded_ids.push(id);
-        }
-
-        // Load paths for each annotation
-        let mut path_stmt = self
-            .conn
-            .prepare("SELECT path FROM annotation_paths WHERE annotation_id = ?1")?;
-
-        for (ann, id) in annotations.iter_mut().zip(loaded_ids.iter()) {
-            let mut path_rows = path_stmt.query(params![id])?;
-            while let Some(row) = path_rows.next()? {
-                ann.paths.push(row.get(0)?);
-            }
-        }
-
-        Ok(annotations)
+    fn links_by_kind(&self, kind: &str) -> Result<Vec<Link>, DatasetError> {
+        self.query_links(
+            &format!("SELECT {LINK_COLUMNS} FROM links WHERE kind = ?1"),
+            params![kind],
+        )
     }
 
-    fn annotations_for_bill(&self, bill_id: &str) -> Result<Vec<ChangeAnnotation>, DatasetError> {
-        use crate::annotation::{AnnotationMetadata, AnnotationStatus, BillReference};
-        use crate::legislature::AmendingAction;
-        use std::str::FromStr;
+    fn links_by_namespace(&self, namespace: &str) -> Result<Vec<Link>, DatasetError> {
+        // A namespace is the part of a kind before the dot, so the index on
+        // kind answers this too.
+        self.query_links(
+            &format!("SELECT {LINK_COLUMNS} FROM links WHERE kind LIKE ?1"),
+            params![format!("{namespace}.%")],
+        )
+    }
 
+    fn links_for_object_prefix(&self, prefix: &str) -> Result<Vec<Link>, DatasetError> {
+        self.query_links(
+            &format!("SELECT {LINK_COLUMNS} FROM links WHERE object_reference LIKE ?1"),
+            params![format!("{}%", prefix.replace('%', "\\%"))],
+        )
+    }
+
+    fn link_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, from_date, to_date, operation, bill_id, amendment_id, causative_text,
-                    status, confidence, annotator, timestamp, notes, reasoning
-             FROM annotations WHERE bill_id = ?1",
-        )?;
-        let mut rows = stmt.query(params![bill_id])?;
-
-        let mut annotations = Vec::new();
-        let mut loaded_ids = Vec::new();
-
-        while let Some(row) = rows.next()? {
-            let id: i64 = row.get(0)?;
-            let operation_str: String = row.get(3)?;
-            let bill_id: String = row.get(4)?;
-            let amendment_id: String = row.get(5)?;
-            let causative_text: String = row.get(6)?;
-            let status_str: String = row.get(7)?;
-            let confidence: Option<f32> = row.get(8)?;
-            let annotator: String = row.get(9)?;
-            let timestamp_str: String = row.get(10)?;
-            let notes: Option<String> = row.get(11)?;
-            let reasoning: Option<String> = row.get(12)?;
-
-            let operation =
-                AmendingAction::from_str(&operation_str).unwrap_or(AmendingAction::Amend);
-            let status = match status_str.as_str() {
-                "Verified" => AnnotationStatus::Verified,
-                "Disputed" => AnnotationStatus::Disputed,
-                "Rejected" => AnnotationStatus::Rejected,
-                _ => AnnotationStatus::Pending,
-            };
-            let timestamp = time::OffsetDateTime::parse(
-                &timestamp_str,
-                &time::format_description::well_known::Rfc3339,
-            )
-            .unwrap_or(time::OffsetDateTime::UNIX_EPOCH);
-
-            annotations.push(ChangeAnnotation {
-                operation,
-                source_bill: BillReference {
-                    bill_id,
-                    amendment_id,
-                    causative_text,
-                },
-                paths: Vec::new(),
-                metadata: AnnotationMetadata {
-                    status,
-                    confidence,
-                    annotator,
-                    timestamp,
-                    notes,
-                    reasoning,
-                },
-            });
-            loaded_ids.push(id);
-        }
-
-        // Load paths
-        let mut path_stmt = self
-            .conn
-            .prepare("SELECT path FROM annotation_paths WHERE annotation_id = ?1")?;
-
-        for (ann, id) in annotations.iter_mut().zip(loaded_ids.iter()) {
-            let mut path_rows = path_stmt.query(params![id])?;
-            while let Some(row) = path_rows.next()? {
-                ann.paths.push(row.get(0)?);
-            }
-        }
-
-        Ok(annotations)
-    }
-
-    fn annotation_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
-        let mut stmt = self.conn.prepare(
-            "SELECT DISTINCT work, from_date, to_date FROM annotations \
-             ORDER BY work, from_date, to_date",
+            "SELECT DISTINCT subject_work, subject_from_date, subject_to_date FROM links \
+             WHERE subject_work IS NOT NULL \
+             ORDER BY subject_work, subject_from_date, subject_to_date",
         )?;
         let pairs = stmt
             .query_map([], |row| {
-                let work = WorkId::new(row.get::<_, String>(0)?);
+                let work: String = row.get(0)?;
+                let from: String = row.get(1)?;
+                let to: String = row.get(2)?;
                 Ok((
-                    ExpressionId::new(work.clone(), row.get::<_, String>(1)?),
-                    ExpressionId::new(work, row.get::<_, String>(2)?),
+                    ExpressionId::new(WorkId::new(work.clone()), from),
+                    ExpressionId::new(WorkId::new(work), to),
                 ))
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -1450,44 +1351,27 @@ impl DocumentWriter for SqliteStorage {
 }
 
 impl LinkWriter for SqliteStorage {
-    fn add_annotation(
-        &mut self,
-        from: &ExpressionId,
-        to: &ExpressionId,
-        annotation: ChangeAnnotation,
-    ) -> Result<(), DatasetError> {
-        let operation = format!("{:?}", annotation.operation);
-        let status = format!("{:?}", annotation.metadata.status);
-        let timestamp = annotation.metadata.timestamp.to_string();
+    fn add_link(&mut self, link: Link) -> Result<(), DatasetError> {
+        let id = link.id();
 
-        self.conn.execute(
-            "INSERT INTO annotations (work, from_date, to_date, operation, bill_id, amendment_id, causative_text, status, confidence, annotator, timestamp, notes, reasoning) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-            params![
-                from.work.as_str(),
-                &from.at,
-                &to.at,
-                operation,
-                &annotation.source_bill.bill_id,
-                &annotation.source_bill.amendment_id,
-                &annotation.source_bill.causative_text,
-                status,
-                annotation.metadata.confidence,
-                &annotation.metadata.annotator,
-                timestamp,
-                &annotation.metadata.notes,
-                &annotation.metadata.reasoning,
-            ],
-        )?;
-
-        let ann_id = self.conn.last_insert_rowid();
-        for path in &annotation.paths {
-            self.conn.execute(
-                "INSERT INTO annotation_paths (annotation_id, path) VALUES (?1, ?2)",
-                params![ann_id, path],
-            )?;
+        // A human's verdict is not overwritten by a machine restating the fact.
+        let stored: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT provenance_json FROM links WHERE id = ?1",
+                params![&id],
+                |row| row.get(0),
+            )
+            .ok();
+        if let Some(text) = stored
+            && let Ok(provenance) = serde_json::from_str::<Provenance>(&text)
+            && provenance.verification.is_human_touched()
+        {
+            return Ok(());
         }
 
-        Ok(())
+        let row = LinkRow::new(&id, &link)?;
+        row.execute(&self.conn)
     }
 }
 

--- a/tests/dataset_tests.rs
+++ b/tests/dataset_tests.rs
@@ -53,9 +53,12 @@ fn should_serialize_roundtrip_json() {
 
     let annotations = make_annotations();
     for annotation in annotations.into_iter() {
-        dataset
-            .add_annotation(&at("2025-07-18"), &at("2025-07-30"), annotation)
-            .unwrap();
+        store_annotation(
+            &mut dataset,
+            annotation,
+            &at("2025-07-18"),
+            &at("2025-07-30"),
+        );
     }
 
     // Save and load via Compact format (JSON with tuple keys requires file-based roundtrip)
@@ -68,13 +71,34 @@ fn should_serialize_roundtrip_json() {
     assert_eq!(expressions.len(), 2);
     assert_eq!(expressions[0].id, at("2025-07-18"));
     assert_eq!(expressions[0].label, Some("test".to_string()));
+    // Links are what is stored now, and they regroup: one record carries every
+    // path one amendment touched, per asserter. So the record count is no
+    // longer the fixture's 753. What must survive is the *facts* — the distinct
+    // (amendment, path) statements. The fixture's 753 single-path records hold
+    // 718 of them; the other 35 restate one already there, and a link is
+    // identified by what it says, so a restatement updates rather than adds
+    // (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+    let annotations = roundtripped
+        .get_annotations(&at("2025-07-18"), &at("2025-07-30"))
+        .unwrap()
+        .unwrap();
+    let facts: std::collections::HashSet<(String, String)> = annotations
+        .iter()
+        .flat_map(|a| {
+            a.paths
+                .iter()
+                .map(|p| (a.source_bill.amendment_id.clone(), p.clone()))
+        })
+        .collect();
     assert_eq!(
-        roundtripped
-            .get_annotations(&at("2025-07-18"), &at("2025-07-30"))
-            .unwrap()
-            .unwrap()
-            .len(),
-        753
+        facts.len(),
+        718,
+        "every distinct (amendment, path) statement must survive the round trip"
+    );
+    assert_eq!(
+        annotations.len(),
+        317,
+        "one record per amendment per asserter, not one per path"
     );
     assert!(
         roundtripped
@@ -328,9 +352,12 @@ fn should_query_annotations_by_path() {
     let mut dataset = make_test_dataset();
 
     for annotation in make_annotations().into_iter() {
-        dataset
-            .add_annotation(&at("2025-07-18"), &at("2025-07-30"), annotation)
-            .unwrap();
+        store_annotation(
+            &mut dataset,
+            annotation,
+            &at("2025-07-18"),
+            &at("2025-07-30"),
+        );
     }
 
     // Query by path
@@ -338,9 +365,17 @@ fn should_query_annotations_by_path() {
     assert_eq!(found.len(), 2);
     assert_eq!(found[0].source_bill.bill_id, "119-21");
 
-    // Query by bill
+    // Query by bill. Answered from the link's object reference, which now
+    // names the bill as well as the amendment, so the `bill_id` column that
+    // predates the core/extension split is gone.
     let found = dataset.annotations_for_bill("119-21").unwrap();
-    assert_eq!(found.len(), 753);
+    assert_eq!(
+        found.len(),
+        317,
+        "records regroup by amendment and asserter; the whole fixture is one bill"
+    );
+    let paths: usize = found.iter().map(|a| a.paths.len()).sum();
+    assert_eq!(paths, 718, "every distinct statement is still reachable");
 
     // No matches
     let found = dataset
@@ -395,4 +430,20 @@ fn should_search_text_across_expressions() {
     // A hit names the expression it was found in, not a bare date: the date
     // alone cannot say which document the text belongs to.
     assert_eq!(results[0].expression, at("2025-07-18"));
+}
+
+/// Store an annotation the way the pipeline does: one link per path it names.
+///
+/// There is deliberately no writer convenience for this in the library — two
+/// ways to write one fact means the convenient one is used, and it could only
+/// express the single kind we own (`docs/adr/0004`).
+fn store_annotation<S: words_to_data::storage::Storage>(
+    dataset: &mut Dataset<S>,
+    annotation: ChangeAnnotation,
+    from: &ExpressionId,
+    to: &ExpressionId,
+) {
+    for link in words_to_data::link::Link::from_annotation(&annotation, from, to) {
+        dataset.add_link(link).expect("the link should be added");
+    }
 }

--- a/tests/inspect_tests.rs
+++ b/tests/inspect_tests.rs
@@ -71,9 +71,7 @@ fn make_fixture() -> Dataset<InMemoryStorage> {
         },
     };
     let (from, to) = pair();
-    dataset
-        .add_annotation(&from, &to, annotation)
-        .expect("add annotation");
+    store_annotation(&mut dataset, annotation, &from, &to);
     dataset
 }
 
@@ -373,29 +371,28 @@ fn should_pass_validation_for_a_consistent_dataset() {
         .path
         .to_string();
 
-    dataset
-        .add_annotation(
-            &from,
-            &to,
-            ChangeAnnotation {
-                operation: AmendingAction::Amend,
-                source_bill: BillReference {
-                    bill_id: "119-hr-1".to_string(),
-                    amendment_id,
-                    causative_text: "real".to_string(),
-                },
-                paths: vec![real_path],
-                metadata: AnnotationMetadata {
-                    status: AnnotationStatus::Verified,
-                    confidence: None,
-                    annotator: "human:tester".to_string(),
-                    timestamp: time::OffsetDateTime::UNIX_EPOCH,
-                    notes: None,
-                    reasoning: None,
-                },
+    store_annotation(
+        &mut dataset,
+        ChangeAnnotation {
+            operation: AmendingAction::Amend,
+            source_bill: BillReference {
+                bill_id: "119-hr-1".to_string(),
+                amendment_id,
+                causative_text: "real".to_string(),
             },
-        )
-        .expect("add annotation");
+            paths: vec![real_path],
+            metadata: AnnotationMetadata {
+                status: AnnotationStatus::Verified,
+                confidence: None,
+                annotator: "human:tester".to_string(),
+                timestamp: time::OffsetDateTime::UNIX_EPOCH,
+                notes: None,
+                reasoning: None,
+            },
+        },
+        &from,
+        &to,
+    );
 
     let report = inspect::validate(&dataset).expect("validate");
     assert!(
@@ -579,29 +576,28 @@ fn should_account_coverage_against_the_real_diff() {
     assert!(before.unannotated_paths.contains(&target));
 
     // Annotate one real changed path.
-    dataset
-        .add_annotation(
-            &from,
-            &to,
-            ChangeAnnotation {
-                operation: AmendingAction::Amend,
-                source_bill: BillReference {
-                    bill_id: "119-hr-1".to_string(),
-                    amendment_id: "amd".to_string(),
-                    causative_text: "x".to_string(),
-                },
-                paths: vec![target.clone()],
-                metadata: AnnotationMetadata {
-                    status: AnnotationStatus::Pending,
-                    confidence: None,
-                    annotator: "test".to_string(),
-                    timestamp: time::OffsetDateTime::UNIX_EPOCH,
-                    notes: None,
-                    reasoning: None,
-                },
+    store_annotation(
+        &mut dataset,
+        ChangeAnnotation {
+            operation: AmendingAction::Amend,
+            source_bill: BillReference {
+                bill_id: "119-hr-1".to_string(),
+                amendment_id: "amd".to_string(),
+                causative_text: "x".to_string(),
             },
-        )
-        .expect("annotate");
+            paths: vec![target.clone()],
+            metadata: AnnotationMetadata {
+                status: AnnotationStatus::Pending,
+                confidence: None,
+                annotator: "test".to_string(),
+                timestamp: time::OffsetDateTime::UNIX_EPOCH,
+                notes: None,
+                reasoning: None,
+            },
+        },
+        &from,
+        &to,
+    );
 
     // After: that path is covered and drops out of the work queue.
     let after = inspect::coverage(&dataset, &from, &to).expect("coverage");
@@ -641,4 +637,20 @@ fn should_report_identical_info_for_sqlite_backend() {
     // The scope pairs each work with its own dates, and both backends must
     // derive the same pairing.
     assert_eq!(actual.scope.held, expected.scope.held);
+}
+
+/// Store an annotation the way the pipeline does: one link per path it names.
+///
+/// There is deliberately no writer convenience for this in the library — two
+/// ways to write one fact means the convenient one is used, and it could only
+/// express the single kind we own (`docs/adr/0004`).
+fn store_annotation<S: words_to_data::storage::Storage>(
+    dataset: &mut Dataset<S>,
+    annotation: ChangeAnnotation,
+    from: &ExpressionId,
+    to: &ExpressionId,
+) {
+    for link in words_to_data::link::Link::from_annotation(&annotation, from, to) {
+        dataset.add_link(link).expect("the link should be added");
+    }
 }

--- a/tests/link_storage_tests.rs
+++ b/tests/link_storage_tests.rs
@@ -1,0 +1,375 @@
+//! Links as the stored form, not a projection (#70).
+//!
+//! `docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md` records
+//! why a link is shaped and named this way. The fixture is
+//! `tests/test_data/processed/annotations.json`, the output of a real matching
+//! run over the real corpus.
+
+use words_to_data::annotation::ChangeAnnotation;
+use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId};
+use words_to_data::link::{KindPayload, Link, LinkKind, Target, VerificationState};
+
+const ANNOTATIONS: &str = "tests/test_data/processed/annotations.json";
+/// The work the fixture's first annotation belongs to.
+const TITLE_26: &str = "uscode/title_26";
+
+fn real_annotations() -> Vec<ChangeAnnotation> {
+    let json = std::fs::read_to_string(ANNOTATIONS).expect("the fixture should be readable");
+    serde_json::from_str(&json).expect("the fixture should parse as annotations")
+}
+
+fn pair() -> (ExpressionId, ExpressionId) {
+    (
+        ExpressionId::new(WorkId::new(TITLE_26), "2025-07-18"),
+        ExpressionId::new(WorkId::new(TITLE_26), "2025-07-30"),
+    )
+}
+
+/// The first fixture annotation, which touches title 26.
+fn title_26_annotation() -> ChangeAnnotation {
+    real_annotations()
+        .into_iter()
+        .find(|a| a.paths.iter().any(|p| p.starts_with(TITLE_26)))
+        .expect("the fixture should hold a title 26 annotation")
+}
+
+#[test]
+fn should_make_a_change_the_subject_of_an_amendment_link() {
+    let annotation = title_26_annotation();
+    let (from, to) = pair();
+
+    let links = Link::from_annotation(&annotation, &from, &to);
+    let link = links.first().expect("at least one link");
+
+    // A bare provision cannot say *when* it was amended, so the pair was
+    // dropped and `get_annotations(from, to)` had nothing to answer from.
+    match &link.subject {
+        Target::Change {
+            work,
+            path,
+            from_date,
+            to_date,
+        } => {
+            assert_eq!(work.as_str(), TITLE_26);
+            assert!(annotation.paths.contains(path));
+            assert_eq!(from_date, "2025-07-18");
+            assert_eq!(to_date, "2025-07-30");
+        }
+        other => panic!("the subject should name a change, got {other:?}"),
+    }
+}
+
+#[test]
+fn should_identify_a_link_by_what_it_says_rather_than_by_who_said_it() {
+    let annotation = title_26_annotation();
+    let (from, to) = pair();
+    let link = Link::from_annotation(&annotation, &from, &to)
+        .into_iter()
+        .next()
+        .expect("at least one link");
+
+    // Restating a fact a machine already stated must update one link, not grow
+    // the table. That is what makes a rebuild idempotent.
+    let mut restated = link.clone();
+    restated.provenance.source = "human:jesse".to_string();
+    restated.provenance.verification = VerificationState::HumanConfirmed;
+    assert_eq!(
+        link.id(),
+        restated.id(),
+        "provenance is who said it, not what was said"
+    );
+
+    let mut other_object = link.clone();
+    other_object.object = Target::External {
+        reference: "legislature.amendment:119-21:something-else".to_string(),
+        display: "a different amendment".to_string(),
+    };
+    assert_ne!(
+        link.id(),
+        other_object.id(),
+        "a different object is a different statement"
+    );
+}
+
+#[test]
+fn should_carry_the_bill_in_the_amendment_reference() {
+    let annotation = title_26_annotation();
+    let (from, to) = pair();
+
+    let links = Link::from_annotation(&annotation, &from, &to);
+    let link = links.first().expect("at least one link");
+
+    // A reader that does not know the legislature extension must still be able
+    // to resolve what the reference points at. The amendment id alone needed a
+    // separate `bill_id` column to be useful, which is cruft from before the
+    // core and the extensions were separated.
+    match &link.object {
+        Target::External { reference, .. } => {
+            assert!(
+                reference.contains(&annotation.source_bill.bill_id),
+                "the reference should name the bill, got {reference}"
+            );
+            assert!(
+                reference.contains(&annotation.source_bill.amendment_id),
+                "the reference should name the amendment, got {reference}"
+            );
+        }
+        other => panic!("an amendment is reached as an external reference, got {other:?}"),
+    }
+}
+
+#[test]
+fn should_keep_the_time_a_statement_was_made_in_its_provenance() {
+    let annotation = title_26_annotation();
+    let (from, to) = pair();
+
+    let links = Link::from_annotation(&annotation, &from, &to);
+    let link = links.first().expect("at least one link");
+
+    // Every statement has a when. It is core provenance, not a kind payload:
+    // a reader that cannot read the payload still needs it to judge the link.
+    assert_eq!(
+        link.provenance.timestamp,
+        Some(annotation.metadata.timestamp),
+        "the annotation's timestamp should survive as provenance"
+    );
+}
+
+#[test]
+fn should_carry_kind_specific_facts_in_a_payload_the_core_does_not_read() {
+    let annotation = title_26_annotation();
+    let (from, to) = pair();
+
+    let links = Link::from_annotation(&annotation, &from, &to);
+    let link = links.first().expect("at least one link");
+
+    // The amending action is a legislature concept. It used to be crammed into
+    // `Provenance.method` as a `Debug` string, which round-tripped only because
+    // the enum happens to carry no data.
+    let payload = link
+        .payload
+        .as_ref()
+        .expect("an amendment link carries legislature facts");
+    assert_eq!(payload.namespace, "legislature");
+    assert!(
+        payload.value.get("operation").is_some(),
+        "the amending action belongs to the payload, got {:?}",
+        payload.value
+    );
+}
+
+// --- Storage ---
+
+use words_to_data::storage::{InMemoryStorage, LinkReader};
+
+const UNKNOWN_KIND_LINKS: &str = "tests/test_data/processed/unknown_kind_links.json";
+const TITLE_9_XML: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
+
+/// Links of a kind this build does not define, over real corpus paths.
+fn unknown_kind_links() -> Vec<Link> {
+    let json = std::fs::read_to_string(UNKNOWN_KIND_LINKS).expect("the fixture should be readable");
+    serde_json::from_str(&json).expect("the fixture should parse as links")
+}
+
+fn empty_dataset() -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Link storage fixture".to_string(),
+        ..Default::default()
+    });
+    dataset
+        .add_uslm_xml(TITLE_9_XML, "2025-07-18", None)
+        .expect("title 9 should parse");
+    dataset
+}
+
+/// Round-trip a dataset through SQLite so both backends are exercised.
+fn through_sqlite(
+    dataset: &Dataset<InMemoryStorage>,
+    name: &str,
+) -> Dataset<words_to_data::storage::SqliteStorage> {
+    let dir = std::path::Path::new("target/link_storage_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let file = dir.join(format!("{name}.sqlite"));
+    std::fs::remove_file(&file).ok();
+    dataset.save_to_sqlite(&file).expect("save to sqlite");
+    Dataset::open_sqlite(&file).expect("open sqlite")
+}
+
+#[test]
+fn should_carry_a_link_of_a_kind_this_build_has_never_seen() {
+    let fixture = unknown_kind_links();
+    let mut dataset = empty_dataset();
+    for link in fixture.clone() {
+        dataset.add_link(link).expect("the link should be stored");
+    }
+
+    for (label, stored) in [
+        ("memory", dataset.links_by_namespace("westlaw").unwrap()),
+        (
+            "sqlite",
+            through_sqlite(&dataset, "unknown_kind")
+                .links_by_namespace("westlaw")
+                .unwrap(),
+        ),
+    ] {
+        // A reader that does not understand `westlaw.headnote` must still find
+        // it, report it, and hand it back byte-identical. Silent loss is the
+        // one failure a portable format cannot have.
+        assert_eq!(
+            stored.len(),
+            fixture.len(),
+            "{label} should hold both links"
+        );
+        for expected in &fixture {
+            let found = stored
+                .iter()
+                .find(|l| l.id() == expected.id())
+                .unwrap_or_else(|| panic!("{label} lost a link"));
+            assert_eq!(
+                found, expected,
+                "{label} changed a link it does not understand"
+            );
+        }
+    }
+}
+
+#[test]
+fn should_leave_one_link_when_the_same_statement_is_written_twice() {
+    let link = unknown_kind_links().remove(0);
+    let mut dataset = empty_dataset();
+
+    dataset.add_link(link.clone()).expect("first write");
+    let mut restated = link.clone();
+    restated.provenance.source = "westlaw:reimport".to_string();
+    dataset.add_link(restated).expect("second write");
+
+    let stored = dataset.links_by_namespace("westlaw").unwrap();
+    assert_eq!(
+        stored.len(),
+        1,
+        "restating a fact updates one link rather than growing the table"
+    );
+    assert_eq!(
+        stored[0].provenance.source, "westlaw:reimport",
+        "the newer provenance wins when nobody has judged the link"
+    );
+}
+
+#[test]
+fn should_keep_a_human_verdict_when_a_machine_restates_the_fact() {
+    let mut confirmed = unknown_kind_links().remove(0);
+    confirmed.provenance.source = "human:jesse".to_string();
+    confirmed.provenance.verification = VerificationState::HumanConfirmed;
+
+    let mut dataset = empty_dataset();
+    dataset.add_link(confirmed.clone()).expect("human write");
+
+    let mut machine = confirmed.clone();
+    machine.provenance.source = "model:local".to_string();
+    machine.provenance.verification = VerificationState::MachineSuggested;
+    dataset.add_link(machine).expect("machine write");
+
+    // Re-running the pipeline must not destroy human review. The loss would be
+    // invisible until somebody looked for a confirmation that was gone.
+    let stored = dataset.links_by_namespace("westlaw").unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(
+        stored[0].provenance.verification,
+        VerificationState::HumanConfirmed
+    );
+    assert_eq!(stored[0].provenance.source, "human:jesse");
+}
+
+#[test]
+fn should_keep_both_links_when_two_amendments_cause_one_change() {
+    let base = unknown_kind_links().remove(0);
+    let mut second = base.clone();
+    second.object = Target::External {
+        reference: "westlaw.headnote:9999".to_string(),
+        display: "A different headnote".to_string(),
+    };
+
+    let mut dataset = empty_dataset();
+    dataset.add_link(base).expect("first");
+    dataset.add_link(second).expect("second");
+
+    // Same subject, same kind, different object. Several statements about one
+    // change are all real, so the table carries no uniqueness on subject+kind.
+    assert_eq!(dataset.links_by_namespace("westlaw").unwrap().len(), 2);
+}
+
+#[test]
+fn should_find_links_by_kind_and_by_the_path_they_are_about() {
+    let fixture = unknown_kind_links();
+    let mut dataset = empty_dataset();
+    for link in fixture.clone() {
+        dataset.add_link(link).expect("stored");
+    }
+    let sqlite = through_sqlite(&dataset, "queries");
+
+    let Target::Change { path, .. } = &fixture[0].subject else {
+        panic!("the fixture's subject is a change");
+    };
+
+    for (label, by_kind, by_path, by_other_kind) in [
+        (
+            "memory",
+            dataset.links_by_kind("westlaw.headnote").unwrap(),
+            dataset.links_for_path(path).unwrap(),
+            dataset.links_by_kind(LinkKind::AMENDED_BY).unwrap(),
+        ),
+        (
+            "sqlite",
+            sqlite.links_by_kind("westlaw.headnote").unwrap(),
+            sqlite.links_for_path(path).unwrap(),
+            sqlite.links_by_kind(LinkKind::AMENDED_BY).unwrap(),
+        ),
+    ] {
+        assert_eq!(by_kind.len(), 2, "{label} by kind");
+        assert_eq!(by_path.len(), 1, "{label} by path");
+        assert!(
+            by_other_kind.is_empty(),
+            "{label} should not answer a kind it holds none of"
+        );
+    }
+}
+
+#[test]
+fn should_report_no_annotations_for_a_dataset_of_links_it_does_not_own() {
+    let mut dataset = empty_dataset();
+    for link in unknown_kind_links() {
+        dataset.add_link(link).expect("stored");
+    }
+
+    // A `westlaw.headnote` is not a change annotation. The projection is a
+    // legislature-shaped view, and must not claim links of another kind.
+    let pair = pair();
+    assert!(
+        dataset
+            .get_annotations(&pair.0, &pair.1)
+            .unwrap()
+            .unwrap_or_default()
+            .is_empty()
+    );
+}
+
+#[test]
+fn should_carry_an_unreadable_payload_through_storage_untouched() {
+    let mut link = unknown_kind_links().remove(0);
+    link.payload = Some(KindPayload {
+        namespace: "westlaw".to_string(),
+        value: serde_json::json!({
+            "nested": {"a": [1, 2, {"b": null}]},
+            "unicode": "§ 174 — “quoted”",
+        }),
+    });
+    let expected = link.payload.clone();
+
+    let mut dataset = empty_dataset();
+    dataset.add_link(link).expect("stored");
+    let sqlite = through_sqlite(&dataset, "payload");
+
+    // The core stores it, hands it back unchanged, and never reads it.
+    let stored = sqlite.links_by_namespace("westlaw").unwrap();
+    assert_eq!(stored[0].payload, expected);
+}

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -4,10 +4,23 @@
 //! real matching run, not invented data.
 
 use words_to_data::annotation::{AnnotationStatus, ChangeAnnotation};
+use words_to_data::dataset::{ExpressionId, WorkId};
 use words_to_data::diff::AmendmentSimilarity;
 use words_to_data::link::{Corroboration, Link, LinkKind, Target, VerificationState};
 
 const ANNOTATIONS: &str = "tests/test_data/processed/annotations.json";
+
+/// The pair the fixture's annotations sit between.
+///
+/// A link's subject is a change, and a change is not addressable without the
+/// dates it changed between, so the projection now needs the pair.
+fn from() -> ExpressionId {
+    ExpressionId::new(WorkId::new("uscode/title_26"), "2025-07-18")
+}
+
+fn to() -> ExpressionId {
+    ExpressionId::new(WorkId::new("uscode/title_26"), "2025-07-30")
+}
 
 fn real_annotations() -> Vec<ChangeAnnotation> {
     let json = std::fs::read_to_string(ANNOTATIONS).expect("the fixture should be readable");
@@ -19,7 +32,7 @@ fn should_project_a_stored_annotation_into_one_link_per_path() {
     let annotations = real_annotations();
     let annotation = annotations.first().expect("the fixture should hold some");
 
-    let links = Link::from_annotation(annotation);
+    let links = Link::from_annotation(annotation, &from(), &to());
 
     assert_eq!(
         links.len(),
@@ -30,10 +43,18 @@ fn should_project_a_stored_annotation_into_one_link_per_path() {
     let link = links.first().expect("at least one link");
     assert_eq!(link.kind, LinkKind::new(LinkKind::AMENDED_BY));
     assert_eq!(link.kind.namespace(), "legislature");
+    // The subject is the *change*, not the provision. A bare provision cannot
+    // say when it was amended, so the expression pair had nowhere to live and
+    // was silently dropped (#70, `docs/adr/0004`).
     assert_eq!(
         link.subject,
-        Target::Provision(annotation.paths[0].clone()),
-        "the subject is the provision that changed"
+        Target::Change {
+            work: from().work.clone(),
+            path: annotation.paths[0].clone(),
+            from_date: from().at.clone(),
+            to_date: to().at.clone(),
+        },
+        "the subject is the change, which is the provision plus its two dates"
     );
 }
 
@@ -45,7 +66,7 @@ fn should_reach_the_amendment_as_an_external_reference() {
     let annotations = real_annotations();
     let annotation = annotations.first().expect("the fixture should hold some");
 
-    let links = Link::from_annotation(annotation);
+    let links = Link::from_annotation(annotation, &from(), &to());
     let link = links.first().expect("at least one link");
 
     match &link.object {
@@ -81,7 +102,7 @@ fn should_mark_unreviewed_model_output_as_machine_suggested() {
     );
 
     for annotation in from_model {
-        for link in Link::from_annotation(annotation) {
+        for link in Link::from_annotation(annotation, &from(), &to()) {
             assert_eq!(
                 link.provenance.verification,
                 VerificationState::MachineSuggested
@@ -108,12 +129,12 @@ fn should_mark_a_rejected_annotation_as_refuted_rather_than_disputed() {
         .expect("the fixture should hold some");
 
     annotation.metadata.status = AnnotationStatus::Rejected;
-    for link in Link::from_annotation(&annotation) {
+    for link in Link::from_annotation(&annotation, &from(), &to()) {
         assert_eq!(link.provenance.verification, VerificationState::Refuted);
     }
 
     annotation.metadata.status = AnnotationStatus::Disputed;
-    for link in Link::from_annotation(&annotation) {
+    for link in Link::from_annotation(&annotation, &from(), &to()) {
         assert_eq!(
             link.provenance.verification,
             VerificationState::Disputed,
@@ -130,7 +151,7 @@ fn should_carry_corroboration_without_raising_the_verification_state() {
     let annotations = real_annotations();
     let annotation = annotations.first().expect("the fixture should hold some");
 
-    let link = Link::from_annotation(annotation)
+    let link = Link::from_annotation(annotation, &from(), &to())
         .into_iter()
         .next()
         .expect("at least one link")
@@ -212,7 +233,7 @@ fn should_carry_the_models_reasoning_as_evidence() {
     );
 
     for annotation in with_reasoning {
-        for link in Link::from_annotation(annotation) {
+        for link in Link::from_annotation(annotation, &from(), &to()) {
             let evidence = link
                 .provenance
                 .evidence

--- a/tests/sqlite_tests.rs
+++ b/tests/sqlite_tests.rs
@@ -119,9 +119,12 @@ fn should_roundtrip_bills_and_annotations_sqlite() {
 
     // Add annotations
     for annotation in load_annotations() {
-        dataset
-            .add_annotation(&at("2025-07-18"), &at("2025-07-30"), annotation)
-            .unwrap();
+        store_annotation(
+            &mut dataset,
+            annotation,
+            &at("2025-07-18"),
+            &at("2025-07-30"),
+        );
     }
 
     let path = "/tmp/test_dataset_full.db";
@@ -134,12 +137,16 @@ fn should_roundtrip_bills_and_annotations_sqlite() {
     let loaded_bill = loaded.get_bill("119-21").unwrap().unwrap();
     assert_eq!(loaded_bill.bill_id, "119-21");
 
-    // Verify annotations
+    // Verify annotations. Links regroup by amendment and asserter, so one
+    // record now carries every path that amendment touched; the fixture's 753
+    // single-path records hold 718 distinct (amendment, path) statements.
     let anns = loaded
         .get_annotations(&at("2025-07-18"), &at("2025-07-30"))
         .unwrap()
         .unwrap();
-    assert_eq!(anns.len(), 753);
+    assert_eq!(anns.len(), 317);
+    let paths: usize = anns.iter().map(|a| a.paths.len()).sum();
+    assert_eq!(paths, 718, "every statement must survive the round trip");
 
     std::fs::remove_file(path).ok();
 }
@@ -196,9 +203,12 @@ fn should_query_via_trait_interface() {
     dataset.add_bill(bill).unwrap();
 
     for annotation in load_annotations() {
-        dataset
-            .add_annotation(&at("2025-07-18"), &at("2025-07-30"), annotation)
-            .unwrap();
+        store_annotation(
+            &mut dataset,
+            annotation,
+            &at("2025-07-18"),
+            &at("2025-07-30"),
+        );
     }
 
     let path = "/tmp/test_trait_query.db";
@@ -222,12 +232,14 @@ fn should_query_via_trait_interface() {
         let bill = reader.get_bill("119-21").unwrap().unwrap();
         assert_eq!(bill.bill_id, "119-21");
 
-        // get_annotations
+        // get_annotations, projected out of the stored links
         let anns = reader
             .get_annotations(&at("2025-07-18"), &at("2025-07-30"))
             .unwrap()
             .unwrap();
-        assert_eq!(anns.len(), 753);
+        assert_eq!(anns.len(), 317);
+        let paths: usize = anns.iter().map(|a| a.paths.len()).sum();
+        assert_eq!(paths, 718);
 
         // compute_diff
         let diff = reader
@@ -268,12 +280,18 @@ fn should_load_window_with_two_expressions() {
         .unwrap();
 
     for annotation in load_annotations() {
-        dataset
-            .add_annotation(&at("2024-01-01"), &at("2024-06-01"), annotation.clone())
-            .unwrap();
-        dataset
-            .add_annotation(&at("2024-06-01"), &at("2024-12-01"), annotation)
-            .unwrap();
+        store_annotation(
+            &mut dataset,
+            annotation.clone(),
+            &at("2024-01-01"),
+            &at("2024-06-01"),
+        );
+        store_annotation(
+            &mut dataset,
+            annotation,
+            &at("2024-06-01"),
+            &at("2024-12-01"),
+        );
     }
 
     let path = "/tmp/test_load_window.db";
@@ -294,16 +312,19 @@ fn should_load_window_with_two_expressions() {
         vec![at("2024-01-01"), at("2024-06-01")]
     );
 
-    // Should have annotations for that pair only
-    assert!(
-        windowed
-            .diff_annotations
-            .contains_key(&(at("2024-01-01"), at("2024-06-01")))
-    );
+    // Should have links about that pair only
+    use words_to_data::storage::LinkReader;
     assert!(
         !windowed
-            .diff_annotations
-            .contains_key(&(at("2024-06-01"), at("2024-12-01")))
+            .links_for_pair(&at("2024-01-01"), &at("2024-06-01"))
+            .expect("links should read")
+            .is_empty()
+    );
+    assert!(
+        windowed
+            .links_for_pair(&at("2024-06-01"), &at("2024-12-01"))
+            .expect("links should read")
+            .is_empty()
     );
 
     // Bills/members/sponsors should be empty (query from storage when needed)
@@ -323,9 +344,12 @@ fn should_query_annotations_for_path_via_trait() {
         .unwrap();
 
     for annotation in load_annotations() {
-        dataset
-            .add_annotation(&at("2025-07-18"), &at("2025-07-30"), annotation)
-            .unwrap();
+        store_annotation(
+            &mut dataset,
+            annotation,
+            &at("2025-07-18"),
+            &at("2025-07-30"),
+        );
     }
 
     let path = "/tmp/test_ann_path.db";
@@ -347,4 +371,20 @@ fn should_query_annotations_for_path_via_trait() {
     check_annotations_for_path(&storage);
 
     std::fs::remove_file(path).ok();
+}
+
+/// Store an annotation the way the pipeline does: one link per path it names.
+///
+/// There is deliberately no writer convenience for this in the library — two
+/// ways to write one fact means the convenient one is used, and it could only
+/// express the single kind we own (`docs/adr/0004`).
+fn store_annotation<S: words_to_data::storage::Storage>(
+    dataset: &mut Dataset<S>,
+    annotation: ChangeAnnotation,
+    from: &ExpressionId,
+    to: &ExpressionId,
+) {
+    for link in words_to_data::link::Link::from_annotation(&annotation, from, to) {
+        dataset.add_link(link).expect("the link should be added");
+    }
 }

--- a/tests/test_data/processed/unknown_kind_links.json
+++ b/tests/test_data/processed/unknown_kind_links.json
@@ -1,0 +1,88 @@
+[
+  {
+    "subject": {
+      "change": {
+        "work": "uscode/title_26",
+        "path": "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_163/subsection_j/paragraph_8/subparagraph_A/clause_v",
+        "from_date": "2025-07-18",
+        "to_date": "2025-07-30"
+      }
+    },
+    "kind": "westlaw.headnote",
+    "object": {
+      "external": {
+        "reference": "westlaw.headnote:4200",
+        "display": "Headnote 4200"
+      }
+    },
+    "provenance": {
+      "source": "westlaw:import",
+      "method": "third-party enrichment",
+      "verification": "asserted",
+      "evidence": null,
+      "raw_score": null,
+      "timestamp": [
+        1970,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "corroboration": null
+    },
+    "payload": {
+      "namespace": "westlaw",
+      "value": {
+        "key_number": 220,
+        "topic": "Taxation"
+      }
+    }
+  },
+  {
+    "subject": {
+      "change": {
+        "work": "uscode/title_26",
+        "path": "uscode/title_26/subtitle_A/chapter_1/subchapter_A/part_IV/subpart_E/section_48/subsection_a/paragraph_2",
+        "from_date": "2025-07-18",
+        "to_date": "2025-07-30"
+      }
+    },
+    "kind": "westlaw.headnote",
+    "object": {
+      "external": {
+        "reference": "westlaw.headnote:4201",
+        "display": "Headnote 4201"
+      }
+    },
+    "provenance": {
+      "source": "westlaw:import",
+      "method": "third-party enrichment",
+      "verification": "asserted",
+      "evidence": null,
+      "raw_score": null,
+      "timestamp": [
+        1970,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "corroboration": null
+    },
+    "payload": {
+      "namespace": "westlaw",
+      "value": {
+        "key_number": 220,
+        "topic": "Taxation"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Closes #70. (PRs into `vibes` do not auto-close, so #70 needs closing by hand after merge.)

Second of the three breaking changes in this window. #71 is merged; #58 follows. Implements the brief on #70 and the decisions in `docs/adr/0004`, merged separately as `d1a2d0b`.

## What was wrong

`Link` existed but nothing stored one — `Link::from_annotation` built links out of the `annotations` tables as they were asked for. A schema whose only link table has columns for `bill_id` and `amendment_id` holds exactly one kind, so ADR 0002's promise (another party defines `westlaw.headnote`, our reader carries it) could not be kept by the storage beneath it.

## Why the inversion needed model changes first

The old projection was **lossy**, so "`ChangeAnnotation` becomes a projection out of links" was not achievable as written:

| Dropped | Now |
| --- | --- |
| the expression pair | `Target::Change { work, path, from_date, to_date }` |
| `bill_id` | fully-qualified `legislature.amendment:<bill>:<amendment>` |
| `timestamp` | `Provenance.timestamp` |
| `notes`, `operation` | the kind payload |

## Storage

One `links` table. Kind is text, never an enum. Targets are a variant tag beside the whole value as JSON, with `kind` and the subject's work, path, and dates promoted to indexed columns — a denormalised index of the JSON, derived on write, with the JSON as the record.

`links_for_object_prefix` is one query beyond what ADR 0004 listed. `annotations_for_bill` has to stay indexed, and with the reference now fully qualified a bill's links are a prefix query. Flagging it as a small extension of the ADR's "promote what you query" rule.

The four annotation queries are **default methods on `LinkReader`**, implemented once over the link queries rather than per backend.

## Two rules worth review

**A human-touched provenance survives a machine re-write.** Without it, re-running the pipeline destroys human review silently. This has its own test, and I mutated both backends to drop the guard to confirm the test actually fails.

**The record count changes, deliberately.** Links regroup by `(amendment, pair, source)`, so one record now carries every path an amendment touched. The fixture's 753 single-path annotations hold **718 distinct (amendment, path) statements** and regroup into **317 records**; the other 35 restate a fact already present, and a link is identified by what it says, so a restatement updates rather than adds.

I verified this against the fixture rather than assuming: `distinct (amendment, path) = 718`, `distinct (amendment, annotator) = 317`. The updated tests assert the **statements** survive, not the old record count. `annotations_for_path` for a path touched by two different amendments still returns 2 — the grouping key includes the amendment, exactly as you noted during grilling.

## Tests

**287 passed, 7 ignored, 0 failed**, against a baseline of 275 / 7. Clippy and fmt clean.

Twelve new tests. The unknown-kind fixture is `tests/test_data/processed/unknown_kind_links.json` — **generated from the real corpus** (its paths come from the real annotations fixture) and committed as readable JSON. Only the kind is one we do not own.

Covered: a `westlaw.headnote` link written, read back byte-identical, and listed on **both backends**; an opaque payload with nesting and unicode surviving storage untouched; the same statement written twice leaving one link; a human verdict surviving a machine re-write; two links sharing a subject and kind but differing in object both persisting; `links_by_kind` / `links_for_path` / `links_by_namespace`; and the projection refusing to report a `westlaw.headnote` as a change annotation.

The first five tests were RED before the model existed. The storage tests were written after, so I mutated the human-wins guard in both backends and confirmed the right test fails.

## Scope

`match-amendments` builds links directly — the change that proves the design. `SCHEMA_VERSION` 3 → 5 across this window (4 was #71), each bump separate so a dataset built between merges cannot claim a shape it does not have.

Not touched, per the brief: the verbatim model reply (#58, next), producing `judicial.cites` (#52/#53 — this can *store* one), provision identity (#93), and a provenance list on one link (ADR 0004 records why it was rejected and what would reopen it).