### PR TITLE
feat: keep the verbatim model reply as evidence

### DIFF
--- a/src/bin/words_to_data/extract_changes.rs
+++ b/src/bin/words_to_data/extract_changes.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use clap::Args as ClapArgs;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use words_to_data::dataset::{Dataset, Format};
 use words_to_data::legislature::BillDiff;
 
@@ -42,6 +42,33 @@ pub struct Args {
     /// Where to write the enriched dataset (defaults to overwriting the input)
     #[arg(long)]
     pub output: Option<String>,
+}
+
+/// One amendment's cached extraction.
+///
+/// Untagged so a cache written before replies were recorded still loads: it is
+/// a cache, not a record, and forcing a re-extraction of everything to add a
+/// field nobody had yet would be a poor trade.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum Cached {
+    /// The current form: what was parsed, and what the model actually said.
+    WithReply {
+        changes: Vec<BillDiff>,
+        reply: String,
+        prompt_hash: String,
+    },
+    /// Written before replies were recorded. Usable, but carries no evidence.
+    ChangesOnly(Vec<BillDiff>),
+}
+
+impl Cached {
+    fn changes(&self) -> &[BillDiff] {
+        match self {
+            Self::WithReply { changes, .. } => changes,
+            Self::ChangesOnly(changes) => changes,
+        }
+    }
 }
 
 /// One amendment queued for LLM extraction.
@@ -105,7 +132,7 @@ pub fn run(args: Args) {
     );
 
     if !todo.is_empty() {
-        let llm = LlmClient::new(args.base_url, args.model, None);
+        let llm = LlmClient::new(args.base_url.clone(), args.model.clone(), None);
         // The cache is updated and flushed to disk after every successful call so
         // an interrupted run can be resumed without losing completed extractions.
         let shared = Mutex::new(cache);
@@ -114,13 +141,51 @@ pub fn run(args: Args) {
     }
 
     // Apply cached changes for every amendment not already populated.
-    for (amendment_id, changes) in &cache {
+    let model_name = if args.model.is_empty() {
+        "local".to_string()
+    } else {
+        args.model.clone()
+    };
+    for (amendment_id, cached) in &cache {
         if done.contains(amendment_id) {
             continue;
         }
-        for change in changes {
+        for change in cached.changes() {
             dataset.add_changes_to_amendment(amendment_id, change);
         }
+
+        // The amending text is a fact from the bill; these word-level changes
+        // are a model's reading of it. Recording the evidence without the
+        // verification state would read as corroboration for a machine guess.
+        let evidence = match cached {
+            Cached::WithReply {
+                reply, prompt_hash, ..
+            } => {
+                let reply_id = crate::fail::or_exit(
+                    dataset.add_reply(reply),
+                    "Error recording the model reply",
+                );
+                Some(words_to_data::link::Evidence {
+                    reasoning: None,
+                    reply: Some(reply_id),
+                    model: Some(model_name.clone()),
+                    prompt_hash: Some(prompt_hash.clone()),
+                })
+            }
+            Cached::ChangesOnly(_) => None,
+        };
+        dataset.set_amendment_provenance(
+            amendment_id,
+            words_to_data::link::Provenance {
+                source: format!("model:{model_name}"),
+                method: Some("extract-changes".to_string()),
+                verification: words_to_data::link::VerificationState::MachineSuggested,
+                evidence,
+                raw_score: None,
+                timestamp: Some(time::OffsetDateTime::now_utc()),
+                corroboration: None,
+            },
+        );
     }
 
     let output = args.output.as_deref().unwrap_or(&args.dataset);
@@ -140,7 +205,7 @@ fn extract_all(
     llm: &LlmClient,
     tasks: &[Task],
     threads: usize,
-    cache: &Mutex<HashMap<String, Vec<BillDiff>>>,
+    cache: &Mutex<HashMap<String, Cached>>,
     cache_path: &Path,
 ) {
     let next = AtomicUsize::new(0);
@@ -155,11 +220,11 @@ fn extract_all(
                     let Some(task) = tasks.get(i) else { break };
 
                     match extract_changes(llm, &task.amending_text) {
-                        Ok(changes) => {
+                        Ok(cached) => {
                             // Insert and persist while holding the lock so the on-disk
                             // cache is always consistent with in-memory state.
                             let mut guard = cache.lock().unwrap();
-                            guard.insert(task.amendment_id.clone(), changes);
+                            guard.insert(task.amendment_id.clone(), cached);
                             write_cache(cache_path, &guard);
                         }
                         Err(err) => {
@@ -176,7 +241,11 @@ fn extract_all(
 }
 
 /// Query the LLM for one amendment and parse its `<response>` payload.
-fn extract_changes(llm: &LlmClient, amending_text: &str) -> Result<Vec<BillDiff>, String> {
+///
+/// The reply is carried out rather than dropped. Nothing of the model's words
+/// used to survive this command at all — the parsed result went to the cache
+/// and the raw text only ever appeared in an error message (#58).
+fn extract_changes(llm: &LlmClient, amending_text: &str) -> Result<Cached, String> {
     let user_prompt = format!(
         "Extract the word-level changes from this amendment text:\n\n<amendment>\n{amending_text}\n</amendment>"
     );
@@ -184,9 +253,26 @@ fn extract_changes(llm: &LlmClient, amending_text: &str) -> Result<Vec<BillDiff>
         temperature: 1.0,
         max_tokens: Some(64_000),
     };
-    let raw = llm.chat(EXTRACT_SYSTEM_PROMPT, &user_prompt, &opts)?;
+    let reply = llm.chat(EXTRACT_SYSTEM_PROMPT, &user_prompt, &opts)?;
     // Include the full raw model output on any parse failure so it can be inspected.
-    parse_changes(&raw).map_err(|e| format!("{e}\n--- raw model output ---\n{raw}"))
+    let changes =
+        parse_changes(&reply).map_err(|e| format!("{e}\n--- raw model output ---\n{reply}"))?;
+    Ok(Cached::WithReply {
+        changes,
+        prompt_hash: prompt_hash(EXTRACT_SYSTEM_PROMPT, &user_prompt),
+        reply,
+    })
+}
+
+/// A hash of the exact prompt that was sent. The prompt itself is not stored:
+/// it is built from the amending text, which the dataset already holds.
+fn prompt_hash(system: &str, user: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(system.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(user.as_bytes());
+    hex::encode(hasher.finalize())
 }
 
 /// Pull the JSON array out of `<response>...</response>` and into `BillDiff`s.
@@ -220,7 +306,7 @@ fn sibling(dataset_path: &str, filename: &str) -> PathBuf {
 }
 
 /// Load the extraction cache from disk, or start empty when it doesn't exist yet.
-fn load_cache(path: &Path) -> HashMap<String, Vec<BillDiff>> {
+fn load_cache(path: &Path) -> HashMap<String, Cached> {
     match fs::read_to_string(path) {
         Ok(text) => serde_json::from_str(&text).expect("Error parsing cache file"),
         Err(_) => HashMap::new(),
@@ -231,7 +317,7 @@ fn load_cache(path: &Path) -> HashMap<String, Vec<BillDiff>> {
 ///
 /// Writes to a temp file then renames, so an interrupt mid-write can never leave
 /// a half-written (corrupt, unresumable) cache on disk.
-fn write_cache(path: &Path, cache: &HashMap<String, Vec<BillDiff>>) {
+fn write_cache(path: &Path, cache: &HashMap<String, Cached>) {
     let json = serde_json::to_string_pretty(cache).expect("Error serializing cache");
     let tmp = path.with_extension("json.tmp");
     fs::write(&tmp, json).expect("Error writing cache");

--- a/src/bin/words_to_data/match_amendments.rs
+++ b/src/bin/words_to_data/match_amendments.rs
@@ -18,7 +18,7 @@ use words_to_data::annotation::{
 };
 use words_to_data::dataset::{Dataset, Format};
 use words_to_data::legislature::AmendingAction;
-use words_to_data::link::Link;
+use words_to_data::link::{Evidence, Link};
 use words_to_data::matching::{
     AmendmentMatch, Candidate, DEFAULT_SIMILARITY_CUTOFF, build_matches,
 };
@@ -76,14 +76,12 @@ pub fn run(args: Args) {
     );
 
     let llm = LlmClient::new(args.base_url.clone(), args.model.clone(), None);
-    let annotator = format!(
-        "model:{}",
-        if args.model.is_empty() {
-            "local"
-        } else {
-            &args.model
-        }
-    );
+    let model_name = if args.model.is_empty() {
+        "local".to_string()
+    } else {
+        args.model.clone()
+    };
+    let annotator = format!("model:{model_name}");
 
     let pairs = args.span.resolve(&dataset);
     let mut candidates_by_work = Vec::new();
@@ -101,9 +99,15 @@ pub fn run(args: Args) {
         let matched = classify_all(&llm, &matches, args.threads);
 
         // Apply the LLM's annotations single-threaded.
-        for (match_idx, annotations) in matched {
+        for (match_idx, classification) in matched {
             let m = &matches[match_idx];
-            for ann in annotations {
+            // One reply produced every annotation below, so it is recorded once
+            // and referenced, not copied onto each.
+            let reply_id = crate::fail::or_exit(
+                dataset.add_reply(&classification.reply),
+                "Error recording the model reply",
+            );
+            for ann in classification.annotations {
                 let Some(candidate) = usize::try_from(ann.candidate_index)
                     .ok()
                     .and_then(|i| m.candidates.get(i))
@@ -138,7 +142,13 @@ pub fn run(args: Args) {
                 // Links are what is stored, so this writes links rather than
                 // handing an annotation to a convenience that fans out. One
                 // annotation is one link per path it names.
-                for link in Link::from_annotation(&annotation, &from, &to) {
+                for mut link in Link::from_annotation(&annotation, &from, &to) {
+                    link.provenance.evidence = Some(Evidence {
+                        reasoning: annotation.metadata.reasoning.clone(),
+                        reply: Some(reply_id.clone()),
+                        model: Some(model_name.clone()),
+                        prompt_hash: Some(classification.prompt_hash.clone()),
+                    });
                     crate::fail::or_exit(dataset.add_link(link), "Error adding link");
                 }
                 applied += 1;
@@ -208,10 +218,10 @@ fn classify_all(
     llm: &LlmClient,
     matches: &[AmendmentMatch],
     threads: usize,
-) -> Vec<(usize, Vec<LlmAnnotation>)> {
+) -> Vec<(usize, Classification)> {
     let next = AtomicUsize::new(0);
     let done = AtomicUsize::new(0);
-    let results: Mutex<Vec<(usize, Vec<LlmAnnotation>)>> = Mutex::new(Vec::new());
+    let results: Mutex<Vec<(usize, Classification)>> = Mutex::new(Vec::new());
     let worker_count = threads.max(1);
 
     std::thread::scope(|scope| {
@@ -222,8 +232,8 @@ fn classify_all(
                     let Some(m) = matches.get(i) else { break };
 
                     match classify(llm, m) {
-                        Ok(annotations) => {
-                            results.lock().unwrap().push((i, annotations));
+                        Ok(classification) => {
+                            results.lock().unwrap().push((i, classification));
                         }
                         Err(err) => {
                             eprintln!("ERROR matching {}: {err}", m.amendment_id);
@@ -240,15 +250,47 @@ fn classify_all(
     results.into_inner().unwrap()
 }
 
+/// One amendment's answer: what the model said, and what it was parsed into.
+///
+/// The reply is carried out of here rather than dropped. It is what lets a
+/// receiving party check that the parse was faithful, and it is the only thing
+/// that can prove the parser survives what a model really emits (#58).
+struct Classification {
+    annotations: Vec<LlmAnnotation>,
+    reply: String,
+    prompt_hash: String,
+}
+
 /// Query the LLM for one amendment and parse its annotation list.
-fn classify(llm: &LlmClient, m: &AmendmentMatch) -> Result<Vec<LlmAnnotation>, String> {
+fn classify(llm: &LlmClient, m: &AmendmentMatch) -> Result<Classification, String> {
     let user_prompt = build_user_prompt(m);
     let opts = ChatOptions {
         temperature: 0.0,
         max_tokens: None,
     };
-    let raw = llm.chat(SYSTEM_PROMPT, &user_prompt, &opts)?;
-    parse_response(&raw).map_err(|e| format!("{e}\n--- raw model output ---\n{raw}"))
+    let reply = llm.chat(SYSTEM_PROMPT, &user_prompt, &opts)?;
+    let annotations =
+        parse_response(&reply).map_err(|e| format!("{e}\n--- raw model output ---\n{reply}"))?;
+    Ok(Classification {
+        annotations,
+        prompt_hash: prompt_hash(SYSTEM_PROMPT, &user_prompt),
+        reply,
+    })
+}
+
+/// A hash of the exact prompt that was sent.
+///
+/// The prompt itself is not stored: it is built from material the dataset
+/// already holds, so keeping it would duplicate the file's own contents. The
+/// hash still answers the question that matters — whether the prompt behind
+/// this reply is the one this build produces now.
+fn prompt_hash(system: &str, user: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(system.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(user.as_bytes());
+    hex::encode(hasher.finalize())
 }
 
 /// The LLM's JSON response envelope.

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -166,6 +166,9 @@ pub struct DatasetCompact {
     /// Every link, by its content-hash id (stored as-is)
     #[serde(default)]
     pub links: std::collections::BTreeMap<String, Link>,
+    /// Every verbatim model reply, by the hash of its own text
+    #[serde(default)]
+    pub replies: std::collections::BTreeMap<String, String>,
     /// Congress members (stored as-is)
     #[serde(default)]
     pub members: HashMap<String, Member>,
@@ -223,6 +226,7 @@ impl DatasetCompact {
             expressions,
             bills: storage.bills.clone(),
             links: storage.links.clone(),
+            replies: storage.replies.clone(),
             members: storage.members.clone(),
             sponsors: storage.sponsors.clone(),
             bill_votes: storage.bill_votes.clone(),
@@ -302,6 +306,7 @@ impl DatasetCompact {
             expressions,
             self.bills,
             self.links,
+            self.replies,
             self.members,
             self.sponsors,
             self.bill_votes,

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -26,8 +26,8 @@ use crate::diff::TreeDiff;
 use crate::legislature::BillDiff;
 use crate::link::Link;
 use crate::storage::{
-    DocumentReader, DocumentWriter, InMemoryStorage, LegislatureReader, LegislatureWriter,
-    LinkReader, LinkWriter, SqliteStorage, Storage,
+    DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, InMemoryStorage,
+    LegislatureReader, LegislatureWriter, LinkReader, LinkWriter, SqliteStorage, Storage,
 };
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
@@ -268,6 +268,16 @@ impl<S: Storage> Dataset<S> {
         self.storage.add_bill(bill)
     }
 
+    /// Record a verbatim model reply and return its id.
+    pub fn add_reply(&mut self, reply: &str) -> Result<String, DatasetError> {
+        self.storage.add_reply(reply)
+    }
+
+    /// One verbatim model reply, by its id.
+    pub fn get_reply(&self, id: &str) -> Result<Option<String>, DatasetError> {
+        self.storage.get_reply(id)
+    }
+
     /// Record one link.
     ///
     /// There is no annotation-shaped convenience beside this: two ways to write
@@ -356,6 +366,24 @@ impl Dataset<InMemoryStorage> {
         for bill in self.storage.bills.values_mut() {
             if let Some(amendment) = bill.amendments.get_mut(amendment_id) {
                 amendment.changes.push(bill_diff.clone());
+                return;
+            }
+        }
+    }
+
+    /// Record where an amendment's word-level changes came from.
+    ///
+    /// The amending text is parsed from the bill and is a fact from a source.
+    /// The changes are a model's reading of it, and until this existed nothing
+    /// said so (#58).
+    pub fn set_amendment_provenance(
+        &mut self,
+        amendment_id: &str,
+        provenance: crate::link::Provenance,
+    ) {
+        for bill in self.storage.bills.values_mut() {
+            if let Some(amendment) = bill.amendments.get_mut(amendment_id) {
+                amendment.provenance = Some(provenance);
                 return;
             }
         }
@@ -627,6 +655,22 @@ impl<S: Storage> LinkReader for Dataset<S> {
 
     fn link_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
         self.storage.link_pairs()
+    }
+}
+
+impl<S: Storage> EvidenceReader for Dataset<S> {
+    fn get_reply(&self, id: &str) -> Result<Option<String>, DatasetError> {
+        self.storage.get_reply(id)
+    }
+
+    fn replies(&self) -> Result<Vec<String>, DatasetError> {
+        self.storage.replies()
+    }
+}
+
+impl<S: Storage> EvidenceWriter for Dataset<S> {
+    fn add_reply(&mut self, reply: &str) -> Result<String, DatasetError> {
+        self.storage.add_reply(reply)
     }
 }
 

--- a/src/legislature/mod.rs
+++ b/src/legislature/mod.rs
@@ -93,7 +93,11 @@ pub struct UscReference {
 }
 
 /// An amending action found in a bill
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+///
+/// Not `Eq` or `Hash`: its provenance carries a raw model score, which is a
+/// float. It was never used as a key — only as a map value — so nothing is
+/// lost. Its identity is `id`, a content hash.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BillAmendment {
     /// Content-based ID: sha256("{bill_id}:{amending_text}")
     /// This provides a stable, deterministic identifier that works regardless of source format.
@@ -107,6 +111,19 @@ pub struct BillAmendment {
 
     /// List of word-level changes that an amendment enacts
     pub changes: Vec<BillDiff>,
+
+    /// Where `changes` came from.
+    ///
+    /// The amending text is parsed from the bill and is a fact from a source.
+    /// The word-level changes are not: a model produced them, and until this
+    /// existed nothing recorded that. Evidence without a verification state
+    /// reads as corroboration, so the whole provenance is carried rather than
+    /// the evidence alone (#58).
+    ///
+    /// `None` means nothing was recorded, which is every amendment extracted
+    /// before this was built.
+    #[serde(default)]
+    pub provenance: Option<crate::link::Provenance>,
 }
 
 impl BillAmendment {
@@ -116,6 +133,7 @@ impl BillAmendment {
             action_types: self.action_types.clone(),
             amending_text: self.amending_text.clone(),
             changes: changes.to_vec(),
+            provenance: self.provenance.clone(),
         }
     }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -128,6 +128,55 @@ impl VerificationState {
     }
 }
 
+/// What a statement was based on.
+///
+/// A machine's claim is checkable only if a receiving party can see what the
+/// machine actually said. The reasoning explains the claim; the reply is what
+/// lets someone confirm the reasoning was parsed out of it faithfully. Without
+/// the reply, "never lie" rests on a label rather than on evidence (#58).
+///
+/// The reply is a reference, not the text. One reply produces many statements,
+/// so copying it onto each would claim each statement had its own reply, and
+/// would store it many times over. The text lives once in the dataset, under
+/// the hash of itself.
+///
+/// The prompt is hashed rather than stored. It is built from material the
+/// dataset already holds, so keeping it would duplicate the file's own
+/// contents; the hash still says whether the prompt that produced this reply is
+/// the one this build produces now.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct Evidence {
+    /// Why the maker says it reached this answer, in their own words.
+    ///
+    /// For a machine-made annotation this is the reasoning the model gave.
+    #[serde(default)]
+    pub reasoning: Option<String>,
+    /// The verbatim reply that produced the statement, by its id.
+    ///
+    /// Resolve it with `EvidenceReader::get_reply`. `None` means no reply was
+    /// recorded, which is every statement made before this was built.
+    #[serde(default)]
+    pub reply: Option<String>,
+    /// Which model answered, as configured when it ran.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// A hash of the exact prompt that was sent.
+    #[serde(default)]
+    pub prompt_hash: Option<String>,
+}
+
+impl Evidence {
+    /// Evidence that carries only the maker's reasoning.
+    ///
+    /// The shape of every statement made before replies were recorded.
+    pub fn from_reasoning(reasoning: Option<String>) -> Option<Self> {
+        reasoning.map(|reasoning| Self {
+            reasoning: Some(reasoning),
+            ..Self::default()
+        })
+    }
+}
+
 /// Where a statement came from.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Provenance {
@@ -137,13 +186,8 @@ pub struct Provenance {
     pub method: Option<String>,
     /// How far the statement can be trusted.
     pub verification: VerificationState,
-    /// What the statement was based on, in the maker's own words.
-    ///
-    /// For a machine-made annotation this is the reasoning the model gave for
-    /// its answer. It is not the verbatim reply: the text around the answer,
-    /// including any fences and prose, was never persisted (#58). So this
-    /// explains a claim without being enough to reproduce how it was parsed.
-    pub evidence: Option<String>,
+    /// What the statement was based on.
+    pub evidence: Option<Evidence>,
     /// The raw score a model reported, kept as diagnostic data only. It is not
     /// a probability and must not be presented as one.
     ///
@@ -231,6 +275,17 @@ pub struct Link {
     pub payload: Option<KindPayload>,
 }
 
+/// The id of a verbatim model reply: the hash of its own text.
+///
+/// Identified by what it says, like a link and like an amendment, so the same
+/// reply recorded twice is one record and a rebuild is idempotent.
+pub fn reply_id(reply: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(reply.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
 /// How an amendment is named as a link object.
 ///
 /// Fully qualified — the bill and the amendment — so a reader that does not
@@ -287,7 +342,7 @@ impl Link {
             source: annotation.metadata.annotator.clone(),
             method: None,
             verification: verification_of(annotation),
-            evidence: annotation.metadata.reasoning.clone(),
+            evidence: Evidence::from_reasoning(annotation.metadata.reasoning.clone()),
             raw_score: annotation.metadata.confidence,
             timestamp: Some(annotation.metadata.timestamp),
             corroboration: None,
@@ -407,7 +462,11 @@ pub fn annotations_from_links(links: &[Link]) -> Vec<ChangeAnnotation> {
                         .timestamp
                         .unwrap_or(time::OffsetDateTime::UNIX_EPOCH),
                     notes: field("notes"),
-                    reasoning: link.provenance.evidence.clone(),
+                    reasoning: link
+                        .provenance
+                        .evidence
+                        .as_ref()
+                        .and_then(|e| e.reasoning.clone()),
                 },
             })
             .paths

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -13,8 +13,8 @@ use crate::diff::TreeDiff;
 use crate::intern::StringInterner;
 use crate::link::{Link, Target};
 use crate::storage::{
-    DocumentReader, DocumentWriter, LegislatureReader, LegislatureWriter, LinkReader, LinkWriter,
-    Storage,
+    DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, LegislatureReader,
+    LegislatureWriter, LinkReader, LinkWriter, Storage,
 };
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
@@ -40,6 +40,9 @@ pub struct InMemoryStorage {
     /// Every link, by its content-hash id. Keying on the id is what makes
     /// restating a fact update one link rather than grow the map.
     pub links: BTreeMap<String, Link>,
+    /// Every verbatim model reply, by the hash of its own text.
+    #[serde(default)]
+    pub replies: BTreeMap<String, String>,
     pub members: HashMap<String, Member>,
     pub sponsors: HashMap<String, SponsorInfo>,
     pub bill_votes: HashMap<String, BillVotes>,
@@ -54,6 +57,7 @@ impl InMemoryStorage {
             expressions: BTreeMap::new(),
             bills: HashMap::new(),
             links: BTreeMap::new(),
+            replies: BTreeMap::new(),
             members: HashMap::new(),
             sponsors: HashMap::new(),
             bill_votes: HashMap::new(),
@@ -79,6 +83,7 @@ impl InMemoryStorage {
         expressions: ExpressionsByWork,
         bills: HashMap<String, Bill>,
         links: BTreeMap<String, Link>,
+        replies: BTreeMap<String, String>,
         members: HashMap<String, Member>,
         sponsors: HashMap<String, SponsorInfo>,
         bill_votes: HashMap<String, BillVotes>,
@@ -89,6 +94,7 @@ impl InMemoryStorage {
             expressions,
             bills,
             links,
+            replies,
             members,
             sponsors,
             bill_votes,
@@ -334,6 +340,24 @@ fn pair_of(link: &Link) -> Option<ExpressionPair> {
 
 fn about_pair(link: &Link, from: &ExpressionId, to: &ExpressionId) -> bool {
     pair_of(link).is_some_and(|(f, t)| &f == from && &t == to)
+}
+
+impl EvidenceReader for InMemoryStorage {
+    fn get_reply(&self, id: &str) -> Result<Option<String>, DatasetError> {
+        Ok(self.replies.get(id).cloned())
+    }
+
+    fn replies(&self) -> Result<Vec<String>, DatasetError> {
+        Ok(self.replies.keys().cloned().collect())
+    }
+}
+
+impl EvidenceWriter for InMemoryStorage {
+    fn add_reply(&mut self, reply: &str) -> Result<String, DatasetError> {
+        let id = crate::link::reply_id(reply);
+        self.replies.insert(id.clone(), reply.to_string());
+        Ok(id)
+    }
 }
 
 impl LegislatureReader for InMemoryStorage {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,6 +42,8 @@ use crate::uslm::bill_parser::Bill;
 /// break. Both on-disk forms carry this number and refuse a file that does not
 /// match, because a break that is not loud reads as an empty dataset.
 ///
+/// 6 keeps the verbatim model reply as evidence, stored once under the hash of
+/// its own text and referenced from a statement's provenance (#58).
 /// 5 stores links directly: one table for every kind, including kinds this
 /// build has never seen, with `ChangeAnnotation` projected out of them rather
 /// than stored (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
@@ -54,7 +56,7 @@ use crate::uslm::bill_parser::Bill;
 /// bumping this would have rejected valid JSON datasets to fix a SQLite table.
 /// That case is caught where it happens, when the database is opened, rather
 /// than here. A change that alters both forms still belongs to this number.
-pub const SCHEMA_VERSION: i32 = 5;
+pub const SCHEMA_VERSION: i32 = 6;
 
 /// Reading the documents a dataset holds.
 ///
@@ -222,6 +224,33 @@ pub trait LegislatureReader {
     ) -> Result<Vec<(HouseRollCall, VotePosition)>, DatasetError>;
 }
 
+/// Reading the evidence a dataset holds.
+///
+/// Core, not an extension. A reader that does not know the legislature must
+/// still be able to see what a machine's claim was based on, or the claim's
+/// verification state is a label rather than something checkable (#58).
+pub trait EvidenceReader {
+    /// One verbatim model reply, by its id, or `None` when unheld.
+    ///
+    /// `None` is an answer: a dataset that never recorded a reply is a
+    /// different thing from one whose reply was empty.
+    fn get_reply(&self, id: &str) -> Result<Option<String>, DatasetError>;
+
+    /// Every reply id this dataset holds, in id order.
+    fn replies(&self) -> Result<Vec<String>, DatasetError>;
+}
+
+/// Writing evidence.
+pub trait EvidenceWriter {
+    /// Record a verbatim model reply and return its id.
+    ///
+    /// A reply is identified by the hash of its own text, so recording the same
+    /// reply twice leaves one record. Evidence is append-only: a reply whose
+    /// statement was later superseded is kept, because deleting it destroys the
+    /// trail it exists to create.
+    fn add_reply(&mut self, reply: &str) -> Result<String, DatasetError>;
+}
+
 /// Writing documents and dataset metadata.
 ///
 /// Reading metadata lives on [`DocumentReader`], not here.
@@ -275,7 +304,14 @@ pub trait LegislatureWriter {
 /// should bind to [`DocumentReader`] instead, so it keeps working against a
 /// dataset that carries no legislative material.
 pub trait Storage:
-    DocumentReader + LinkReader + LegislatureReader + DocumentWriter + LinkWriter + LegislatureWriter
+    DocumentReader
+    + LinkReader
+    + EvidenceReader
+    + LegislatureReader
+    + DocumentWriter
+    + LinkWriter
+    + EvidenceWriter
+    + LegislatureWriter
 {
     /// The legislature extension, when this dataset actually carries one.
     ///

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -16,8 +16,8 @@ use crate::intern::StringInterner;
 use crate::link::{Link, LinkKind, Provenance, Target};
 use crate::storage::memory::{ExpressionsByWork, require_same_work};
 use crate::storage::{
-    DocumentReader, DocumentWriter, InMemoryStorage, LegislatureReader, LegislatureWriter,
-    LinkReader, LinkWriter, SCHEMA_VERSION, Storage,
+    DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, InMemoryStorage,
+    LegislatureReader, LegislatureWriter, LinkReader, LinkWriter, SCHEMA_VERSION, Storage,
 };
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
@@ -397,6 +397,14 @@ impl SqliteStorage {
             -- Finding a path is now a keyed lookup rather than a scan that
             -- deserializes one whole tree per date.
             CREATE INDEX IF NOT EXISTS idx_elem_path ON element_index(path);
+            -- Verbatim model replies, by the hash of their own text. Append
+            -- only: a reply whose statement was later superseded is kept,
+            -- because deleting it destroys the trail it exists to create.
+            CREATE TABLE IF NOT EXISTS model_replies (
+                id TEXT PRIMARY KEY,
+                reply TEXT NOT NULL
+            );
+
             -- A namespace is a prefix of a kind, so one index serves both.
             CREATE INDEX IF NOT EXISTS idx_links_kind ON links(kind);
             CREATE INDEX IF NOT EXISTS idx_links_subject_path ON links(subject_path);
@@ -522,6 +530,16 @@ impl SqliteStorage {
             }
         }
 
+        // Save replies. Append-only, so no DELETE: a reply the incoming
+        // storage no longer references is still a record that it was said.
+        {
+            let mut stmt =
+                tx.prepare("INSERT OR REPLACE INTO model_replies (id, reply) VALUES (?1, ?2)")?;
+            for (id, reply) in &storage.replies {
+                stmt.execute(params![id, reply])?;
+            }
+        }
+
         // Save links
         {
             tx.execute("DELETE FROM links", [])?;
@@ -628,12 +646,14 @@ impl SqliteStorage {
             .into_iter()
             .map(|link| (link.id(), link))
             .collect();
+        let replies = self.load_replies()?;
 
         let mut storage = InMemoryStorage::from_parts(
             metadata,
             expressions,
             HashMap::new(), // bills - query from storage
             links,
+            replies,
             HashMap::new(), // members - query from storage
             HashMap::new(), // sponsors - query from storage
             HashMap::new(), // bill_votes - query from storage
@@ -652,6 +672,7 @@ impl SqliteStorage {
         let members = self.load_members()?;
         let sponsors = self.load_sponsors()?;
         let links = self.load_links()?;
+        let replies = self.load_replies()?;
         let bill_votes = self.load_bill_votes()?;
 
         let mut storage = InMemoryStorage::from_parts(
@@ -659,6 +680,7 @@ impl SqliteStorage {
             expressions,
             bills,
             links,
+            replies,
             members,
             sponsors,
             bill_votes,
@@ -778,6 +800,17 @@ impl SqliteStorage {
         }
 
         Ok(sponsors)
+    }
+
+    /// Every verbatim model reply, by id.
+    fn load_replies(&self) -> Result<std::collections::BTreeMap<String, String>, DatasetError> {
+        let mut stmt = self.conn.prepare("SELECT id, reply FROM model_replies")?;
+        let replies = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<std::collections::BTreeMap<_, _>, _>>()?;
+        Ok(replies)
     }
 
     /// Every link in the database, by id.
@@ -1178,6 +1211,40 @@ impl LinkReader for SqliteStorage {
             })?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(pairs)
+    }
+}
+
+impl EvidenceReader for SqliteStorage {
+    fn get_reply(&self, id: &str) -> Result<Option<String>, DatasetError> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT reply FROM model_replies WHERE id = ?1",
+                params![id],
+                |row| row.get(0),
+            )
+            .ok())
+    }
+
+    fn replies(&self) -> Result<Vec<String>, DatasetError> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM model_replies ORDER BY id")?;
+        let ids = stmt
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<Vec<String>, _>>()?;
+        Ok(ids)
+    }
+}
+
+impl EvidenceWriter for SqliteStorage {
+    fn add_reply(&mut self, reply: &str) -> Result<String, DatasetError> {
+        let id = crate::link::reply_id(reply);
+        self.conn.execute(
+            "INSERT OR REPLACE INTO model_replies (id, reply) VALUES (?1, ?2)",
+            params![&id, reply],
+        )?;
+        Ok(id)
     }
 }
 

--- a/src/uslm/bill_parser.rs
+++ b/src/uslm/bill_parser.rs
@@ -192,6 +192,8 @@ fn get_amendment_data(node: &Node, bill_id: &str) -> BillAmendment {
     let id = compute_amendment_id(bill_id, &amending_text);
 
     BillAmendment {
+        // Parsed from the bill, so nothing has been asserted about `changes` yet.
+        provenance: None,
         id,
         action_types,
         amending_text,

--- a/tests/link_tests.rs
+++ b/tests/link_tests.rs
@@ -110,8 +110,12 @@ fn should_mark_unreviewed_model_output_as_machine_suggested() {
             assert_eq!(link.provenance.source, annotation.metadata.annotator);
             assert_eq!(link.provenance.raw_score, annotation.metadata.confidence);
             assert_eq!(
-                link.provenance.evidence, annotation.metadata.reasoning,
-                "the model's stated reasoning is the evidence we do have"
+                link.provenance
+                    .evidence
+                    .as_ref()
+                    .and_then(|e| e.reasoning.clone()),
+                annotation.metadata.reasoning,
+                "the model's stated reasoning is one part of the evidence"
             );
         }
     }
@@ -234,11 +238,12 @@ fn should_carry_the_models_reasoning_as_evidence() {
 
     for annotation in with_reasoning {
         for link in Link::from_annotation(annotation, &from(), &to()) {
-            let evidence = link
+            let reasoning = link
                 .provenance
                 .evidence
+                .and_then(|e| e.reasoning)
                 .expect("a link should carry the reasoning behind it");
-            assert!(!evidence.trim().is_empty());
+            assert!(!reasoning.trim().is_empty());
         }
     }
 }

--- a/tests/reply_evidence_tests.rs
+++ b/tests/reply_evidence_tests.rs
@@ -1,0 +1,273 @@
+//! The verbatim model reply is kept as evidence (#58).
+//!
+//! `CONTEXT.md` defines provenance as the source, the method, the evidence, and
+//! the verification state. Three of those survived an LLM extraction. The
+//! reasoning did too — that part of #58's original claim was withdrawn — but the
+//! text *around* the answer never did, so nobody could check that the answer was
+//! parsed out of it faithfully.
+//!
+//! One reply produces many statements, so a reply is stored once under the hash
+//! of its own text and referenced, rather than copied onto every link.
+
+use words_to_data::dataset::{Dataset, DatasetMetadata, WorkId};
+use words_to_data::link::{Evidence, Link, LinkKind, Provenance, Target, VerificationState};
+use words_to_data::storage::{EvidenceReader, InMemoryStorage, LinkReader};
+
+/// A reply as a model really emits one: prose, a fence, then the payload.
+///
+/// **Stubbed.** No raw reply has ever been recorded, so this stands in until a
+/// real `match-amendments` sweep records some and they replace it. It exercises
+/// storage, which is what this issue builds; it is not the messy-reply corpus
+/// the parser will eventually be tested against.
+const STUB_REPLY: &str = "tests/test_data/processed/stub_model_reply.txt";
+
+fn stub_reply() -> String {
+    std::fs::read_to_string(STUB_REPLY).expect("the stub reply should be readable")
+}
+
+fn dataset() -> Dataset<InMemoryStorage> {
+    Dataset::new(DatasetMetadata {
+        name: "Reply evidence fixture".to_string(),
+        ..Default::default()
+    })
+}
+
+fn a_link(evidence: Option<Evidence>) -> Link {
+    Link {
+        subject: Target::Change {
+            work: WorkId::new("uscode/title_26"),
+            path: "uscode/title_26/subtitle_A/chapter_1/section_163".to_string(),
+            from_date: "2025-07-18".to_string(),
+            to_date: "2025-07-30".to_string(),
+        },
+        kind: LinkKind::new(LinkKind::AMENDED_BY),
+        object: Target::External {
+            reference: "legislature.amendment:119-21:abc".to_string(),
+            display: "by striking ...".to_string(),
+        },
+        provenance: Provenance {
+            source: "model:local".to_string(),
+            method: None,
+            verification: VerificationState::MachineSuggested,
+            evidence,
+            raw_score: Some(0.9),
+            timestamp: None,
+            corroboration: None,
+        },
+        payload: None,
+    }
+}
+
+#[test]
+fn should_store_a_reply_once_under_the_hash_of_its_own_text() {
+    let mut dataset = dataset();
+    let reply = stub_reply();
+
+    let first = dataset.add_reply(&reply).expect("the reply should store");
+    let second = dataset
+        .add_reply(&reply)
+        .expect("storing it again should be fine");
+
+    // A reply is identified by what it says, like a link and like an amendment.
+    // One reply produced many statements, so storing it per statement would
+    // claim each statement had its own reply.
+    assert_eq!(first, second, "the same text is the same reply");
+    assert_eq!(
+        dataset.replies().expect("replies should list").len(),
+        1,
+        "the same reply stored twice is one record"
+    );
+    assert_eq!(
+        dataset.get_reply(&first).expect("readable").as_deref(),
+        Some(reply.as_str()),
+        "the reply must come back byte-identical, fences and prose included"
+    );
+}
+
+#[test]
+fn should_reach_the_reply_from_a_links_evidence() {
+    let mut dataset = dataset();
+    let reply_id = dataset.add_reply(&stub_reply()).expect("stored");
+
+    dataset
+        .add_link(a_link(Some(Evidence {
+            reasoning: Some("Section reference matches exactly".to_string()),
+            reply: Some(reply_id.clone()),
+            model: Some("deepseek-v4-pro".to_string()),
+            prompt_hash: Some("f00d".to_string()),
+        })))
+        .expect("the link should store");
+
+    let stored = dataset
+        .links_by_kind(LinkKind::AMENDED_BY)
+        .expect("links should read");
+    let evidence = stored[0]
+        .provenance
+        .evidence
+        .as_ref()
+        .expect("a machine claim carries evidence");
+
+    // The reasoning explains the claim; the reply is what lets a receiving
+    // party check that the reasoning was parsed out of it faithfully.
+    assert_eq!(
+        evidence.reasoning.as_deref(),
+        Some("Section reference matches exactly")
+    );
+    assert_eq!(evidence.model.as_deref(), Some("deepseek-v4-pro"));
+    assert!(evidence.prompt_hash.is_some());
+    assert_eq!(
+        dataset
+            .get_reply(evidence.reply.as_ref().expect("a reply reference"))
+            .expect("readable"),
+        Some(stub_reply())
+    );
+}
+
+#[test]
+fn should_keep_a_reply_whose_statement_was_superseded() {
+    let mut dataset = dataset();
+    let reply_id = dataset.add_reply(&stub_reply()).expect("stored");
+
+    dataset
+        .add_link(a_link(Some(Evidence {
+            reasoning: Some("first answer".to_string()),
+            reply: Some(reply_id.clone()),
+            model: Some("model-a".to_string()),
+            prompt_hash: None,
+        })))
+        .expect("first");
+
+    // Restating the fact replaces the link, so nothing references the old
+    // reply any more.
+    dataset
+        .add_link(a_link(Some(Evidence {
+            reasoning: Some("second answer".to_string()),
+            reply: None,
+            model: Some("model-b".to_string()),
+            prompt_hash: None,
+        })))
+        .expect("second");
+
+    // Evidence is append-only. Deleting a reply because the statement it
+    // supported was superseded destroys the trail this exists to create.
+    assert_eq!(
+        dataset.get_reply(&reply_id).expect("readable"),
+        Some(stub_reply()),
+        "an orphaned reply is a record that something was said, not garbage"
+    );
+}
+
+#[test]
+fn should_carry_replies_and_evidence_through_sqlite() {
+    let mut memory = dataset();
+    let reply_id = memory.add_reply(&stub_reply()).expect("stored");
+    memory
+        .add_link(a_link(Some(Evidence {
+            reasoning: Some("why".to_string()),
+            reply: Some(reply_id.clone()),
+            model: Some("deepseek-v4-pro".to_string()),
+            prompt_hash: Some("f00d".to_string()),
+        })))
+        .expect("link stored");
+
+    let dir = std::path::Path::new("target/reply_evidence_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let file = dir.join("evidence.sqlite");
+    std::fs::remove_file(&file).ok();
+    memory.save_to_sqlite(&file).expect("save to sqlite");
+    let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
+
+    // Evidence that does not travel in the file cannot be checked by the party
+    // it was sent to, which is the whole reason for keeping it.
+    assert_eq!(
+        sqlite.get_reply(&reply_id).expect("readable"),
+        Some(stub_reply())
+    );
+    let stored = sqlite
+        .links_by_kind(LinkKind::AMENDED_BY)
+        .expect("links should read");
+    assert_eq!(
+        stored[0].provenance.evidence,
+        memory.links_by_kind(LinkKind::AMENDED_BY).unwrap()[0]
+            .provenance
+            .evidence
+    );
+}
+
+#[test]
+fn should_answer_none_for_a_reply_the_dataset_does_not_hold() {
+    let dataset = dataset();
+
+    // A missing reply is a question with an answer. A dataset that never
+    // recorded one is different from a dataset whose reply is empty.
+    assert_eq!(dataset.get_reply("nosuchhash").expect("readable"), None);
+}
+
+#[test]
+fn should_say_a_model_produced_an_amendments_word_level_changes() {
+    use words_to_data::uslm::bill_parser::parse_bill_amendments;
+
+    let mut dataset = dataset();
+    let bill = parse_bill_amendments(
+        "119-21",
+        "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml",
+    )
+    .expect("the public law should parse");
+    let amendment_id = bill
+        .amendments
+        .keys()
+        .next()
+        .expect("the bill should hold amendments")
+        .clone();
+    dataset.add_bill(bill).expect("the bill should be added");
+
+    // Parsed from the bill, so nothing has been asserted about its changes yet.
+    assert!(
+        dataset.get_bill("119-21").unwrap().unwrap().amendments[&amendment_id]
+            .provenance
+            .is_none(),
+        "the amending text is a fact from a source; its word-level changes are not"
+    );
+
+    let reply_id = dataset.add_reply(&stub_reply()).expect("stored");
+    dataset.set_amendment_provenance(
+        &amendment_id,
+        Provenance {
+            source: "model:local".to_string(),
+            method: Some("extract-changes".to_string()),
+            verification: VerificationState::MachineSuggested,
+            evidence: Some(Evidence {
+                reasoning: None,
+                reply: Some(reply_id),
+                model: Some("local".to_string()),
+                prompt_hash: Some("beef".to_string()),
+            }),
+            raw_score: None,
+            timestamp: None,
+            corroboration: None,
+        },
+    );
+
+    let dir = std::path::Path::new("target/reply_evidence_dbs");
+    std::fs::create_dir_all(dir).expect("create sqlite test dir");
+    let file = dir.join("amendment_provenance.sqlite");
+    std::fs::remove_file(&file).ok();
+    dataset.save_to_sqlite(&file).expect("save to sqlite");
+    let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
+
+    let stored = sqlite.get_bill("119-21").unwrap().unwrap().amendments[&amendment_id]
+        .provenance
+        .clone()
+        .expect("the provenance should survive the file it travels in");
+
+    // Evidence without a verification state would read as corroboration for
+    // what is actually a machine's reading of the amending text.
+    assert_eq!(stored.verification, VerificationState::MachineSuggested);
+    assert_eq!(stored.source, "model:local");
+    assert_eq!(
+        sqlite
+            .get_reply(stored.evidence.unwrap().reply.as_ref().unwrap())
+            .expect("readable"),
+        Some(stub_reply())
+    );
+}

--- a/tests/test_data/processed/stub_model_reply.txt
+++ b/tests/test_data/processed/stub_model_reply.txt
@@ -1,0 +1,29 @@
+STUB FIXTURE — replace with a real recorded reply.
+
+No verbatim model reply had ever been persisted when #58 was built, so this
+file stands in for one. It carries the shapes a parser has to survive — prose
+before the payload, a fenced JSON block, and trailing commentary — but it was
+written by hand, not emitted by a model, so it proves nothing about what models
+actually do.
+
+Replace it after a full `match-amendments` sweep records real replies, and move
+the parser tests onto those. The annotation content below is taken from a real
+matching run against 26 U.S.C. § 163(j)(8)(A)(v).
+
+Looking at the amendment and the candidate diffs, candidate 0 is the match.
+
+```json
+{
+  "annotations": [
+    {
+      "candidate_index": 0,
+      "operation": "strike",
+      "causative_text": "Section 163(j)(8)(A)(v) is amended by striking \"in the case of taxable years beginning before January 1, 2022,\".",
+      "confidence": 0.95,
+      "reasoning": "Section reference matches exactly (Section 163(j)(8)(A)(v)), and the old text in the diff ('in the case of taxable years beginning before') is a truncated version of the text being struck."
+    }
+  ]
+}
+```
+
+That is the only candidate whose text overlaps the amending instruction.


### PR DESCRIPTION
Closes #58. (PRs into `vibes` do not auto-close, so #58 needs closing by hand after merge.)

**Last of the breaking changes.** `SCHEMA_VERSION` reaches 6, and the window is complete: 3 → 4 (#71) → 5 (#70) → 6 (#58). One rebuild covers all of it.

## What was missing

The issue's own correction was right, and it narrows the work: `reasoning` **was** already persisted and reaches `Provenance.evidence`. What never survived is the **verbatim reply**. Both `classify` and `extract_changes` used the raw text only inside an error message and then dropped it, so nobody could confirm the answer was parsed out of it faithfully, and no recorded reply existed to test the parser against.

## Shape

A reply is stored **once, under the hash of its own text**, and referenced. One reply produces many statements — 317 replies produced 718 links in the test corpus — so copying it onto each would claim every statement had its own reply, and store it ~2.3× over.

`Provenance.evidence` becomes a struct: the maker's reasoning, a reply reference, the model, and a prompt hash.

**The prompt is hashed, not stored.** It is built from material the dataset already holds, so keeping it would duplicate the file's own contents, and it is the *larger* of the two. The hash still answers whether the prompt behind a reply is the one this build produces now. The case it does not cover: a build whose prompt construction changed — you learn the hash differs but cannot see the old text. That is the one place this is genuinely weaker.

**Evidence is append-only.** A reply whose statement was superseded is kept. Deleting it destroys the trail this exists to create, and a superseded machine reply is precisely how you would audit the ADR 0004 rule that a human verdict survives a machine re-write.

## `extract-changes` needed more than evidence

`BillAmendment` had **no provenance at all**. The amending text is a fact parsed from the bill; the word-level changes are a model's reading of it, and nothing recorded that a model made them. Attaching evidence without a verification state would read as corroboration for a machine guess, so the whole provenance is carried.

This widens the issue beyond "persist the raw reply" — flagging it because the issue did not ask for it, and it is the change I would most expect you to push back on.

`BillAmendment` loses `Eq` and `Hash`. It never used them (only ever a `HashMap` value, never a key) and it now holds a float.

## The fixture is a stub, deliberately

`tests/test_data/processed/stub_model_reply.txt` is **hand-written and says so in its first line**. No verbatim reply has ever been recorded, so one cannot be derived — a reply rebuilt from stored annotations is well-formed by construction, which is exactly what a parser test needs it not to be.

**So this PR ships the mechanism, not the payoff.** The parser-regression corpus the issue describes arrives with your next full `match-amendments` sweep, and those real replies replace the stub. The tests here exercise storage and round-tripping, which is what is actually built.

## Tests

**293 passed, 7 ignored, 0 failed**, against a baseline of 287 / 7. Clippy and fmt clean.

Six new tests: a reply stored twice is one record; a link's evidence resolves to the reply; an orphaned reply survives its superseded statement; replies and structured evidence round-trip through SQLite; a missing reply answers `None` rather than erroring; and an amendment's changes carry a machine provenance that survives the file.

All were RED before the model existed. I also mutated `add_reply` to stop content-addressing and confirmed the dedup test fails.

## Note on my own process

The pre-commit clippy caught an unused import that my own `cargo clippy` run had reported clean — the same thing happened on #98. A cached clippy result after a `cargo fmt` is not trustworthy; I now force a rebuild before believing it.