### PR TITLE
Report the amendments a sweep loses to an unparseable reply

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ What a statement was based on: the maker's reasoning in their own words, and the
 _Avoid_: Proof, justification, backing
 
 **Model reply**:
-The text a model returned, kept exactly as it arrived. One reply usually makes several statements, so it is stored once and referred to, never copied onto each. It is never deleted, even when the statement it supported has been superseded: an unreferenced reply is a record that something was said.
+The text a model returned, kept exactly as it arrived. One reply usually makes several statements, so it is stored once and referred to, never copied onto each. It is never deleted, even when the statement it supported has been superseded: an unreferenced reply is a record that something was said. A reply that no parser could read makes no statement, so the Dataset does not carry it at all.
 _Avoid_: Response, output, completion
 
 **Provision**:

--- a/docs/adr/0005-evidence-is-stored-once-and-never-deleted.md
+++ b/docs/adr/0005-evidence-is-stored-once-and-never-deleted.md
@@ -38,7 +38,11 @@ The evidence store is **core**, not part of an extension. A reader that does not
 
 A dataset grows by the size of its replies. The first sweep added 1,210 KB against a 1.9 GB dataset, so the proportion is small, and it is not optional: evidence you can switch off is evidence you will not have on the run that mattered.
 
-**A reply is only recorded when it parses.** Both commands still log a parse failure and drop the reply, so the malformed output this decision most wants to capture is the one thing it does not. That is a gap in the implementation rather than in this decision, and it is tracked separately.
+**A reply is only recorded when it parses.** This is the decision, not an unfinished part of it. Evidence is what a statement was based on, and a reply that no parser could read produced no statement. Keeping it would put text in the W2D file that the receiving party cannot check anything against, which is the opposite of what this ADR exists for.
+
+A parse failure is reported instead of kept. The run counts the failures, names the amendments that failed, and prints the model's raw text to stderr, where a person can read it and a redirect can save it. Running the command again retries every amendment that failed, because a failure never enters the extraction cache.
+
+The cost is real and we accept it. #58 gave parser-regression testing as a reason to record replies, and no sweep can now supply a fixture for truncation, for a refusal, or for a stray thinking block. A fixture like that has to be kept by hand from a run's stderr.
 
 ## Considered and rejected
 
@@ -49,3 +53,5 @@ A dataset grows by the size of its replies. The first sweep added 1,210 KB again
 **Storing the prompt alongside the reply.** The most complete record, and it duplicates data the dataset already holds while roughly multiplying the storage cost of evidence. Revisit if prompt construction ever changes often enough that the hash stops being informative.
 
 **Reference-counting replies and deleting the orphans.** Keeps the store tidy. It also throws away the record of a claim that was later revised, which is exactly the history an auditor asks for.
+
+**Keeping a reply that failed to parse.** It would give the parser the malformed fixtures that have no other source, and it would let a receiving party measure what a sweep lost. It also fills the evidence store with text that backs no statement. Worse, it makes an unreferenced reply ambiguous: a reader could no longer tell a superseded reply from one that never parsed, and telling the two apart needs a stored marker, which costs a schema version. Reported and retried beats stored (#101).

--- a/src/bin/words_to_data/extract_changes.rs
+++ b/src/bin/words_to_data/extract_changes.rs
@@ -148,6 +148,10 @@ pub fn run(args: Args) {
         todo.len(),
     );
 
+    // Amendments whose reply never parsed. They are lost from this sweep, so the
+    // run has to name them rather than let the totals imply everything landed.
+    let mut failed: Vec<String> = Vec::new();
+
     if !todo.is_empty() {
         let opts = crate::fail::or_exit(
             chat_options(
@@ -165,7 +169,7 @@ pub fn run(args: Args) {
         // The cache is updated and flushed to disk after every successful call so
         // an interrupted run can be resumed without losing completed extractions.
         let shared = Mutex::new(cache);
-        extract_all(&llm, &todo, args.threads, &shared, &cache_path, &opts);
+        failed = extract_all(&llm, &todo, args.threads, &shared, &cache_path, &opts);
         cache = shared.into_inner().unwrap();
     }
 
@@ -222,6 +226,7 @@ pub fn run(args: Args) {
         .save(output, Format::Compact)
         .expect("Error saving dataset");
 
+    crate::report::failed_amendments(&failed);
     println!("Wrote {output}");
 }
 
@@ -230,6 +235,10 @@ pub fn run(args: Args) {
 /// Each successful extraction is inserted into `cache` and flushed to
 /// `cache_path` immediately (under the lock), so an interrupted run leaves a
 /// complete, resumable cache on disk. The dataset itself is untouched here.
+///
+/// Returns the ids of the amendments that failed, so the caller can report the
+/// loss. A failure is deliberately kept out of the cache: that is what makes
+/// running the command again retry it, with no flag (`docs/adr/0005`).
 fn extract_all(
     llm: &LlmClient,
     tasks: &[Task],
@@ -237,9 +246,10 @@ fn extract_all(
     cache: &Mutex<HashMap<String, Cached>>,
     cache_path: &Path,
     opts: &ChatOptions,
-) {
+) -> Vec<String> {
     let next = AtomicUsize::new(0);
     let done = AtomicUsize::new(0);
+    let failed: Mutex<Vec<String>> = Mutex::new(Vec::new());
     let worker_count = threads.max(1);
 
     std::thread::scope(|scope| {
@@ -249,25 +259,35 @@ fn extract_all(
                     let i = next.fetch_add(1, Ordering::Relaxed);
                     let Some(task) = tasks.get(i) else { break };
 
-                    match extract_changes(llm, &task.amending_text, opts) {
+                    let outcome = match extract_changes(llm, &task.amending_text, opts) {
                         Ok(cached) => {
                             // Insert and persist while holding the lock so the on-disk
                             // cache is always consistent with in-memory state.
                             let mut guard = cache.lock().unwrap();
                             guard.insert(task.amendment_id.clone(), cached);
                             write_cache(cache_path, &guard);
+                            "extracted"
                         }
                         Err(err) => {
+                            // One call, so the raw reply inside `err` stays in one
+                            // piece even when several workers fail at once.
                             eprintln!("ERROR extracting {}: {err}", task.amendment_id);
+                            failed.lock().unwrap().push(task.amendment_id.clone());
+                            "failed"
                         }
-                    }
+                    };
 
                     let n = done.fetch_add(1, Ordering::Relaxed) + 1;
-                    println!("[{n}/{}] extracted", tasks.len());
+                    println!("[{n}/{}] {outcome}", tasks.len());
                 }
             });
         }
     });
+
+    // Workers race, so sort for a report that reads the same on every run.
+    let mut failed = failed.into_inner().unwrap();
+    failed.sort();
+    failed
 }
 
 /// Query the LLM for one amendment and parse its `<response>` payload.

--- a/src/bin/words_to_data/main.rs
+++ b/src/bin/words_to_data/main.rs
@@ -16,6 +16,7 @@ mod info;
 mod load;
 mod match_amendments;
 mod path;
+mod report;
 mod score_amendments;
 mod search;
 mod show_bill;

--- a/src/bin/words_to_data/match_amendments.rs
+++ b/src/bin/words_to_data/match_amendments.rs
@@ -125,6 +125,9 @@ pub fn run(args: Args) {
     let mut candidates_by_work = Vec::new();
     let mut applied = 0;
     let mut annotated_paths = 0;
+    // Amendments whose reply never parsed, gathered across every pair in the
+    // span so one run reports one total.
+    let mut failed: Vec<String> = Vec::new();
 
     for (from, to) in pairs {
         let diff = crate::fail::or_exit(dataset.compute_diff(&from, &to), "Error computing diff");
@@ -134,7 +137,8 @@ pub fn run(args: Args) {
         print_stats(&matches);
 
         // Ask the LLM which candidate(s) each amendment matches.
-        let matched = classify_all(&llm, &matches, args.threads, &opts);
+        let (matched, lost) = classify_all(&llm, &matches, args.threads, &opts);
+        failed.extend(lost);
 
         // Apply the LLM's annotations single-threaded.
         for (match_idx, classification) in matched {
@@ -224,6 +228,7 @@ pub fn run(args: Args) {
         candidates_by_work.len()
     );
     println!("Annotated paths: {annotated_paths}");
+    crate::report::failed_amendments(&failed);
     println!("Wrote {}", candidates_path.display());
     println!("Wrote {output}");
 }
@@ -252,15 +257,20 @@ fn print_stats(matches: &[AmendmentMatch]) {
 ///
 /// Workers only read match data and return `(match_index, annotations)`; the
 /// caller applies the annotations to the dataset single-threaded.
+/// Returns the classifications that succeeded, and the ids of the amendments
+/// that failed so the caller can report the loss. A reply that does not parse
+/// is not kept: it backs no statement, so it is not evidence
+/// (`docs/adr/0005`). Running the command again is the retry.
 fn classify_all(
     llm: &LlmClient,
     matches: &[AmendmentMatch],
     threads: usize,
     opts: &ChatOptions,
-) -> Vec<(usize, Classification)> {
+) -> (Vec<(usize, Classification)>, Vec<String>) {
     let next = AtomicUsize::new(0);
     let done = AtomicUsize::new(0);
     let results: Mutex<Vec<(usize, Classification)>> = Mutex::new(Vec::new());
+    let failed: Mutex<Vec<String>> = Mutex::new(Vec::new());
     let worker_count = threads.max(1);
 
     std::thread::scope(|scope| {
@@ -270,23 +280,31 @@ fn classify_all(
                     let i = next.fetch_add(1, Ordering::Relaxed);
                     let Some(m) = matches.get(i) else { break };
 
-                    match classify(llm, m, opts) {
+                    let outcome = match classify(llm, m, opts) {
                         Ok(classification) => {
                             results.lock().unwrap().push((i, classification));
+                            "matched"
                         }
                         Err(err) => {
+                            // One call, so the raw reply inside `err` stays in one
+                            // piece even when several workers fail at once.
                             eprintln!("ERROR matching {}: {err}", m.amendment_id);
+                            failed.lock().unwrap().push(m.amendment_id.clone());
+                            "failed"
                         }
-                    }
+                    };
 
                     let n = done.fetch_add(1, Ordering::Relaxed) + 1;
-                    println!("[{n}/{}] matched", matches.len());
+                    println!("[{n}/{}] {outcome}", matches.len());
                 }
             });
         }
     });
 
-    results.into_inner().unwrap()
+    // Workers race, so sort for a report that reads the same on every run.
+    let mut failed = failed.into_inner().unwrap();
+    failed.sort();
+    (results.into_inner().unwrap(), failed)
 }
 
 /// One amendment's answer: what the model said, and what it was parsed into.

--- a/src/bin/words_to_data/report.rs
+++ b/src/bin/words_to_data/report.rs
@@ -1,0 +1,43 @@
+//! Telling the person who ran a sweep what it lost.
+//!
+//! An LLM sweep drops any amendment whose reply does not parse. The reply is not
+//! kept — it backs no statement, so it is not evidence (`docs/adr/0005`) — which
+//! leaves the run itself as the only place the loss is visible. Silence here
+//! means an amendment goes missing while every total says the run went fine.
+
+/// How many ids to name before falling back to a count.
+///
+/// A sweep over a whole Congress can fail on hundreds. Naming every one buries
+/// the totals printed after it, and nobody reads the four hundredth id.
+const NAMED: usize = 10;
+
+/// Report the amendments a sweep lost, naming as many as will fit.
+///
+/// The id is what a person greps for in stderr to read the model's raw text, so
+/// a bare count would say a loss happened without saying where to look.
+/// Prints nothing when nothing failed: a clean run stays quiet.
+pub fn failed_amendments(failed: &[String]) {
+    if failed.is_empty() {
+        return;
+    }
+
+    let noun = if failed.len() == 1 {
+        "amendment"
+    } else {
+        "amendments"
+    };
+    println!("\n{} {noun} failed:", failed.len());
+
+    // One id per line. An id is 64 characters, so ten of them on one line is a
+    // wall of hex that a person has to scroll sideways through to read.
+    for id in failed.iter().take(NAMED) {
+        println!("  {id}");
+    }
+    let rest = failed.len().saturating_sub(NAMED);
+    if rest > 0 {
+        println!("  and {rest} more");
+    }
+
+    println!("Their replies are not kept. Run the command again to retry them.");
+    println!("What the model sent is on stderr above, under the same ids.");
+}

--- a/tests/cli_llm_tests.rs
+++ b/tests/cli_llm_tests.rs
@@ -6,11 +6,17 @@
 //! real. Only the network peer is fake, which is the system boundary that
 //! `CLAUDE.md` allows mocking.
 //!
-//! The reply content is real: it comes from `changes_cache.json`, the surviving
-//! output of a production extraction run. The wrapper around it is
-//! reconstructed, because the raw model replies were never persisted (#58). So
-//! this proves the pipeline works. It does not prove the parser survives the
-//! formatting a model really emits, and it cannot until #58 is done.
+//! The reply content is real. The well-formed cases come from a production run:
+//! either `changes_cache.json` or the recorded replies in the corpus. The
+//! malformed cases are a recorded reply cut short, which is what a `max_tokens`
+//! ceiling does to a reply in flight.
+//!
+//! Cutting one short is the only way to get a malformed fixture, and it stays
+//! that way: a reply that does not parse produced no statement, so it is not
+//! evidence and is never recorded
+//! (`docs/adr/0005-evidence-is-stored-once-and-never-deleted.md`). No sweep will
+//! ever add one to the corpus. What a run does instead is report the loss, and
+//! that is what the failure tests below pin.
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -18,15 +24,67 @@ use std::process::Command;
 use std::thread;
 
 use words_to_data::dataset::{Dataset, DatasetMetadata, Format};
+use words_to_data::storage::EvidenceReader;
 use words_to_data::uslm::bill_parser::parse_bill_amendments;
 
 /// A real public law from the test corpus: HR 1 of the 119th Congress.
 const BILL_XML: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml";
 const BILL_ID: &str = "119-21";
 
+/// The title HR 1 amends, at the two release points the corpus holds. Title 51
+/// is smaller, but it did not change between them and HR 1 does not mention it,
+/// so it yields no candidates and the model is never called.
+const TITLE_26: &str = "uscode/title_26";
+const USC26_EARLY: &str = "tests/test_data/usc/2025-07-18/usc26.xml";
+const USC26_LATE: &str = "tests/test_data/usc/2025-07-30/usc26.xml";
+const EARLY: &str = "2025-07-18";
+const LATE: &str = "2025-07-30";
+
 /// One real extraction result, lifted verbatim from `changes_cache.json`.
 const REAL_EXTRACTION: &str =
     r#"[{"added":["of—\"(A)"],"removed":["of"]},{"added":[";"],"removed":["."]}]"#;
+
+/// Real recorded replies, one per command shape.
+const REPLIES: &str = "tests/test_data/processed/model_replies.json";
+
+/// A real recorded reply for `command`, cut in half.
+///
+/// A reply that failed to parse is never stored (`docs/adr/0005`), so the corpus
+/// holds no malformed reply and never will. Cutting a real one short is not
+/// invented data: it is what a `max_tokens` ceiling does to a reply in flight,
+/// and the surviving half is the model's own text.
+fn truncated_real_reply(command: &str) -> String {
+    #[derive(serde::Deserialize)]
+    struct RecordedReply {
+        command: String,
+        reply: String,
+    }
+    let json = std::fs::read_to_string(REPLIES).expect("the fixture should be readable");
+    let replies: Vec<RecordedReply> =
+        serde_json::from_str(&json).expect("the fixture should parse");
+    let full = replies
+        .into_iter()
+        .filter(|r| r.command == command)
+        .max_by_key(|r| r.reply.len())
+        .expect("the fixture should hold a reply for this command")
+        .reply;
+    full[..full.len() / 2].to_string()
+}
+
+/// The id of the single amendment in a fixture dataset.
+fn only_amendment_id(dataset_path: &str) -> String {
+    let dataset = Dataset::load(dataset_path, Format::Compact).expect("the fixture should load");
+    let bill = dataset
+        .get_bill(BILL_ID)
+        .expect("reading the bill should work")
+        .expect("the bill should be there");
+    bill.amendments
+        .values()
+        .next()
+        .expect("the fixture should hold one amendment")
+        .id
+        .clone()
+}
 
 /// Serve one canned chat-completion reply to every request, forever.
 ///
@@ -83,6 +141,14 @@ fn start_stub_server(content: String) -> String {
 /// it yet. One amendment keeps the test to a single round trip; the amendment
 /// itself is real, taken from the parsed public law.
 fn dataset_with_one_amendment(name: &str) -> String {
+    dataset_with_amendments(name, 1)
+}
+
+/// The same, holding the first `count` real amendments of the public law.
+///
+/// The bill carries 603, so a caller can ask for more than the summary will
+/// name and still be working from real amendments.
+fn dataset_with_amendments(name: &str, count: usize) -> String {
     let directory = format!("{}/{name}", env!("CARGO_TARGET_TMPDIR"));
     std::fs::create_dir_all(&directory).expect("the fixture directory should exist");
     // A stale sibling cache would let the command skip the server entirely.
@@ -92,11 +158,9 @@ fn dataset_with_one_amendment(name: &str) -> String {
 
     let mut ids: Vec<String> = bill.amendments.keys().cloned().collect();
     ids.sort();
-    let keep = ids
-        .first()
-        .expect("the bill should have amendments")
-        .clone();
-    bill.amendments.retain(|id, _| *id == keep);
+    let keep: std::collections::HashSet<String> = ids.into_iter().take(count).collect();
+    assert_eq!(keep.len(), count, "the bill should have {count} amendments");
+    bill.amendments.retain(|id, _| keep.contains(id));
 
     let mut dataset = Dataset::new(DatasetMetadata {
         name: "LLM Test Fixture".to_string(),
@@ -107,6 +171,50 @@ fn dataset_with_one_amendment(name: &str) -> String {
         version: "1.0.0".to_string(),
         ..Default::default()
     });
+    dataset.add_bill(bill).expect("the bill should be added");
+
+    let path = format!("{directory}/dataset.json");
+    dataset
+        .save(&path, Format::Compact)
+        .expect("the fixture should save");
+    path
+}
+
+/// A dataset `match-amendments` can work on: title 26 at both release points,
+/// plus the public law that amends it, with word-level changes on the
+/// amendments so the similarity channel produces candidates.
+///
+/// The changes are one amendment's real extraction, copied across the bill.
+/// Extraction is an LLM's reading and the corpus holds no per-amendment result,
+/// so this is the same compromise `matching_tests` makes, with real output
+/// rather than invented words. It decides which candidates appear, not what the
+/// command does with a reply, which is what the test is about.
+fn dataset_for_matching(name: &str) -> String {
+    let directory = format!("{}/{name}", env!("CARGO_TARGET_TMPDIR"));
+    std::fs::create_dir_all(&directory).expect("the fixture directory should exist");
+
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Matching Test Fixture".to_string(),
+        description: "Title 26 at two release points, with HR 1".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "MIT".to_string(),
+        version: "1.0.0".to_string(),
+        ..Default::default()
+    });
+    for (xml, date, label) in [(USC26_EARLY, EARLY, "Before"), (USC26_LATE, LATE, "After")] {
+        dataset
+            .add_uslm_xml(xml, date, Some(label.to_string()))
+            .expect("the corpus should parse and load");
+    }
+
+    let changes =
+        words_to_data::llm::parse_changes(&format!("<response>{REAL_EXTRACTION}</response>"))
+            .expect("the real extraction should parse");
+    let mut bill = parse_bill_amendments(BILL_ID, BILL_XML).expect("the public law should parse");
+    for amendment in bill.amendments.values_mut() {
+        amendment.changes = changes.clone();
+    }
     dataset.add_bill(bill).expect("the bill should be added");
 
     let path = format!("{directory}/dataset.json");
@@ -204,5 +312,307 @@ fn should_write_nothing_when_the_model_finds_no_changes() {
         amendment.changes.is_empty(),
         "an empty reply must not invent changes, got {:?}",
         amendment.changes
+    );
+}
+
+/// A reply that does not parse loses its amendment. The run has to say so, and
+/// say which one, because the id is the key into the stderr record (#101).
+#[test]
+fn should_name_the_lost_amendment_when_a_reply_cannot_be_parsed() {
+    let dataset_path = dataset_with_one_amendment("llm_unparseable");
+    let amendment_id = only_amendment_id(&dataset_path);
+    let base_url = start_stub_server(truncated_real_reply("extract-changes"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "extract-changes",
+            &dataset_path,
+            "--base-url",
+            &base_url,
+            "--threads",
+            "1",
+            "--no-cache",
+        ])
+        .output()
+        .expect("the binary should run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("1 amendment failed"),
+        "the summary should count the loss, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&amendment_id),
+        "the summary should name the lost amendment {amendment_id}, got:\n{stdout}"
+    );
+}
+
+/// The per-item progress line counted every reply as `extracted`, including the
+/// ones that were lost, so the running total contradicted the summary (#101).
+#[test]
+fn should_not_count_a_failure_as_an_extraction_in_the_progress_line() {
+    let dataset_path = dataset_with_one_amendment("llm_progress");
+    let base_url = start_stub_server(truncated_real_reply("extract-changes"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "extract-changes",
+            &dataset_path,
+            "--base-url",
+            &base_url,
+            "--threads",
+            "1",
+            "--no-cache",
+        ])
+        .output()
+        .expect("the binary should run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("[1/1] extracted"),
+        "a lost amendment must not read as extracted, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("[1/1] failed"),
+        "the progress line should say the item failed, got:\n{stdout}"
+    );
+}
+
+/// A sweep over a whole Congress can lose hundreds of amendments. Naming every
+/// one buries the totals printed after it, so the list stops and says how many
+/// it did not name (#101).
+#[test]
+fn should_cap_the_named_ids_when_more_amendments_fail_than_fit() {
+    let dataset_path = dataset_with_amendments("llm_many_failures", 12);
+    let base_url = start_stub_server(truncated_real_reply("extract-changes"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "extract-changes",
+            &dataset_path,
+            "--base-url",
+            &base_url,
+            "--threads",
+            "1",
+            "--no-cache",
+        ])
+        .output()
+        .expect("the binary should run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("12 amendments failed"),
+        "the summary should count every loss, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("and 2 more"),
+        "the summary should say how many it did not name, got:\n{stdout}"
+    );
+
+    // Ids are the only 64-character hex tokens the report prints.
+    let named = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.len() == 64 && line.chars().all(|c| c.is_ascii_hexdigit()))
+        .count();
+    assert_eq!(
+        named, 10,
+        "ten ids should be named before the count takes over, got:\n{stdout}"
+    );
+}
+
+/// A reply that produced no statement is not evidence, so the dataset does not
+/// carry it (`docs/adr/0005`). This pins that decision: the obvious way to
+/// "improve" the report is to keep the text, and that is the rejected design.
+#[test]
+fn should_store_no_evidence_when_a_reply_cannot_be_parsed() {
+    let dataset_path = dataset_with_one_amendment("llm_no_evidence");
+    let base_url = start_stub_server(truncated_real_reply("extract-changes"));
+
+    Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "extract-changes",
+            &dataset_path,
+            "--base-url",
+            &base_url,
+            "--threads",
+            "1",
+            "--no-cache",
+        ])
+        .output()
+        .expect("the binary should run");
+
+    let dataset = Dataset::load(&dataset_path, Format::Compact).expect("the result should load");
+
+    assert!(
+        dataset
+            .replies()
+            .expect("replies should be readable")
+            .is_empty(),
+        "a reply that did not parse must not reach the reply store"
+    );
+
+    let bill = dataset
+        .get_bill(BILL_ID)
+        .expect("reading the bill should work")
+        .expect("the bill should still be there");
+    let amendment = bill
+        .amendments
+        .values()
+        .next()
+        .expect("the amendment should still be there");
+
+    assert!(
+        amendment.changes.is_empty(),
+        "a lost amendment must carry no changes"
+    );
+    assert!(
+        amendment.provenance.is_none(),
+        "a lost amendment must carry no provenance, got {:?}",
+        amendment.provenance
+    );
+}
+
+/// Retrying is running the command again: a failure never enters the cache, so
+/// the next run re-queries it with no flag (`docs/adr/0005`).
+#[test]
+fn should_retry_a_failed_amendment_on_the_next_run_without_a_flag() {
+    let dataset_path = dataset_with_one_amendment("llm_retry");
+    let failing = start_stub_server(truncated_real_reply("extract-changes"));
+
+    let first = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "extract-changes",
+            &dataset_path,
+            "--base-url",
+            &failing,
+            "--threads",
+            "1",
+        ])
+        .output()
+        .expect("the binary should run");
+    assert!(
+        String::from_utf8_lossy(&first.stdout).contains("1 amendment failed"),
+        "the first run should lose the amendment"
+    );
+
+    // Same command, no flags, against a server that now answers properly.
+    let working = start_stub_server(format!("<response>{REAL_EXTRACTION}</response>"));
+    let second = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "extract-changes",
+            &dataset_path,
+            "--base-url",
+            &working,
+            "--threads",
+            "1",
+        ])
+        .output()
+        .expect("the binary should run");
+
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        stdout.contains("1 to extract"),
+        "the failed amendment should be queued again, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("failed"),
+        "the retry should succeed, got:\n{stdout}"
+    );
+
+    let dataset = Dataset::load(&dataset_path, Format::Compact).expect("the result should load");
+    let bill = dataset
+        .get_bill(BILL_ID)
+        .expect("reading the bill should work")
+        .expect("the bill should still be there");
+    assert_eq!(
+        bill.amendments
+            .values()
+            .next()
+            .expect("the amendment should be there")
+            .changes
+            .len(),
+        2,
+        "the retry should write the changes the second reply carried"
+    );
+}
+
+/// `match-amendments` loses an amendment to an unparseable reply exactly as
+/// `extract-changes` does, and has to report it the same way (#101).
+#[test]
+fn should_name_the_lost_amendment_when_match_amendments_cannot_parse_a_reply() {
+    let dataset_path = dataset_for_matching("llm_match_failure");
+    let base_url = start_stub_server(truncated_real_reply("match-amendments"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "match-amendments",
+            &dataset_path,
+            "--from",
+            &format!("{TITLE_26}@{EARLY}"),
+            "--to",
+            &format!("{TITLE_26}@{LATE}"),
+            "--base-url",
+            &base_url,
+            "--threads",
+            "1",
+        ])
+        .output()
+        .expect("the binary should run");
+
+    assert!(
+        output.status.success(),
+        "a lost amendment is not a failed run, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("amendments failed:") || stdout.contains("amendment failed:"),
+        "the summary should report the loss, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("] matched"),
+        "no reply parsed, so nothing should read as matched, got:\n{stdout}"
+    );
+
+    // The rejected design is to keep the text. Pin that it is not kept.
+    let dataset = Dataset::load(&dataset_path, Format::Compact).expect("the result should load");
+    assert!(
+        dataset
+            .replies()
+            .expect("replies should be readable")
+            .is_empty(),
+        "a reply that did not parse must not reach the reply store"
+    );
+}
+
+/// A partial failure is the normal state of an LLM sweep, not an error. A hard
+/// exit would break a pipeline over three losses in nine hundred (#101).
+#[test]
+fn should_exit_zero_when_some_amendments_fail() {
+    let dataset_path = dataset_with_one_amendment("llm_exit_code");
+    let base_url = start_stub_server(truncated_real_reply("extract-changes"));
+
+    let output = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "extract-changes",
+            &dataset_path,
+            "--base-url",
+            &base_url,
+            "--threads",
+            "1",
+            "--no-cache",
+        ])
+        .output()
+        .expect("the binary should run");
+
+    assert!(
+        output.status.success(),
+        "a lost amendment is not a failed run, got {:?}",
+        output.status
     );
 }


### PR DESCRIPTION
Closes #101 — but `Closes` does not fire on a PR into `vibes`, so the issue gets closed by hand after merge.

## What this does

`extract-changes` and `match-amendments` dropped any amendment whose reply did not parse, and said nothing about it. Reproduced against the real binary, serving a real recorded reply cut in half:

```
EXIT: exit status: 0
STDOUT:  0 amendments already extracted; 0 cached; 1 to extract
         [1/1] extracted
         Wrote .../dataset.json
STDERR:  ERROR extracting 0064b563...: no </response> tag in model output
```

The amendment was gone and every line said the run went fine.

Now:

```
[12/12] failed

12 amendments failed:
  0064b563daa23ae280ca89cd532a0f4f569e0e35457620b4a2f7996bc9bc2451
  ... eight more ...
  and 2 more
Their replies are not kept. Run the command again to retry them.
What the model sent is on stderr above, under the same ids.
```

## The decision behind it

Triage rejected the storage half of #101. A reply that no parser could read produced no statement, so it is not evidence and the dataset does not carry it. ADR 0005 previously called this "a gap in the implementation" and promised a fix; the first commit withdraws that promise, records the cost, and adds the rejected design to *Considered and rejected*.

The cost is real: no sweep can now supply a parser fixture for truncation, a refusal, or a stray thinking block. Those have to be kept by hand from a run's stderr.

## Deliberately unchanged

- **Storage.** A failed reply reaches neither the reply store nor the extraction cache. The cache part is load-bearing: it is what makes re-running the command the retry, with no flag.
- **Exit code.** Still zero. A partial failure is the normal state of an LLM sweep, and a hard exit would break a pipeline over three losses in nine hundred.
- **Schema.** No new serialized field, no `SCHEMA_VERSION` bump, so no `breaking-changes` label. Distinguishing a failed reply from a superseded one in the file *would* have cost a schema version, which is part of why that design lost.

## Tests

306 → 313, 0 failed, clippy clean. Malformed fixtures are a real recorded reply cut in half, which is what a `max_tokens` ceiling does to a reply in flight.

Two notes for the reviewer:

- **The suite is 34s slower** (141s → 175s). The `match-amendments` test needs title 26 at both release points: title 51 has no diff between them and HR 1 does not mention it, so the smaller title yields no candidates and never calls the model. `matching_tests` already pays the same 34s for the same reason.
- **One fixture compromise.** `dataset_for_matching` copies one amendment's real extraction across the bill, because the corpus holds no per-amendment extraction result. `matching_tests` makes the same compromise with invented words; this uses real output. It decides which candidates appear, not what the command does with a reply.
