### PR TITLE
fix: read a member's party from the day of the vote (BREAKING: schema 6 -> 7)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,14 @@ _Avoid_: Delta, comparison, change set
 An instruction in a bill that tells a reader how to change existing law.
 _Avoid_: Edit, modification, revision
 
+**Member**:
+A person who sits in a legislature. The person does not change. Almost everything the source says about them is true only of a date.
+_Avoid_: Legislator, representative
+
+**Party affiliation**:
+The party a Member held, with the years the source gives for it. A Member carries a history of these and never one undated party, because the affiliation is dated in the same way that an Expression is one Work on one date: the person is the Work, the affiliation on a day is the Expression. A vote carries a date, so the party reported beside a vote is the party held on that day. The source gives years and not days, and the year of a change belongs to two affiliations, so a date in that year is answered as unresolved. An unresolved affiliation is a different answer from a known one, and every reader can tell them apart.
+_Avoid_: Current party, the member's party
+
 **Link**:
 A statement that connects one provision to something else. It carries a subject, a namespaced kind, an object, and its provenance. Every reader can read a link, even a reader that does not know the kind. Its identity comes from its subject, its kind, and its object, so restating the same fact updates one link rather than making a second one.
 _Avoid_: Relation, edge, reference

--- a/src/bin/words_to_data/main.rs
+++ b/src/bin/words_to_data/main.rs
@@ -22,6 +22,7 @@ mod search;
 mod show_bill;
 mod span;
 mod validate;
+mod votes;
 
 /// Words to Data — legal document tooling
 #[derive(Parser)]
@@ -54,6 +55,8 @@ enum Command {
 
     /// Show a bill's amendments
     ShowBill(show_bill::Args),
+    /// Show how the House voted on a bill, by the party held on the vote's date
+    Votes(votes::Args),
     /// Full-text search across every expression
     Search(search::Args),
     /// List the paths that changed between two expressions of one work
@@ -79,6 +82,7 @@ fn main() {
         Command::Expressions(args) => expressions::run(args),
         Command::Bills(args) => bills::run(args),
         Command::ShowBill(args) => show_bill::run(args),
+        Command::Votes(args) => votes::run(args),
         Command::Search(args) => search::run(args),
         Command::Diff(args) => diff::run(args),
         Command::Coverage(args) => coverage::run(args),

--- a/src/bin/words_to_data/votes.rs
+++ b/src/bin/words_to_data/votes.rs
@@ -1,0 +1,88 @@
+//! `words_to_data votes` — how the House voted on a bill, party by party.
+//!
+//! Each party is the one the member held on the day of the roll call, not the
+//! one they hold now. A vote whose party the date cannot settle is listed on its
+//! own rather than counted into a party, because the party history carries years
+//! and a change year belongs to two parties (#105).
+
+use clap::Args as ClapArgs;
+use words_to_data::inspect::{self, RollCallTally};
+
+use crate::load::{self, with_dataset};
+
+#[derive(ClapArgs)]
+pub struct Args {
+    /// Dataset file (`.json` compact or `.sqlite`)
+    pub dataset: String,
+
+    /// Bill identifier (e.g. `119-hr-1`)
+    pub bill_id: String,
+
+    /// Emit JSON instead of human-readable text
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub fn run(args: Args) {
+    let ds = crate::fail::or_exit(load::open(&args.dataset), "Error opening dataset");
+    let tallies = crate::fail::or_exit(
+        with_dataset!(ds, d => inspect::votes(&d, &args.bill_id)),
+        "Error reading votes",
+    );
+
+    let Some(tallies) = tallies else {
+        eprintln!("No votes for bill: {}", args.bill_id);
+        std::process::exit(1);
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&tallies).unwrap());
+        return;
+    }
+
+    println!("Bill: {}", args.bill_id);
+    for tally in &tallies {
+        print_tally(tally);
+    }
+    if tallies.is_empty() {
+        println!("\nThe dataset holds no roll call for this bill.");
+    }
+}
+
+fn print_tally(tally: &RollCallTally) {
+    println!(
+        "\nRoll call {} on {} — {}",
+        tally.roll_number, tally.date, tally.result
+    );
+    println!("  {}", tally.question);
+
+    for row in &tally.by_party {
+        println!(
+            "  {:<12} {:<10} {:>4}",
+            row.party.to_string(),
+            row.position.to_string(),
+            row.count
+        );
+    }
+
+    if tally.unresolved.is_empty() {
+        return;
+    }
+
+    // These votes are in no party column above. Saying so is the point: the
+    // alternative is a tally that silently does not add up to the roll call.
+    println!(
+        "  {} vote(s) with no party for this date:",
+        tally.unresolved.len()
+    );
+    for vote in &tally.unresolved {
+        let name = vote.name.as_deref().unwrap_or("(member not in dataset)");
+        println!(
+            "    {:<10} {:<24} {:<10} {}",
+            vote.bioguide_id,
+            name,
+            vote.position.to_string(),
+            vote.party
+        );
+    }
+}

--- a/src/congress/member.rs
+++ b/src/congress/member.rs
@@ -1,14 +1,28 @@
+//! Congress members, and the party each of them held on a given day.
+//!
+//! A member's affiliation is dated, in the same way that an expression is one
+//! work as it read on one date (`CONTEXT.md`). The API supplies the history, so
+//! all of it is kept: reading a 2025 vote through the party a member holds in
+//! 2026 states something false (#105).
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
 use std::str::FromStr;
+use time::Date;
 
 use super::CongressError;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum Party {
     Democrat,
     Republican,
     Independent,
+    /// A party this build has no variant for, under the name the API gave it.
+    ///
+    /// Every member in the cached corpus parses to one of the three above. The
+    /// variant stays all the same: one corpus is not the whole legislature, and
+    /// a party met for the first time must be carried, not dropped.
     Other(String),
 }
 
@@ -22,6 +36,87 @@ impl FromStr for Party {
             "I" | "ID" | "Independent" => Party::Independent,
             other => Party::Other(other.to_string()),
         })
+    }
+}
+
+impl fmt::Display for Party {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Party::Democrat => write!(f, "Democrat"),
+            Party::Republican => write!(f, "Republican"),
+            Party::Independent => write!(f, "Independent"),
+            Party::Other(name) => write!(f, "{name}"),
+        }
+    }
+}
+
+/// One party a member belonged to, over the years the API gives for it.
+///
+/// The API dates an affiliation by year and not by day, and an end year is the
+/// year the member left rather than the last full year in the party. Two
+/// affiliations therefore share the year of a change, and a day inside that
+/// year belongs to both of them as far as this data can tell.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartyAffiliation {
+    pub party: Party,
+    /// The API's own name for the party, such as `Democratic`.
+    pub name: String,
+    pub start_year: u16,
+    /// `None` while the member still holds this affiliation.
+    pub end_year: Option<u16>,
+}
+
+impl PartyAffiliation {
+    /// Whether this affiliation covers a year.
+    ///
+    /// The end year counts as covered, because the member held the party for
+    /// part of it. That is what makes a change year ambiguous instead of
+    /// quietly resolving to the party that was left.
+    fn covers(&self, year: u16) -> bool {
+        self.start_year <= year && self.end_year.is_none_or(|end| year <= end)
+    }
+}
+
+/// The party a member held on one date, or the reason it cannot be told.
+///
+/// A party worked out from overlapping years is not a known fact, so it is not
+/// reported as one. Every reader can tell the two apart, including a reader of
+/// `--json`, which is the same separation between what is known and what is
+/// suggested that the rest of the project keeps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PartyOnDate {
+    /// One affiliation covers the date.
+    Resolved(Party),
+    /// More than one affiliation covers the date, because the history carries
+    /// years and not days. Every party the date can belong to, oldest first.
+    Ambiguous(Vec<Party>),
+    /// No affiliation on file covers the date.
+    Unknown,
+}
+
+impl PartyOnDate {
+    /// The one party held on the date, or `None` when it is unresolved.
+    ///
+    /// Use this where a caller must have one party. It gives no answer rather
+    /// than a guess, which is why the ambiguous case is not folded into it.
+    pub fn resolved(&self) -> Option<&Party> {
+        match self {
+            PartyOnDate::Resolved(party) => Some(party),
+            PartyOnDate::Ambiguous(_) | PartyOnDate::Unknown => None,
+        }
+    }
+}
+
+impl fmt::Display for PartyOnDate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PartyOnDate::Resolved(party) => write!(f, "{party}"),
+            PartyOnDate::Ambiguous(parties) => {
+                let names: Vec<String> = parties.iter().map(Party::to_string).collect();
+                write!(f, "unresolved ({})", names.join(" or "))
+            }
+            PartyOnDate::Unknown => write!(f, "unknown"),
+        }
     }
 }
 
@@ -59,7 +154,12 @@ pub struct Member {
     pub name: String,
     pub first_name: String,
     pub last_name: String,
-    pub party: Party,
+    /// Every party this member has belonged to, oldest first.
+    ///
+    /// There is deliberately no single `party` beside this. One undated field
+    /// is read as the party held on whatever day the caller is asking about,
+    /// and it holds the party the member has today (#105).
+    pub party_history: Vec<PartyAffiliation>,
     pub state: String,
     pub district: Option<u8>,
     pub chamber: Chamber,
@@ -67,6 +167,30 @@ pub struct Member {
 }
 
 impl Member {
+    /// The party this member held on one date.
+    ///
+    /// A roll call carries a date, so this is the only honest way to report the
+    /// party behind a vote. Where the party history cannot answer for the date,
+    /// the answer says so instead of picking one.
+    pub fn party_on(&self, date: Date) -> PartyOnDate {
+        let Ok(year) = u16::try_from(date.year()) else {
+            return PartyOnDate::Unknown;
+        };
+
+        let mut covering: Vec<Party> = self
+            .party_history
+            .iter()
+            .filter(|affiliation| affiliation.covers(year))
+            .map(|affiliation| affiliation.party.clone())
+            .collect();
+
+        match covering.len() {
+            0 => PartyOnDate::Unknown,
+            1 => PartyOnDate::Resolved(covering.remove(0)),
+            _ => PartyOnDate::Ambiguous(covering),
+        }
+    }
+
     pub fn from_api_response(json: &str) -> Result<Self, CongressError> {
         let v: Value = serde_json::from_str(json)?;
         let member = &v["member"];
@@ -85,13 +209,14 @@ impl Member {
             .map(String::from)
             .unwrap_or_else(|| format!("{} {}", first_name, last_name));
 
-        // Parse party from partyHistory (most recent)
-        let party = member["partyHistory"]
+        // The whole party history, sorted by the field that decides the order.
+        // The API happens to list it newest first and promises nothing, so the
+        // order is made here rather than assumed.
+        let mut party_history: Vec<PartyAffiliation> = member["partyHistory"]
             .as_array()
-            .and_then(|arr| arr.first())
-            .and_then(|p| p["partyAbbreviation"].as_str())
-            .map(|s| s.parse::<Party>().unwrap_or(Party::Other(s.to_string())))
-            .unwrap_or(Party::Other("Unknown".to_string()));
+            .map(|entries| entries.iter().map(party_affiliation).collect())
+            .unwrap_or_default();
+        party_history.sort_by_key(|affiliation| affiliation.start_year);
 
         // Parse terms
         let mut terms = Vec::new();
@@ -119,6 +244,10 @@ impl Member {
             }
         }
 
+        // Same again for the terms: the API lists them oldest first, so the
+        // order is imposed here before the most recent one is read off the end.
+        terms.sort_by_key(|term| (term.start_year, term.congress));
+
         // Get state and chamber from most recent term
         let (state, chamber, district) = terms
             .last()
@@ -130,11 +259,32 @@ impl Member {
             name,
             first_name,
             last_name,
-            party,
+            party_history,
             state,
             district,
             chamber,
             terms,
         })
+    }
+}
+
+/// One `partyHistory` entry from a member response.
+///
+/// An entry with no abbreviation keeps the name the API gave, because a dated
+/// affiliation this build cannot name is still a dated affiliation.
+fn party_affiliation(entry: &Value) -> PartyAffiliation {
+    let abbreviation = entry["partyAbbreviation"].as_str().unwrap_or("");
+    let name = entry["partyName"]
+        .as_str()
+        .unwrap_or(abbreviation)
+        .to_string();
+
+    PartyAffiliation {
+        party: abbreviation
+            .parse::<Party>()
+            .unwrap_or(Party::Other(abbreviation.to_string())),
+        name,
+        start_year: entry["startYear"].as_u64().unwrap_or(0) as u16,
+        end_year: entry["endYear"].as_u64().map(|year| year as u16),
     }
 }

--- a/src/congress/mod.rs
+++ b/src/congress/mod.rs
@@ -10,6 +10,6 @@ pub use cache::ResponseCache;
 pub use client::CongressClient;
 pub use download::BillDownload;
 pub use error::CongressError;
-pub use member::{Chamber, Member, MemberTerm, Party};
+pub use member::{Chamber, Member, MemberTerm, Party, PartyAffiliation, PartyOnDate};
 pub use sponsor::{CosponsorRecord, SponsorInfo};
 pub use vote::{BillVotes, HouseRollCall, MemberVote, RecordedVoteRef, VotePosition};

--- a/src/congress/vote.rs
+++ b/src/congress/vote.rs
@@ -1,16 +1,32 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt;
 use std::str::FromStr;
+use time::Date;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 use super::CongressError;
+use crate::date::date_str_to_date;
 
 /// How a member voted on a roll call
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum VotePosition {
     Yea,
     Nay,
     NotVoting,
     Present,
+}
+
+impl fmt::Display for VotePosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VotePosition::Yea => write!(f, "Yea"),
+            VotePosition::Nay => write!(f, "Nay"),
+            VotePosition::NotVoting => write!(f, "Not Voting"),
+            VotePosition::Present => write!(f, "Present"),
+        }
+    }
 }
 
 impl FromStr for VotePosition {
@@ -51,6 +67,23 @@ pub struct HouseRollCall {
 }
 
 impl HouseRollCall {
+    /// The day this roll call was held.
+    ///
+    /// This is what joins a vote to the party the member held, so it is read
+    /// from the roll call rather than worked out by each caller. The API gives
+    /// an offset date-time, such as `2025-07-03T14:31:00-04:00`, and the day is
+    /// taken in the offset it supplied: a vote held late in the evening belongs
+    /// to the day the chamber sat.
+    ///
+    /// `None` means the date is not one this build can read. A caller must
+    /// answer that it does not know, not pick a day.
+    pub fn day(&self) -> Option<Date> {
+        if let Ok(moment) = OffsetDateTime::parse(&self.date, &Rfc3339) {
+            return Some(moment.date());
+        }
+        date_str_to_date(self.date.get(..10)?).ok()
+    }
+
     /// Parse from Congress API house-vote response JSON
     ///
     /// Expects the response from `/house-vote/{congress}/{session}/{voteNumber}`

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -9,9 +9,12 @@
 //! Reports are plain serde structs: the CLI prints them (human-readable or as
 //! `--json`), and tests assert on the data rather than on formatting.
 
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 
 use crate::annotation::ChangeAnnotation;
+use crate::congress::{Party, PartyOnDate, VotePosition};
 use crate::dataset::{DatasetError, ExpressionId, Scope, SearchResult, WorkId};
 use crate::diff::TreeDiff;
 use crate::storage::Storage;
@@ -772,6 +775,107 @@ pub fn show_bill<S: Storage>(
         amendment_count: amendments.len(),
         amendments,
     }))
+}
+
+/// How many members of one party took one position on a roll call.
+#[derive(Debug, Clone, Serialize)]
+pub struct PartyVoteCount {
+    pub party: Party,
+    pub position: VotePosition,
+    pub count: usize,
+}
+
+/// One vote whose party the roll call's date cannot settle.
+#[derive(Debug, Clone, Serialize)]
+pub struct UnresolvedVote {
+    pub bioguide_id: String,
+    /// `None` when this dataset holds no member under that id.
+    pub name: Option<String>,
+    pub position: VotePosition,
+    /// Why the party is unresolved: years two parties share, or nothing on file.
+    pub party: PartyOnDate,
+}
+
+/// One roll call, with every party taken from the day the vote was held.
+///
+/// A member's affiliation is dated, so a roll call cannot be reported through
+/// the party a member holds today: that restates a 2025 vote as a 2026 fact
+/// (#105).
+#[derive(Debug, Clone, Serialize)]
+pub struct RollCallTally {
+    pub roll_number: u32,
+    /// The date of the roll call, as the source gave it.
+    pub date: String,
+    pub question: String,
+    pub result: String,
+    /// One row per party and position, in party then position order. It counts
+    /// only the votes whose party the day of the roll call settles.
+    pub by_party: Vec<PartyVoteCount>,
+    /// The votes no row counts, each with the reason. These and `by_party`
+    /// together are every vote on the roll call: a party that cannot be told is
+    /// left uncounted rather than guessed at.
+    pub unresolved: Vec<UnresolvedVote>,
+}
+
+/// Tally every roll call on one bill, or `None` if the bill has no votes here.
+pub fn votes<S: Storage>(
+    dataset: &S,
+    bill_id: &str,
+) -> Result<Option<Vec<RollCallTally>>, DatasetError> {
+    let Some(bill_votes) = dataset.get_bill_votes(bill_id)? else {
+        return Ok(None);
+    };
+
+    let mut tallies = Vec::new();
+    for roll_call in &bill_votes.roll_calls {
+        let day = roll_call.day();
+        let mut counted: BTreeMap<(Party, VotePosition), usize> = BTreeMap::new();
+        let mut unresolved = Vec::new();
+
+        for vote in &roll_call.member_votes {
+            let member = dataset.get_member(&vote.bioguide_id)?;
+            let party = match (day, &member) {
+                (Some(day), Some(member)) => member.party_on(day),
+                // Either the date is unreadable or the member is not held. In
+                // both cases the party is not known from this dataset.
+                _ => PartyOnDate::Unknown,
+            };
+
+            match party.resolved() {
+                Some(resolved) => {
+                    *counted
+                        .entry((resolved.clone(), vote.position))
+                        .or_default() += 1;
+                }
+                None => unresolved.push(UnresolvedVote {
+                    bioguide_id: vote.bioguide_id.clone(),
+                    name: member.map(|member| member.name),
+                    position: vote.position,
+                    party,
+                }),
+            }
+        }
+
+        unresolved.sort_by(|a, b| a.bioguide_id.cmp(&b.bioguide_id));
+        tallies.push(RollCallTally {
+            roll_number: roll_call.roll_number,
+            date: roll_call.date.clone(),
+            question: roll_call.question.clone(),
+            result: roll_call.result.clone(),
+            by_party: counted
+                .into_iter()
+                .map(|((party, position), count)| PartyVoteCount {
+                    party,
+                    position,
+                    count,
+                })
+                .collect(),
+            unresolved,
+        });
+    }
+
+    tallies.sort_by_key(|tally| tally.roll_number);
+    Ok(Some(tallies))
 }
 
 /// Summarize a dataset's metadata and contents.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -42,6 +42,9 @@ use crate::uslm::bill_parser::Bill;
 /// break. Both on-disk forms carry this number and refuse a file that does not
 /// match, because a break that is not loud reads as an empty dataset.
 ///
+/// 7 dates a member's party: the whole party history is kept, in place of the
+/// one undated field that reported a 2025 vote through a 2026 affiliation
+/// (#105).
 /// 6 keeps the verbatim model reply as evidence, stored once under the hash of
 /// its own text and referenced from a statement's provenance (#58).
 /// 5 stores links directly: one table for every kind, including kinds this
@@ -56,7 +59,7 @@ use crate::uslm::bill_parser::Bill;
 /// bumping this would have rejected valid JSON datasets to fix a SQLite table.
 /// That case is caught where it happens, when the database is opened, rather
 /// than here. A change that alters both forms still belongs to this number.
-pub const SCHEMA_VERSION: i32 = 6;
+pub const SCHEMA_VERSION: i32 = 7;
 
 /// Reading the documents a dataset holds.
 ///

--- a/tests/member_party_tests.rs
+++ b/tests/member_party_tests.rs
@@ -1,0 +1,232 @@
+//! A member's party is dated, so a vote is read with the party of its own day.
+//!
+//! Every member here comes from a cached Congress API response committed under
+//! `tests/test_data/congress_client_cache/member`. None of it is written by
+//! hand: the bug this guards against was only visible in the real responses.
+
+use words_to_data::congress::{Member, Party, PartyOnDate};
+use words_to_data::date::date_str_to_date;
+
+const MEMBER_CACHE: &str = "tests/test_data/congress_client_cache/member";
+
+/// One member, parsed from the response the Congress API really returned.
+fn member(bioguide_id: &str) -> Member {
+    let path = format!("{MEMBER_CACHE}/{bioguide_id}.json");
+    let json = std::fs::read_to_string(&path).expect("the cached response should read");
+    Member::from_api_response(&json).expect("the cached response should parse")
+}
+
+/// Kevin Kiley voted Yea on HR 1 on 2025-07-03 as a Republican, and became an
+/// Independent in 2026. Reading his vote through an undated party made the
+/// dataset report an Independent Yea (#105).
+#[test]
+fn should_report_republican_when_kiley_is_asked_about_the_day_he_voted_on_hr_1() {
+    let kiley = member("K000401");
+
+    let party = kiley.party_on(date_str_to_date("2025-07-03").unwrap());
+
+    assert_eq!(party, PartyOnDate::Resolved(Party::Republican));
+}
+
+/// Jefferson Van Drew changed party from Democratic to Republican across
+/// 2019-2020. He read correctly before this work by luck, because his change
+/// came before every vote in the corpus. He must read correctly on purpose.
+#[test]
+fn should_report_van_drew_on_both_sides_of_his_party_change() {
+    let van_drew = member("V000133");
+
+    assert_eq!(
+        van_drew.party_on(date_str_to_date("2019-06-01").unwrap()),
+        PartyOnDate::Resolved(Party::Democrat),
+        "he sat as a Democrat through 2019"
+    );
+    assert_eq!(
+        van_drew.party_on(date_str_to_date("2021-06-01").unwrap()),
+        PartyOnDate::Resolved(Party::Republican),
+        "he sat as a Republican from 2021 on"
+    );
+}
+
+/// The history carries years, so the year of a change belongs to both parties.
+/// Kiley's Republican entry ends in 2026 and his Independent entry starts in
+/// 2026: no day in 2026 can be given to one of them from this data.
+#[test]
+fn should_report_an_unresolved_party_when_the_date_falls_in_a_year_two_parties_share() {
+    let kiley = member("K000401");
+
+    let party = kiley.party_on(date_str_to_date("2026-03-01").unwrap());
+
+    assert_eq!(
+        party,
+        PartyOnDate::Ambiguous(vec![Party::Republican, Party::Independent])
+    );
+    assert_eq!(
+        party.resolved(),
+        None,
+        "an ambiguous party is not an answer"
+    );
+}
+
+/// A reader that only sees the output must be able to tell the two apart. The
+/// text says `unresolved`, and the JSON tags the two cases differently.
+#[test]
+fn should_distinguish_an_unresolved_party_from_a_resolved_one_in_json_and_in_text() {
+    let kiley = member("K000401");
+
+    let voting_day = kiley.party_on(date_str_to_date("2025-07-03").unwrap());
+    let change_year = kiley.party_on(date_str_to_date("2026-03-01").unwrap());
+    let before_he_arrived = kiley.party_on(date_str_to_date("2001-03-01").unwrap());
+
+    assert_eq!(
+        serde_json::to_string(&voting_day).unwrap(),
+        r#"{"Resolved":"Republican"}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&change_year).unwrap(),
+        r#"{"Ambiguous":["Republican","Independent"]}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&before_he_arrived).unwrap(),
+        r#""Unknown""#
+    );
+
+    assert_eq!(voting_day.to_string(), "Republican");
+    assert_eq!(
+        change_year.to_string(),
+        "unresolved (Republican or Independent)"
+    );
+    assert_eq!(before_he_arrived.to_string(), "unknown");
+}
+
+/// The API lists the history newest first and promises nothing. Feeding the
+/// real response back with its entries reversed must give the same answer.
+#[test]
+fn should_give_the_same_answer_when_the_party_history_arrives_in_reverse_order() {
+    let path = format!("{MEMBER_CACHE}/K000401.json");
+    let json = std::fs::read_to_string(&path).expect("the cached response should read");
+    let mut response: serde_json::Value =
+        serde_json::from_str(&json).expect("the cached response should be JSON");
+
+    let history = response["member"]["partyHistory"]
+        .as_array_mut()
+        .expect("the response should carry a party history");
+    history.reverse();
+
+    let reversed = Member::from_api_response(&response.to_string())
+        .expect("the reordered response should parse");
+
+    assert_eq!(
+        reversed.party_on(date_str_to_date("2025-07-03").unwrap()),
+        PartyOnDate::Resolved(Party::Republican)
+    );
+    assert_eq!(
+        reversed.party_history,
+        member("K000401").party_history,
+        "the stored history is sorted, not left in the order it arrived"
+    );
+}
+
+/// The tally the bug was visible in: HR 1's passage on 2025-07-03.
+mod hr_1 {
+    use super::*;
+    use words_to_data::congress::{CongressClient, VotePosition};
+    use words_to_data::dataset::{Dataset, DatasetMetadata};
+    use words_to_data::inspect::{self, RollCallTally};
+    use words_to_data::storage::InMemoryStorage;
+
+    const CONGRESS_CACHE: &str = "tests/test_data/congress_client_cache";
+
+    /// HR 1 with its roll call and every member who voted, out of the cached
+    /// responses. No network and no API key: the fixtures are committed.
+    fn dataset_holding_hr_1() -> Dataset<InMemoryStorage> {
+        let client =
+            CongressClient::with_ttl("".to_string(), Some(CONGRESS_CACHE.to_string()), None);
+        let download = client
+            .download_bill("119-hr-1")
+            .expect("the cached bill should load");
+
+        let mut dataset = Dataset::new(DatasetMetadata {
+            name: "HR 1".into(),
+            description: "HR 1 with its roll call".into(),
+            author: "words_to_data tests".into(),
+            source_urls: vec![],
+            license: "MIT".into(),
+            version: "1.0".into(),
+            ..Default::default()
+        });
+        dataset
+            .load_bill_download(&download)
+            .expect("the download should load");
+        dataset
+    }
+
+    fn count(tally: &RollCallTally, party: Party, position: VotePosition) -> usize {
+        tally
+            .by_party
+            .iter()
+            .find(|row| row.party == party && row.position == position)
+            .map(|row| row.count)
+            .unwrap_or(0)
+    }
+
+    /// The Clerk, and the API's own party totals, report 218 Republican Yea.
+    /// The dataset reported 217 Republican and 1 Independent, because Kiley's
+    /// 2026 party was read onto his 2025 vote (#105).
+    #[test]
+    fn should_count_218_republican_yea_when_the_party_is_taken_from_the_day_of_the_vote() {
+        let dataset = dataset_holding_hr_1();
+
+        let tallies = inspect::votes(&dataset, "119-hr-1")
+            .expect("the bill's votes should read")
+            .expect("the dataset should hold HR 1");
+
+        assert_eq!(tallies.len(), 1, "HR 1 carries one House roll call");
+        let tally = &tallies[0];
+        assert_eq!(tally.roll_number, 190);
+        assert_eq!(count(tally, Party::Republican, VotePosition::Yea), 218);
+        assert_eq!(count(tally, Party::Independent, VotePosition::Yea), 0);
+        assert_eq!(count(tally, Party::Democrat, VotePosition::Nay), 212);
+        assert_eq!(count(tally, Party::Republican, VotePosition::Nay), 2);
+        assert!(
+            tally.unresolved.is_empty(),
+            "every party on this date resolves: {:?}",
+            tally.unresolved
+        );
+    }
+
+    /// The same answer through the surface a person or an agent reads.
+    #[test]
+    fn should_report_the_party_of_each_vote_when_the_votes_command_runs() {
+        let path = format!("{}/votes_hr_1.sqlite", env!("CARGO_TARGET_TMPDIR"));
+        let _ = std::fs::remove_file(&path);
+        dataset_holding_hr_1()
+            .save_to_sqlite(&path)
+            .expect("the fixture should save");
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+            .args(["votes", &path, "119-hr-1", "--json"])
+            .output()
+            .expect("the binary should run");
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let reported: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("--json should emit JSON");
+        let republican_yea = reported[0]["by_party"]
+            .as_array()
+            .expect("the tally should carry party rows")
+            .iter()
+            .find(|row| row["party"] == "Republican" && row["position"] == "Yea")
+            .expect("Republicans voted Yea on HR 1");
+
+        assert_eq!(republican_yea["count"], 218);
+        assert_eq!(
+            reported[0]["unresolved"].as_array().map(Vec::len),
+            Some(0),
+            "no party on this date is unresolved"
+        );
+    }
+}

--- a/tests/schema_version_tests.rs
+++ b/tests/schema_version_tests.rs
@@ -15,7 +15,7 @@ use rusqlite::Connection;
 use words_to_data::dataset::{
     Dataset, DatasetError, DatasetMetadata, Expression, ExpressionId, Format, WorkId, work_roots,
 };
-use words_to_data::storage::{DocumentReader, DocumentWriter, SqliteStorage};
+use words_to_data::storage::{DocumentReader, DocumentWriter, SCHEMA_VERSION, SqliteStorage};
 use words_to_data::uslm::parser::parse;
 
 const TITLE_9: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
@@ -85,6 +85,30 @@ fn should_refuse_a_dataset_written_by_a_different_schema() {
         }
         Err(other) => panic!("the failure should name the schema, got {other}"),
         Ok(_) => panic!("a dataset from another schema must not open"),
+    }
+}
+
+/// Dating a member's party changed a type written into every form of the file,
+/// so a dataset from the build before it must be refused by name (#105).
+#[test]
+fn should_refuse_a_dataset_written_at_the_previous_schema() {
+    assert_eq!(SCHEMA_VERSION, 7, "the member party history is schema 7");
+
+    let path = written_dataset("schema_six");
+    let conn = Connection::open(&path).expect("the file should open directly");
+    conn.execute("UPDATE schema_version SET version = 6", [])
+        .expect("the version should update");
+    drop(conn);
+
+    match SqliteStorage::open(&path) {
+        Err(DatasetError::SchemaVersionMismatch { found, expected }) => {
+            assert_eq!(found, 6);
+            assert_eq!(expected, 7);
+            let message = DatasetError::SchemaVersionMismatch { found, expected }.to_string();
+            assert!(message.contains("regenerate"), "got: {message}");
+        }
+        Err(other) => panic!("the failure should name the schema, got {other}"),
+        Ok(_) => panic!("a dataset written before the party history must not open"),
     }
 }
 


### PR DESCRIPTION
**BREAKING: `SCHEMA_VERSION` 6 -> 7.** A member is written into both on-disk forms, so a dataset written at 6 is refused and must be rebuilt. The crate version stays at 0.3.0 and no tag is cut.

Closes nothing automatically — the maintainer closes #105.

## What changed

- `Member` no longer carries one undated `party`. It carries `party_history: Vec<PartyAffiliation>`, oldest first, with the API's abbreviation, its own party name, the start year and the end year.
- `Member::party_on(date)` answers `PartyOnDate`: `Resolved(Party)`, `Ambiguous(Vec<Party>)`, or `Unknown`. `PartyOnDate::resolved()` gives a party only when one is known.
- `MemberTerm` is untouched and carries no party. Option 2 in the issue cannot hold Kiley's change, which falls inside his 119th-Congress term.
- `HouseRollCall::day()` reads the day a roll call was held, so the join between a vote and a party is made in one place.
- `inspect::votes` and a new `words_to_data votes <dataset> <bill-id> [--json]` report a roll call party by party, each party taken from the day of the vote. A vote whose party the date cannot settle is listed on its own with its reason, and is in no party count: the counts and the unresolved list together are every vote, so a tally never quietly stops adding up.
- The party history and the terms are both sorted on the field that decides the order. The API lists one newest first and the other oldest first, and promises neither.
- `Party::Other` stays. Display is added to `Party` and to `VotePosition` for the report.
- `CONTEXT.md` records **Member** and **Party affiliation**: the person is the Work, the affiliation on a day is the Expression.

## How an unresolved party is surfaced

`partyHistory` carries years, not days, and an end year is the year the member left. Kiley's Republican entry ends 2026 and his Independent entry starts 2026, so no day in 2026 belongs to one of them.

| | text | `--json` |
| --- | --- | --- |
| known | `Republican` | `{"Resolved":"Republican"}` |
| years shared | `unresolved (Republican or Independent)` | `{"Ambiguous":["Republican","Independent"]}` |
| nothing on file | `unknown` | `"Unknown"` |

## Test evidence

`rtk proxy cargo test --test member_party_tests` — exit 0

```
running 7 tests
test should_report_an_unresolved_party_when_the_date_falls_in_a_year_two_parties_share ... ok
test should_report_republican_when_kiley_is_asked_about_the_day_he_voted_on_hr_1 ... ok
test should_report_van_drew_on_both_sides_of_his_party_change ... ok
test should_distinguish_an_unresolved_party_from_a_resolved_one_in_json_and_in_text ... ok
test should_give_the_same_answer_when_the_party_history_arrives_in_reverse_order ... ok
test hr_1::should_count_218_republican_yea_when_the_party_is_taken_from_the_day_of_the_vote ... ok
test hr_1::should_report_the_party_of_each_vote_when_the_votes_command_runs ... ok

test result: ok. 7 passed; 0 failed; 0 ignored
```

Every member comes from the cached Congress API responses already committed under `tests/test_data/congress_client_cache/`. Nothing is written by hand.

The HR 1 tally, through the new command on a dataset built from those fixtures:

```
$ words_to_data votes hr_1.sqlite 119-hr-1
Bill: 119-hr-1

Roll call 190 on 2025-07-03T14:31:00-04:00 — Passed
  On Motion to Concur in the Senate Amendment
  Democrat     Nay         212
  Republican   Yea         218
  Republican   Nay           2
```

218 Republican Yea, which is what the Clerk and the API's own `votePartyTotal` report. Before this change the same 432 votes read 217 Republican Yea and 1 Independent Yea.

Full suite: `rtk proxy cargo test --all-targets` — exit 0, 301 passed, 0 failed, 1 ignored. `rtk proxy cargo test --doc` — exit 0, 20 passed, 0 failed, 6 ignored. Together: 321 passed, 0 failed, 7 ignored, which holds the baseline of 0 failed and 7 ignored.

`cargo clippy --all-targets -- -D warnings` — exit 0. `cargo fmt --check` — exit 0.

## What I could not do

- **The real 1.9 GB `dataset.sqlite` cannot be read by this build, by design.** It is at schema 6, so it is now refused. I read it before the change to confirm the bug: 217 Republican Yea, 1 Independent Yea, 212 Democrat Nay, 2 Republican Nay. Roll call 190 there holds the same 432 votes as the committed fixtures, so the fixture test covers the same data. It needs a rebuild.
- **A decision the brief did not settle:** two affiliations that name the same party and share a year are reported as `Ambiguous`, although the party is in fact known. No member in the corpus has such a history, so there is no real data to test the other behaviour against and no code was written for it. An unresolved answer is cautious rather than false, but it is a loose end.
