### PR TITLE
fix: read the law that an appendix keeps in a container (#110)

### DIFF
--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -193,7 +193,9 @@ pub enum ElementType {
     Clause,
     /// A Subclause (subdivision of a clause)
     Subclause,
-    /// A Level element (generic structural container when hierarchy is non-standard)
+    /// A Level element (generic structural container when hierarchy is
+    /// non-standard). An appendix also uses one to group a body of law, such as
+    /// the Federal Rules, that carries no number of its own.
     Level,
     /// An Item in an enumerated list
     Item,
@@ -237,6 +239,17 @@ impl std::str::FromStr for ElementType {
             "subsubitem" => Ok(Self::Subsubitem),
             "division" => Ok(Self::Division),
             "subdivision" => Ok(Self::Subdivision),
+            // The appendices group a whole body of law in a container that
+            // carries no number of its own, so each one reads as a level: the
+            // Federal Rules sit in `courtRules`, one rule in `courtRule`, an act
+            // reprinted in an appendix in `compiledAct`, and the reorganization
+            // plans in `reorganizationPlans` and `reorganizationPlan`. They group
+            // law; they are not a new unit of law (#110).
+            "courtrules"
+            | "courtrule"
+            | "compiledact"
+            | "reorganizationplans"
+            | "reorganizationplan" => Ok(Self::Level),
             "publiclaw" | "public_law" | "plaw" => Ok(Self::PublicLawDocument),
             "uscode" | "us_code" | "uscdoc" => Ok(Self::USCodeDocument),
             "appendix" => Ok(Self::Appendix),

--- a/src/uslm/parser.rs
+++ b/src/uslm/parser.rs
@@ -89,6 +89,60 @@ pub enum ParseError {
     QuotedContent,
 }
 
+/// An element the parser dropped although it held law.
+///
+/// The parser skips an element whose name it does not know. For a leaf that is
+/// right: a table of contents or a note is not law. For a container it is data
+/// loss, because a container's children are law. Four US Code appendices held
+/// two to four elements each for this reason, and nothing said so (#110).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DroppedContainer {
+    /// The XML tag name the parser does not know, such as `article`.
+    pub element_name: String,
+    /// The structural path of the element that held it.
+    pub parent_path: String,
+    /// How many structural children went with it.
+    pub structural_children: usize,
+}
+
+impl std::fmt::Display for DroppedContainer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "warning: unknown USLM element <{}> in {} was dropped with {} structural children below it",
+            self.element_name, self.parent_path, self.structural_children
+        )
+    }
+}
+
+/// What one parse dropped that a reader needs to know about.
+///
+/// A count alone would not help: the report names each container and where it
+/// sat, so the reader can see which body of law is absent.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParseReport {
+    /// Every unknown element that held law, in the order the parser met them.
+    pub dropped_containers: Vec<DroppedContainer>,
+}
+
+impl ParseReport {
+    /// True when the parse dropped nothing a reader needs to know about.
+    pub fn is_empty(&self) -> bool {
+        self.dropped_containers.is_empty()
+    }
+
+    /// Write the report to stderr, so it reaches the person who ran the command.
+    ///
+    /// The crate carries no logger, and the CLI writes its own warnings with
+    /// `eprintln!`, so the parser does the same. Every entry point that hides
+    /// the report calls this, which keeps one place to change.
+    pub fn print_to_stderr(&self) {
+        for dropped in &self.dropped_containers {
+            eprintln!("{dropped}");
+        }
+    }
+}
+
 struct TextContents {
     pub heading: Option<String>,
     pub chapeau: Option<String>,
@@ -153,6 +207,33 @@ fn check_attr(node: &roxmltree::Node, attr: &str, val: &str) -> bool {
 /// - The document type is not recognized
 /// - Required elements are missing from the XML structure
 pub fn parse_from_str(xml_str: &str, date: &str) -> Result<USLMElement> {
+    let (element, report) = parse_from_str_with_report(xml_str, date)?;
+    report.print_to_stderr();
+    Ok(element)
+}
+
+/// Parse a USLM XML string, and keep the report of what the parse dropped
+///
+/// Same parse as [`parse_from_str`], except that the caller receives the
+/// [`ParseReport`] instead of having it printed to stderr. Use this when the
+/// caller decides how a dropped container is shown.
+///
+/// # Examples
+///
+/// ```no_run
+/// use words_to_data::uslm::parser::parse_from_str_with_report;
+///
+/// let xml = std::fs::read_to_string("usc28a.xml").unwrap();
+/// let (element, report) = parse_from_str_with_report(&xml, "2025-07-18").unwrap();
+/// assert!(report.is_empty() || !report.dropped_containers.is_empty());
+/// ```
+pub fn parse_from_str_with_report(xml_str: &str, date: &str) -> Result<(USLMElement, ParseReport)> {
+    let mut report = ParseReport::default();
+    let element = parse_document(xml_str, date, &mut report)?;
+    Ok((element, report))
+}
+
+fn parse_document(xml_str: &str, date: &str, report: &mut ParseReport) -> Result<USLMElement> {
     let doc = roxmltree::Document::parse(xml_str)?;
 
     let top_level_node = doc
@@ -254,6 +335,7 @@ pub fn parse_from_str(xml_str: &str, date: &str) -> Result<USLMElement> {
                     Some("uscode"),
                     None,
                     1,
+                    report,
                 );
                 match child_element {
                     Ok(e) => children.push(e),
@@ -272,7 +354,16 @@ pub fn parse_from_str(xml_str: &str, date: &str) -> Result<USLMElement> {
         }
         // For other document types (bills), use the original logic
         _ => {
-            let element = parse_element(top_level_node, &document_type, date, None, None, None, 0)?;
+            let element = parse_element(
+                top_level_node,
+                &document_type,
+                date,
+                None,
+                None,
+                None,
+                0,
+                report,
+            )?;
             Ok(element)
         }
     }
@@ -329,6 +420,27 @@ pub fn parse_from_str(xml_str: &str, date: &str) -> Result<USLMElement> {
 pub fn parse(path: &str, date: &str) -> Result<USLMElement> {
     let xml_str = load_xml_file(path)?;
     parse_from_str(&xml_str, date)
+}
+
+/// Parse a USLM XML file, and keep the report of what the parse dropped
+///
+/// Same parse as [`parse`], except that the caller receives the [`ParseReport`]
+/// instead of having it printed to stderr.
+///
+/// # Examples
+///
+/// ```
+/// use words_to_data::uslm::parser::parse_with_report;
+///
+/// let (element, report) =
+///     parse_with_report("tests/test_data/usc/2025-07-18/usc09.xml", "2025-07-18").unwrap();
+/// assert!(!element.children.is_empty());
+/// // Title 9 holds no container the parser cannot name.
+/// assert!(report.is_empty());
+/// ```
+pub fn parse_with_report(path: &str, date: &str) -> Result<(USLMElement, ParseReport)> {
+    let xml_str = load_xml_file(path)?;
+    parse_from_str_with_report(&xml_str, date)
 }
 
 fn rewrap_str(s: Option<&str>) -> Option<Arc<str>> {
@@ -417,6 +529,52 @@ fn is_quoted_number(display: &str) -> bool {
     )
 }
 
+/// How many children of this node are law the parser knows how to model.
+///
+/// A child counts only when the parser knows its name and it comes from the
+/// same vocabulary as the node that holds it. `<meta>` holds a Dublin Core
+/// `<dc:title>`, which shares a tag name with a US Code title but is metadata,
+/// not law.
+fn structural_child_count(node: &roxmltree::Node) -> usize {
+    node.children()
+        .filter(|child| {
+            child.is_element()
+                && child.tag_name().namespace() == node.tag_name().namespace()
+                && matches!(
+                    ElementType::from_str(child.tag_name().name()),
+                    Ok(element_type) if element_type != ElementType::Unknown
+                )
+        })
+        .count()
+}
+
+/// Record an unknown element that takes law with it when the parser drops it.
+///
+/// An unknown leaf is not recorded. Dropping a table of contents or a note is
+/// what the parser is supposed to do, so a report of it would be noise that
+/// hides the entries that matter.
+fn record_if_container(
+    node: &roxmltree::Node,
+    parent_structural_path: Option<&str>,
+    report: &mut ParseReport,
+) {
+    if !node.is_element() {
+        return;
+    }
+    let structural_children = structural_child_count(node);
+    if structural_children == 0 {
+        return;
+    }
+    report.dropped_containers.push(DroppedContainer {
+        element_name: node.tag_name().name().to_string(),
+        parent_path: parent_structural_path.unwrap_or("").to_string(),
+        structural_children,
+    });
+}
+
+// The parent context this function needs is already long, and the report makes
+// one argument more. Grouping them is a change worth making on its own.
+#[allow(clippy::too_many_arguments)]
 fn parse_element(
     node: roxmltree::Node,
     document_type: &DocumentType,
@@ -425,6 +583,7 @@ fn parse_element(
     parent_structural_path: Option<&str>,
     parent_uslm_path: Option<&str>,
     _depth: usize,
+    report: &mut ParseReport,
 ) -> Result<USLMElement> {
     if check_attr(&node, "status", "repealed") {
         return Err(ParseError::RepealedElement);
@@ -432,9 +591,16 @@ fn parse_element(
     if check_attr(&node, "status", "reserved") {
         return Err(ParseError::ReservedElement);
     }
+    // The parser does not descend into quoted text: see `ParseError::QuotedContent`.
+    // Naming the wrapper here keeps it out of the report, because dropping it is
+    // a decision rather than a gap in what the parser knows.
+    if node.has_tag_name("quotedContent") {
+        return Err(ParseError::QuotedContent);
+    }
     let element_type = ElementType::from_str(node.tag_name().name())
         .expect("When this expect was written, all match cases were Ok()");
     if matches!(element_type, ElementType::Unknown) {
+        record_if_container(&node, parent_structural_path, report);
         return Err(ParseError::UnknownElement);
     }
     let xml_identifier = node.attribute("identifier");
@@ -470,12 +636,14 @@ fn parse_element(
                 ElementType::Appendix => {
                     Some(Arc::from(format!("/us/usc/t{}", number.value).as_str()))
                 }
-                _ => {
-                    return Err(ParseError::UnableToParseElement(format!(
-                        "XML identifier missing for element type {:?}",
-                        element_type
-                    )));
-                }
+                // The publisher supplies no identifier for a section it has
+                // omitted or transferred, because the section is no longer law
+                // in force and has no citation. A USLM ID belongs to the
+                // publisher, and many documents supply none, so the element
+                // keeps its structural path and carries no USLM ID. Until #110
+                // this stopped the whole parse, which is how the compiled acts
+                // in the title 5 appendix first came to light.
+                _ => None,
             },
         }
     } else {
@@ -550,6 +718,7 @@ fn parse_element(
             Some(structural_path.as_str()),
             child_parent_uslm_path.as_deref(),
             _depth + 1,
+            report,
         );
         match child_element {
             Ok(e) => {

--- a/tests/appendix_container_tests.rs
+++ b/tests/appendix_container_tests.rs
@@ -1,0 +1,120 @@
+//! The appendices keep whole bodies of law inside container elements.
+//!
+//! A USLM appendix does not put its sections under the appendix. It groups them
+//! in a container: the Federal Rules sit in `courtRules`, an act reprinted in an
+//! appendix sits in `compiledAct`, and the reorganization plans sit in
+//! `reorganizationPlans`. The parser did not know those names, dropped each
+//! container with the law below it, and said nothing, so four appendices held
+//! two to four elements each while the files held thousands (#110).
+//!
+//! A dropped leaf is correct: a table of contents is not law. A dropped
+//! container is data loss, so the parser now reports it.
+
+use rstest::rstest;
+use words_to_data::dataset::{Dataset, DatasetMetadata};
+use words_to_data::inspect;
+use words_to_data::uslm::USLMElement;
+use words_to_data::uslm::parser::{parse, parse_with_report};
+
+const RELEASE: &str = "2025-07-18";
+const USC28A: &str = "tests/test_data/usc/2025-07-18/usc28a.xml";
+/// Title 9 is small, holds no unknown container, and is full of the leaves a
+/// parse is supposed to drop without a word: `toc`, `note`, `sourceCredit`.
+const USC09: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
+
+/// The opening of Rule 1 of the Federal Rules of Civil Procedure, which the
+/// dataset did not hold at all before this fix.
+const RULE_1_TEXT: &str =
+    "These rules govern the procedure in all civil actions and proceedings in the United States";
+
+fn element_count(element: &USLMElement) -> usize {
+    1 + element.children.iter().map(element_count).sum::<usize>()
+}
+
+fn metadata() -> DatasetMetadata {
+    DatasetMetadata {
+        name: "Appendix Containers".to_string(),
+        description: "The title 28 appendix, for the Federal Rules".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "Public Domain".to_string(),
+        version: "1.0".to_string(),
+        ..Default::default()
+    }
+}
+
+/// Each appendix held 2 to 4 elements. The floors here are far below the counts
+/// the fix produces, so the test fails on a regression rather than on an edit
+/// to one rule.
+#[rstest]
+#[case("usc28a.xml", 2000)]
+#[case("usc11a.xml", 2000)]
+#[case("usc18a.xml", 1000)]
+#[case("usc05A.xml", 100)]
+fn should_hold_the_law_of_an_appendix_when_a_container_groups_it(
+    #[case] file: &str,
+    #[case] floor: usize,
+) {
+    let path = format!("tests/test_data/usc/{RELEASE}/{file}");
+    let root = parse(&path, RELEASE).unwrap_or_else(|e| panic!("{file} should parse: {e}"));
+
+    let count = element_count(&root);
+    assert!(
+        count > floor,
+        "{file} should hold more than {floor} elements, got {count}"
+    );
+}
+
+#[test]
+fn should_find_federal_rules_of_civil_procedure_text_when_the_appendix_is_searched() {
+    let mut dataset = Dataset::new(metadata());
+    dataset
+        .add_uslm_xml(USC28A, RELEASE, None)
+        .expect("the title 28 appendix should parse");
+
+    let hits = inspect::search(&dataset, RULE_1_TEXT).expect("search the dataset");
+
+    assert!(
+        !hits.is_empty(),
+        "Rule 1 of the Federal Rules of Civil Procedure should be searchable"
+    );
+}
+
+#[test]
+fn should_report_a_dropped_container_when_an_unknown_element_holds_structural_children() {
+    let (_root, report) = parse_with_report(USC28A, RELEASE).expect("the appendix should parse");
+
+    // `article` groups the Federal Rules of Evidence. The parser does not know
+    // the name, so it drops the article and the law below it — and now says so.
+    let article = report
+        .dropped_containers
+        .iter()
+        .find(|dropped| dropped.element_name == "article")
+        .unwrap_or_else(|| {
+            panic!(
+                "the dropped articles should be reported, got {:?}",
+                report.dropped_containers
+            )
+        });
+
+    assert!(
+        article.structural_children > 0,
+        "a reported container should say how much law went with it"
+    );
+    assert!(
+        article.parent_path.starts_with("uscode/appendix_28a"),
+        "a reported container should say where it sat, got {}",
+        article.parent_path
+    );
+}
+
+#[test]
+fn should_stay_silent_when_an_unknown_element_holds_no_structural_children() {
+    let (_root, report) = parse_with_report(USC09, RELEASE).expect("title 9 should parse");
+
+    assert!(
+        report.is_empty(),
+        "dropping a leaf is correct and should be quiet, got {:?}",
+        report.dropped_containers
+    );
+}


### PR DESCRIPTION
Fixes the parse half of #110. Does not close the issue: the maintainer closes it.

Rebased onto current `vibes` (the branch first grew from a HEAD 22 commits
behind). The only fallout was `DatasetMetadata`, which gained a required
`declaration` field; the test fixture now ends with `..Default::default()`, the
same as the other test fixtures. All numbers below are re-taken on the true base.

## What changed

**1. The appendix containers are recognized** (`src/uslm/mod.rs`)

`courtRules`, `courtRule`, `compiledAct`, `reorganizationPlans` and
`reorganizationPlan` now read as `ElementType::Level`. They group law; they are
not a new unit of law, and they carry no number of their own.

The brief named only the three plural containers. Three alone do not satisfy the
acceptance criteria, because `courtRules` holds `courtRule`, and each
`courtRule` is one Federal Rule with its text. With three names title 28's
appendix parses to **38** elements and no Rule 1 text, not "thousands". The
singular names are what hold the law, so both pairs are in. `article` is left
unknown on purpose: see point 2 and #122.

**2. An unknown element that holds law is reported** (`src/uslm/parser.rs`)

New `ParseReport` and `DroppedContainer`. When the parser meets an element whose
name it does not know, it counts the element's structural children; if there are
any, it records the name, the structural path of the element that held it, and
how many children went with it. `parse` and `parse_from_str` print the report to
stderr, so the loss reaches the person who ran the command. `parse_with_report`
and `parse_from_str_with_report` hand the report to the caller instead. One
print site, so there is one place to change.

An unknown **leaf** stays silent. Dropping a `toc`, a `note` or a `sourceCredit`
is correct, and reporting it would bury the entries that matter.

Two details keep the report honest rather than noisy:

- A child counts as structural only when it comes from the same vocabulary as
  its parent. `<meta>` holds a Dublin Core `<dc:title>`, which shares a tag name
  with a US Code title but is metadata, not law.
- `quotedContent` is now named in `parse_element` and returns the existing
  `ParseError::QuotedContent`. The parser already refuses to descend into it by
  decision (see that variant's doc), and the corpus holds 12,624 of them; without
  this the report would be all noise. No behavior change: the element was
  dropped silently before and is dropped silently now.

Across the whole test corpus the only thing reported is `article` x 11 in
`usc28a.xml`, plus `main` in a public law (see "Found on the way").

**3. A missing USLM ID no longer stops the parse** (`src/uslm/parser.rs`)

Descending into `compiledAct` uncovered a hard stop: the publisher supplies no
`identifier` for a section it marks `omitted` or `transferred`, because the
section is no longer law in force. Title 5's appendix holds 19 of them, and the
parse of `usc05A.xml` died on the first one. A USLM ID belongs to the publisher
and many documents supply none (`CONTEXT.md`), so such an element now keeps its
structural path and carries no USLM ID. Nothing that parses today changes: every
element that reached this arm used to end the whole parse. Statuses `omitted`
and `transferred` were left alone otherwise, because in the ordinary titles those
elements do carry identifiers and are held today; skipping them would delete law.

## Element counts

Real corpus files at release point 2025-07-18, counted with `parse`, including
the `uscode` root the parse returns.

| source | before | after |
| --- | --- | --- |
| `usc28a.xml` | 4 | **2,642** |
| `usc11a.xml` | 2 | **2,365** |
| `usc18a.xml` | 3 | **1,256** |
| `usc05A.xml` | 2 | **119** |
| `usc09.xml` (control) | 78 | 78 |
| `usc26.xml` (control) | 57,392 | 57,392 |

The "before" column comes from the RED run below and matches the table in #110.

The real 1.9 GB dataset agrees. It was built with the old parser, and it opens
with this branch (schema 6; #111 raises the schema to 7, and had not merged when
this was read):

```
$ words_to_data expressions /home/jesse/code/rust/words_to_data/dataset.sqlite | grep -i appendix
uscode/appendix_11a@2025-07-18           1
uscode/appendix_18a@2025-07-18           2
uscode/appendix_28a@2025-07-18           3
uscode/appendix_50a@2025-07-18           1
uscode/appendix_5a@2025-07-18            1
```

An expression count leaves out the `uscode` root, so each row is one below the
table. `appendix_50a` is not a fault: `usc50A.xml` is a 1.6 KB stub holding one
note, because title 50's appendix was editorially reclassified.

## Test evidence

`tests/appendix_container_tests.rs`, real corpus files only. No fixture is
written by hand; the unknown-container case uses the real `article` elements in
`usc28a.xml`.

**RED** — with the report in place and the names not yet added:

```
$ rtk proxy cargo test --test appendix_container_tests
usc28a.xml should hold more than 2000 elements, got 4
usc11a.xml should hold more than 2000 elements, got 2
usc18a.xml should hold more than 1000 elements, got 3
usc05A.xml should hold more than 100 elements, got 2
Rule 1 of the Federal Rules of Civil Procedure should be searchable
the dropped articles should be reported, got [DroppedContainer { element_name: "courtRules", ... }]
test result: FAILED. 1 passed; 6 failed; 0 ignored
```

**GREEN**:

```
$ rtk proxy cargo test --test appendix_container_tests
running 7 tests
test should_hold_the_law_of_an_appendix_when_a_container_groups_it::case_1 ... ok
test should_hold_the_law_of_an_appendix_when_a_container_groups_it::case_2 ... ok
test should_hold_the_law_of_an_appendix_when_a_container_groups_it::case_3 ... ok
test should_hold_the_law_of_an_appendix_when_a_container_groups_it::case_4 ... ok
test should_find_federal_rules_of_civil_procedure_text_when_the_appendix_is_searched ... ok
test should_report_a_dropped_container_when_an_unknown_element_holds_structural_children ... ok
test should_stay_silent_when_an_unknown_element_holds_no_structural_children ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Exit code 0.

**Full suite** on current `vibes`:

```
$ rtk proxy cargo test --no-fail-fast
passed 322 failed 0 ignored 7
```

Exit code 0. The baseline is 0 failed and 7 ignored, which holds.

```
$ cargo clippy --all-targets -- -D warnings   # exit 0, no issues
$ cargo fmt --check                           # exit 0
```

**The two acceptance criteria, through the CLI.** A dataset built from
`usc28a.xml` alone with this branch:

```
$ words_to_data expressions target/usc28a.sqlite
EXPRESSION                        ELEMENTS  LABEL
uscode/appendix_28a@2025-07-18        2641

$ words_to_data search target/usc28a.sqlite "These rules govern the procedure in all civil actions"
uscode/appendix_28a@2025-07-18  uscode/appendix_28a/level_id2e47c0a6-b17c-11ef-b971-e82c9e4f66ce/title_I/level_1  [content]
    These rules govern the procedure in all civil actions and proceedings in the United
    States district courts, except as stated in Rule 81. ...
1 match(es)
```

That is Rule 1 of the Federal Rules of Civil Procedure, which no dataset held
before. The uuid in the path is #115.

## Found on the way

**The Federal Rules of Evidence are still absent — filed as #122.** `article`
stays unknown, so 11 articles and the 452 elements below them are still dropped.
The new report names every one of them, which is what caught it. The brief put
the remaining container names out of scope, so the fix belongs to its own issue
rather than this branch.

**`parse` drops a public law's body, and now says so — filed as #114.** A `pLaw`
root holds `main`, which the parser does not know, so `parse` on
`public_law.xml` returns **one** element and the report reads:

```
warning: unknown USLM element <main> in publiclawdocument_119-21 was dropped with 11 structural children below it
```

This is not new; only the warning is. Bill amendments come through
`bill_parser`, so nothing downstream depends on that tree today.

**Structural paths do spread, as #110 warned — filed as #115.** An appendix
container with no `<num>` takes its path segment from its XML id, so paths such
as `uscode/appendix_28a/level_id2e47c0a6-.../title_I/level_1` are now ordinary
instead of rare. Path generation was left alone, per the brief.

**Duplicate structural paths are not a new problem.** The title 28 appendix now
holds 6 elements whose path repeats. That rate is ordinary for the corpus (title
42 holds 64, title 21 holds 72), and ADR 0001 says a path locates rather than
identifies, so this needed no action.
