### PR TITLE
perf: ask the index whether a path exists (#109)

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -626,6 +626,10 @@ impl<S: Storage> DocumentReader for Dataset<S> {
     fn find_element(&self, path: &str) -> Result<Vec<(ExpressionId, USLMElement)>, DatasetError> {
         self.storage.find_element(path)
     }
+
+    fn has_element(&self, path: &str) -> Result<bool, DatasetError> {
+        self.storage.has_element(path)
+    }
 }
 
 impl<S: Storage> LinkReader for Dataset<S> {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -465,7 +465,9 @@ pub fn validate<S: Storage>(dataset: &S) -> Result<ValidationReport, DatasetErro
                 ));
             }
             for path in &ann.paths {
-                if dataset.find_element(path)?.is_empty() {
+                // Only whether the path is there, not what sits at it: asking
+                // for the element loads the whole document, once per path.
+                if !dataset.has_element(path)? {
                     issues.push(format!(
                         "annotation ({from} -> {to}) references path not found in any expression: {path}"
                     ));

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -226,6 +226,13 @@ impl DocumentReader for InMemoryStorage {
             })
             .collect())
     }
+
+    fn has_element(&self, path: &str) -> Result<bool, DatasetError> {
+        // One provision is enough to answer, so the walk stops at the first.
+        Ok(self
+            .all_expressions()
+            .any(|e| !e.element.find_all(path).is_empty()))
+    }
 }
 
 /// Fetch both expressions of a diff, refusing a pair that names two works.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -113,6 +113,17 @@ pub trait DocumentReader {
 
     /// Find an element by path, in every expression that holds it.
     fn find_element(&self, path: &str) -> Result<Vec<(ExpressionId, USLMElement)>, DatasetError>;
+
+    /// Whether any expression holds at least one provision at `path`.
+    ///
+    /// A path locates provisions, it does not identify one
+    /// (`docs/adr/0001-structural-paths-locate-not-identify.md`), so the
+    /// question is "at least one", never "exactly one". Ask this rather than
+    /// [`find_element`] wherever the element itself is not wanted: a backend
+    /// can answer it from an index, without reading a document.
+    ///
+    /// [`find_element`]: DocumentReader::find_element
+    fn has_element(&self, path: &str) -> Result<bool, DatasetError>;
 }
 
 /// Reading the links a dataset holds.

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1090,6 +1090,16 @@ impl DocumentReader for SqliteStorage {
 
         Ok(results)
     }
+
+    fn has_element(&self, path: &str) -> Result<bool, DatasetError> {
+        // `idx_elem_path` answers this on its own, so no `element_json` is read.
+        // The index holds a row per provision, and one row is enough: the
+        // question is whether any provision sits at the path.
+        let mut stmt = self
+            .conn
+            .prepare("SELECT 1 FROM element_index WHERE path = ?1")?;
+        Ok(stmt.exists(params![path])?)
+    }
 }
 
 /// Rebuild a link from one row of `links`.

--- a/tests/duplicate_path_tests.rs
+++ b/tests/duplicate_path_tests.rs
@@ -417,3 +417,59 @@ fn should_hold_every_provision_sharing_a_path_on_both_backends() {
         "both backends should answer alike, in document order"
     );
 }
+
+/// A path the fixture does not hold: § 45X(d) has no paragraph (99).
+const ABSENT: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_A/part_IV/subpart_D/section_45X/subsection_d/paragraph_99";
+
+#[test]
+fn should_say_whether_a_path_exists_on_both_backends() {
+    use words_to_data::storage::DocumentReader;
+
+    let (memory, sqlite) = dataset_both_backends("has_element");
+
+    assert!(
+        memory.has_element(DUPLICATED).expect("ask memory"),
+        "the in-memory backend holds this path"
+    );
+    assert!(
+        sqlite.has_element(DUPLICATED).expect("ask sqlite"),
+        "the SQLite backend holds this path"
+    );
+
+    assert!(
+        !memory.has_element(ABSENT).expect("ask memory"),
+        "the in-memory backend does not hold this path"
+    );
+    assert!(
+        !sqlite.has_element(ABSENT).expect("ask sqlite"),
+        "the SQLite backend does not hold this path"
+    );
+}
+
+#[test]
+fn should_say_a_path_exists_when_it_names_more_than_one_provision() {
+    use words_to_data::storage::DocumentReader;
+
+    let (memory, sqlite) = dataset_both_backends("has_element_duplicate");
+
+    // The question is whether at least one provision sits at the path. Two
+    // paragraphs (4) sit at this one, and a check which expects a path to name
+    // exactly one provision cannot answer for it (ADR 0001, #77, #85).
+    assert_eq!(
+        memory
+            .find_element(DUPLICATED)
+            .expect("find in memory")
+            .len(),
+        2,
+        "the fixture must really hold two provisions here"
+    );
+
+    assert!(
+        memory.has_element(DUPLICATED).expect("ask memory"),
+        "two provisions at a path still means the path exists"
+    );
+    assert!(
+        sqlite.has_element(DUPLICATED).expect("ask sqlite"),
+        "two provisions at a path still means the path exists"
+    );
+}

--- a/tests/inspect_tests.rs
+++ b/tests/inspect_tests.rs
@@ -654,3 +654,61 @@ fn store_annotation<S: words_to_data::storage::Storage>(
         dataset.add_link(link).expect("the link should be added");
     }
 }
+
+/// A path no expression holds: title 9 has no § 999.
+const ABSENT_PATH: &str = "uscode/title_9/chapter_1/section_999";
+
+#[test]
+fn should_name_the_absent_path_when_an_annotation_points_nowhere_on_sqlite() {
+    let mut fixture = make_fixture();
+    let (from, to) = pair();
+    store_annotation(
+        &mut fixture,
+        ChangeAnnotation {
+            operation: AmendingAction::Strike,
+            source_bill: BillReference {
+                bill_id: "119-hr-1".to_string(),
+                amendment_id: "amendment-xyz".to_string(),
+                causative_text: "by striking 'bar'".to_string(),
+            },
+            paths: vec![ABSENT_PATH.to_string()],
+            metadata: AnnotationMetadata {
+                status: AnnotationStatus::Pending,
+                confidence: None,
+                annotator: "model:test".to_string(),
+                timestamp: time::OffsetDateTime::UNIX_EPOCH,
+                notes: None,
+                reasoning: None,
+            },
+        },
+        &from,
+        &to,
+    );
+    let sqlite = to_sqlite(&fixture, "validate_absent_path");
+
+    let report = inspect::validate(&sqlite).expect("validate");
+
+    assert!(!report.ok, "a path that points nowhere is a failure");
+    // Both links name one amendment, one pair and one annotator, so they are
+    // one annotation which names two paths.
+    assert_eq!(report.checked_annotations, 1);
+
+    // Exactly one of the two paths is absent. The other names a real
+    // provision, and reporting it would make the command useless as a gate.
+    let absent: Vec<&String> = report
+        .issues
+        .iter()
+        .filter(|issue| issue.contains("path not found"))
+        .collect();
+    assert_eq!(
+        absent.len(),
+        1,
+        "one path is absent and one is real, got: {:?}",
+        report.issues
+    );
+    assert!(
+        absent[0].contains(ABSENT_PATH),
+        "the report should name the absent path, got: {}",
+        absent[0]
+    );
+}

--- a/tests/storage_traits_tests.rs
+++ b/tests/storage_traits_tests.rs
@@ -69,6 +69,10 @@ impl DocumentReader for DocumentsOnly {
     fn find_element(&self, path: &str) -> Result<Vec<(ExpressionId, USLMElement)>, DatasetError> {
         self.0.find_element(path)
     }
+
+    fn has_element(&self, path: &str) -> Result<bool, DatasetError> {
+        self.0.has_element(path)
+    }
 }
 
 /// Accepts anything that can read documents, and asks for nothing else.


### PR DESCRIPTION
Closes nothing automatically — #109 stays open for the maintainer.

## What changed

- `DocumentReader` gains `has_element(path) -> Result<bool>`: "does at least one provision sit at this path".
- SQLite backend answers from `idx_elem_path` with `SELECT 1 FROM element_index WHERE path = ?1`. No `element_json` is read.
- In-memory backend walks its own expressions and stops at the first provision found.
- `validate` uses `has_element` in place of `find_element`.
- `find_element` and its other callers are untouched.
- A path locates provisions, it does not identify one (ADR 0001, #77, #85). The index holds one row per provision, and one row is enough to answer, so a path that names two provisions still answers `true`.

## Timings on the real dataset

Release build, warm cache, 1.9 GB `dataset.sqlite`.

Before:

```
$ time words_to_data validate dataset.sqlite
OK — 443 annotation(s) checked, no issues
165.29s user 46.80s system 99% cpu  3:33.33 total
```

After:

```
$ time words_to_data validate dataset.sqlite
OK — 443 annotation(s) checked, no issues
1.71s user 0.54s system 98% cpu  2.273 total
```

Same output, 443 annotations checked, exit 0. About 94 times faster.

## Test evidence

New tests:

- `tests/duplicate_path_tests.rs::should_say_whether_a_path_exists_on_both_backends` — `true` for a path title 26 holds, `false` for a made-up paragraph (99), on both backends.
- `tests/duplicate_path_tests.rs::should_say_a_path_exists_when_it_names_more_than_one_provision` — § 45X(d)(4) is two paragraphs in the committed title 26; both backends answer `true`.
- `tests/inspect_tests.rs::should_name_the_absent_path_when_an_annotation_points_nowhere_on_sqlite` — `validate` on SQLite reports `ok = false` and names the absent path, and does not report the real path in the same annotation. `validate.rs` turns `ok = false` into exit 1.

Both new tests in `duplicate_path_tests.rs` failed to compile before the implementation existed (`no method named has_element`), which was the RED step.

```
$ cargo test --test duplicate_path_tests --test inspect_tests --test storage_traits_tests
test result: ok. 13 passed; 0 failed; 0 ignored
test result: ok. 25 passed; 0 failed; 0 ignored
test result: ok. 5 passed; 0 failed; 0 ignored
exit 0
```

Full suite, before and after:

```
$ cargo test
baseline: passed=313 failed=0 ignored=7
after:    passed=316 failed=0 ignored=7
exit 0

$ cargo clippy --all-targets -- -D warnings
exit 0

$ cargo fmt --check
exit 0
```

## Notes

- `tests/storage_traits_tests.rs` needed a delegate for the new trait method, because `DocumentsOnly` implements `DocumentReader` by hand. That is the only unrelated file touched, and the change is four lines.
- No inherent `Dataset::has_element` delegate was added. `Dataset<S>` implements `DocumentReader`, so callers get the method from the trait, and no caller in the CLI needs the inherent form. Add one if the public API should mirror `find_element`.
- Nothing left undone.