### PR TITLE
feat: count links, replies, members, sponsors and votes in info

### DIFF
--- a/src/bin/words_to_data/info.rs
+++ b/src/bin/words_to_data/info.rs
@@ -42,6 +42,32 @@ pub fn run(args: Args) {
     println!("Expressions: {}", info.expression_count);
     println!("Bills:       {}", info.bill_count);
 
+    // Links are what this project produces; the document text is the input. The
+    // breakdown names each kind in full, namespace included, because a reader
+    // that does not know a namespace can still report it, and a total hides it
+    // (`docs/adr/0002-links-live-in-the-core.md`).
+    if info.link_count > 0 {
+        println!("Links:       {}", info.link_count);
+        for (kind, count) in &info.link_counts_by_kind {
+            println!("  {kind}  {count}");
+        }
+    }
+
+    // Printed only where there is something to report. A dataset with no
+    // legislature extension holds none of these, and a wall of zeroes reads as
+    // a tool that measured nothing rather than a dataset that holds nothing.
+    for (label, count) in [
+        ("Replies:", info.reply_count),
+        ("Members:", info.member_count),
+        ("Sponsors:", info.sponsor_count),
+        ("Roll calls:", info.roll_call_count),
+        ("Votes:", info.member_vote_count),
+    ] {
+        if count > 0 {
+            println!("{label:<13}{count}");
+        }
+    }
+
     // Scope is the answer to "why did my query find nothing". Print it, so a
     // reader of this dataset knows what it does not hold. Each work carries its
     // own dates, because a dataset need not hold every work on every date.

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -15,6 +15,7 @@ pub use work::{
 };
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -27,7 +28,8 @@ use crate::legislature::BillDiff;
 use crate::link::Link;
 use crate::storage::{
     DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, InMemoryStorage,
-    LegislatureReader, LegislatureWriter, LinkReader, LinkWriter, SqliteStorage, Storage,
+    LegislatureCounts, LegislatureReader, LegislatureWriter, LinkReader, LinkWriter, SqliteStorage,
+    Storage,
 };
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
@@ -656,6 +658,10 @@ impl<S: Storage> LinkReader for Dataset<S> {
     fn link_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
         self.storage.link_pairs()
     }
+
+    fn count_links_by_kind(&self) -> Result<BTreeMap<String, usize>, DatasetError> {
+        self.storage.count_links_by_kind()
+    }
 }
 
 impl<S: Storage> EvidenceReader for Dataset<S> {
@@ -665,6 +671,10 @@ impl<S: Storage> EvidenceReader for Dataset<S> {
 
     fn replies(&self) -> Result<Vec<String>, DatasetError> {
         self.storage.replies()
+    }
+
+    fn count_replies(&self) -> Result<usize, DatasetError> {
+        self.storage.count_replies()
     }
 }
 
@@ -700,6 +710,10 @@ impl<S: Storage> LegislatureReader for Dataset<S> {
         bioguide_id: &str,
     ) -> Result<Vec<(HouseRollCall, VotePosition)>, DatasetError> {
         self.storage.votes_by_member(bioguide_id)
+    }
+
+    fn legislature_counts(&self) -> Result<LegislatureCounts, DatasetError> {
+        self.storage.legislature_counts()
     }
 }
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -9,6 +9,8 @@
 //! Reports are plain serde structs: the CLI prints them (human-readable or as
 //! `--json`), and tests assert on the data rather than on formatting.
 
+use std::collections::BTreeMap;
+
 use serde::Serialize;
 
 use crate::annotation::ChangeAnnotation;
@@ -32,9 +34,51 @@ pub struct DatasetInfo {
     pub expression_count: usize,
     /// Number of bills recorded in the dataset.
     pub bill_count: usize,
+    /// Number of links held, over every kind.
+    ///
+    /// Links are what this project produces; the document text is the input. A
+    /// report that counts only the input cannot tell an annotated dataset from
+    /// a bare corpus.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub link_count: usize,
+    /// Number of links held of each kind, keyed by the kind named in full,
+    /// namespace included.
+    ///
+    /// A reader that meets a kind it does not own, such as `westlaw.headnote`,
+    /// must see it named rather than folded into a total: naming an unknown kind
+    /// is what a reader can still do with it
+    /// (`docs/adr/0002-links-live-in-the-core.md`).
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub link_counts_by_kind: BTreeMap<String, usize>,
+    /// Number of verbatim model replies held as evidence (#58).
+    #[serde(skip_serializing_if = "is_zero")]
+    pub reply_count: usize,
+    /// Number of legislature members held.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub member_count: usize,
+    /// Number of sponsor records held, which is one per bill.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub sponsor_count: usize,
+    /// Number of roll calls held.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub roll_call_count: usize,
+    /// Number of member votes held, summed over every roll call.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub member_vote_count: usize,
     /// What this dataset covers, so a caller can tell "absent from the law"
     /// from "absent from this dataset".
     pub scope: Scope,
+}
+
+/// Whether a count is zero, and so left out of the JSON.
+///
+/// A dataset with no legislature extension holds none of these things. Emitting
+/// a zero for each would grow a wall of them, and a wall of zeroes reads as
+/// "this tool measured nothing" rather than "this dataset holds nothing".
+/// `work_count`, `expression_count`, and `bill_count` are always emitted: they
+/// were there before this rule, and an agent already reads them.
+fn is_zero(count: &usize) -> bool {
+    *count == 0
 }
 
 /// One expression's headline facts (no element tree).
@@ -778,6 +822,10 @@ pub fn show_bill<S: Storage>(
 pub fn info<S: Storage>(dataset: &S) -> Result<DatasetInfo, DatasetError> {
     let meta = dataset.metadata();
     let scope = Scope::derive(dataset)?;
+    // Counted, never loaded: a count query costs the same on a 2 GB dataset as
+    // on a small one, and building the records to count them does not.
+    let links = dataset.count_links_by_kind()?;
+    let legislature = dataset.legislature_counts()?;
     Ok(DatasetInfo {
         name: meta.name.clone(),
         description: meta.description.clone(),
@@ -787,7 +835,14 @@ pub fn info<S: Storage>(dataset: &S) -> Result<DatasetInfo, DatasetError> {
         source_urls: meta.source_urls.clone(),
         work_count: scope.held.len(),
         expression_count: scope.held.iter().map(|held| held.dates.len()).sum(),
-        bill_count: dataset.list_bill_ids()?.len(),
+        bill_count: legislature.bills,
+        link_count: links.values().sum(),
+        link_counts_by_kind: links,
+        reply_count: dataset.count_replies()?,
+        member_count: legislature.members,
+        sponsor_count: legislature.sponsors,
+        roll_call_count: legislature.roll_calls,
+        member_vote_count: legislature.member_votes,
         scope,
     })
 }

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -13,8 +13,8 @@ use crate::diff::TreeDiff;
 use crate::intern::StringInterner;
 use crate::link::{Link, Target};
 use crate::storage::{
-    DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, LegislatureReader,
-    LegislatureWriter, LinkReader, LinkWriter, Storage,
+    DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, LegislatureCounts,
+    LegislatureReader, LegislatureWriter, LinkReader, LinkWriter, Storage,
 };
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
@@ -312,6 +312,14 @@ impl LinkReader for InMemoryStorage {
         pairs.dedup();
         Ok(pairs)
     }
+
+    fn count_links_by_kind(&self) -> Result<BTreeMap<String, usize>, DatasetError> {
+        let mut counts = BTreeMap::new();
+        for link in self.links.values() {
+            *counts.entry(link.kind.0.clone()).or_insert(0) += 1;
+        }
+        Ok(counts)
+    }
 }
 
 /// The structural path a link's subject names, when it names one.
@@ -349,6 +357,10 @@ impl EvidenceReader for InMemoryStorage {
 
     fn replies(&self) -> Result<Vec<String>, DatasetError> {
         Ok(self.replies.keys().cloned().collect())
+    }
+
+    fn count_replies(&self) -> Result<usize, DatasetError> {
+        Ok(self.replies.len())
     }
 }
 
@@ -396,6 +408,17 @@ impl LegislatureReader for InMemoryStorage {
             }
         }
         Ok(results)
+    }
+
+    fn legislature_counts(&self) -> Result<LegislatureCounts, DatasetError> {
+        let roll_calls = || self.bill_votes.values().flat_map(|v| v.roll_calls.iter());
+        Ok(LegislatureCounts {
+            bills: self.bills.len(),
+            members: self.members.len(),
+            sponsors: self.sponsors.len(),
+            roll_calls: roll_calls().count(),
+            member_votes: roll_calls().map(|rc| rc.member_votes.len()).sum(),
+        })
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -26,6 +26,8 @@ pub mod sqlite;
 pub use memory::InMemoryStorage;
 pub use sqlite::SqliteStorage;
 
+use std::collections::BTreeMap;
+
 use crate::annotation::ChangeAnnotation;
 use crate::congress::{BillVotes, HouseRollCall, Member, SponsorInfo, VotePosition};
 use crate::dataset::{
@@ -155,6 +157,15 @@ pub trait LinkReader {
     /// Every expression pair that carries links.
     fn link_pairs(&self) -> Result<Vec<crate::dataset::ExpressionPair>, DatasetError>;
 
+    /// How many links are held of each kind, keyed by the kind named in full.
+    ///
+    /// A count, not a load: a backend that can count answers without building
+    /// the links. Broken down by kind because a total folds a namespace this
+    /// build has never seen into a number that hides it, and naming an unknown
+    /// kind is exactly what a reader can still do with it
+    /// (`docs/adr/0002-links-live-in-the-core.md`).
+    fn count_links_by_kind(&self) -> Result<BTreeMap<String, usize>, DatasetError>;
+
     // --- Projections ---
     //
     // `ChangeAnnotation` is a view of links, the reverse of how it once was.
@@ -222,6 +233,27 @@ pub trait LegislatureReader {
         &self,
         bioguide_id: &str,
     ) -> Result<Vec<(HouseRollCall, VotePosition)>, DatasetError>;
+
+    /// How much legislative material is held, counted rather than loaded.
+    ///
+    /// One method for the five counts, because a caller asking what a dataset
+    /// holds wants all of them and a backend answers each with a count query.
+    fn legislature_counts(&self) -> Result<LegislatureCounts, DatasetError>;
+}
+
+/// How much legislative material a dataset holds.
+///
+/// Counts only. A reader deciding whether a file is worth opening needs the
+/// sizes, not the records, and the records are large.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LegislatureCounts {
+    pub bills: usize,
+    pub members: usize,
+    /// Sponsor records, which is one per bill, not one per person.
+    pub sponsors: usize,
+    pub roll_calls: usize,
+    /// One member's position in one roll call, summed over every roll call.
+    pub member_votes: usize,
 }
 
 /// Reading the evidence a dataset holds.
@@ -238,6 +270,12 @@ pub trait EvidenceReader {
 
     /// Every reply id this dataset holds, in id order.
     fn replies(&self) -> Result<Vec<String>, DatasetError>;
+
+    /// How many replies this dataset holds.
+    ///
+    /// A count, not a load. Listing the ids to count them costs one string per
+    /// reply, and a real sweep holds thousands.
+    fn count_replies(&self) -> Result<usize, DatasetError>;
 }
 
 /// Writing evidence.

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1,6 +1,6 @@
 //! SQLite storage backend for datasets
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -17,7 +17,8 @@ use crate::link::{Link, LinkKind, Provenance, Target};
 use crate::storage::memory::{ExpressionsByWork, require_same_work};
 use crate::storage::{
     DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, InMemoryStorage,
-    LegislatureReader, LegislatureWriter, LinkReader, LinkWriter, SCHEMA_VERSION, Storage,
+    LegislatureCounts, LegislatureReader, LegislatureWriter, LinkReader, LinkWriter,
+    SCHEMA_VERSION, Storage,
 };
 use crate::uslm::USLMElement;
 use crate::uslm::bill_parser::Bill;
@@ -1131,6 +1132,19 @@ fn link_from_row(row: &rusqlite::Row) -> Result<Link, rusqlite::Error> {
 }
 
 impl SqliteStorage {
+    /// How many rows one of this schema's tables holds.
+    ///
+    /// `table` is always a literal from this file — a table name cannot be a
+    /// bound parameter, so it must never come from a caller.
+    fn count_rows(&self, table: &str) -> Result<usize, DatasetError> {
+        let count: i64 =
+            self.conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get(0)
+                })?;
+        Ok(count as usize)
+    }
+
     /// Run one link query and collect the rows.
     fn query_links<P: rusqlite::Params>(
         &self,
@@ -1193,6 +1207,18 @@ impl LinkReader for SqliteStorage {
         )
     }
 
+    fn count_links_by_kind(&self) -> Result<BTreeMap<String, usize>, DatasetError> {
+        // One grouped count. Building the links to count them would read every
+        // subject, object, and provenance document in the table.
+        let mut stmt = self
+            .conn
+            .prepare("SELECT kind, COUNT(*) FROM links GROUP BY kind ORDER BY kind")?;
+        let counts = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get::<_, i64>(1)? as usize)))?
+            .collect::<Result<BTreeMap<String, usize>, _>>()?;
+        Ok(counts)
+    }
+
     fn link_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
         let mut stmt = self.conn.prepare(
             "SELECT DISTINCT subject_work, subject_from_date, subject_to_date FROM links \
@@ -1234,6 +1260,10 @@ impl EvidenceReader for SqliteStorage {
             .query_map([], |row| row.get(0))?
             .collect::<Result<Vec<String>, _>>()?;
         Ok(ids)
+    }
+
+    fn count_replies(&self) -> Result<usize, DatasetError> {
+        self.count_rows("model_replies")
     }
 }
 
@@ -1388,6 +1418,16 @@ impl LegislatureReader for SqliteStorage {
         }
 
         Ok(results)
+    }
+
+    fn legislature_counts(&self) -> Result<LegislatureCounts, DatasetError> {
+        Ok(LegislatureCounts {
+            bills: self.count_rows("bills")?,
+            members: self.count_rows("members")?,
+            sponsors: self.count_rows("sponsors")?,
+            roll_calls: self.count_rows("roll_calls")?,
+            member_votes: self.count_rows("member_votes")?,
+        })
     }
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -7,7 +7,13 @@
 use std::process::{Command, Output};
 use std::sync::OnceLock;
 
-use words_to_data::dataset::{Dataset, DatasetMetadata, Format};
+use words_to_data::annotation::{
+    AnnotationMetadata, AnnotationStatus, BillReference, ChangeAnnotation,
+};
+use words_to_data::congress::CongressClient;
+use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, Format, WorkId};
+use words_to_data::legislature::AmendingAction;
+use words_to_data::link::Link;
 
 /// The two US Code release points held in `tests/test_data`.
 const EARLY: &str = "2025-07-18";
@@ -170,6 +176,88 @@ fn two_works_json_fixture() -> &'static str {
     })
 }
 
+/// A dataset carrying what this project produces as well as its input: one link
+/// over a real provision, the bill behind it, and that bill's legislature facts
+/// — its sponsor, the members of the House, and the roll call they voted in.
+///
+/// `info` on a dataset like this is how a person tells an annotated dataset from
+/// a bare corpus.
+fn annotated_fixture() -> &'static str {
+    static FIXTURE: OnceLock<String> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let path = format!("{}/cli_annotated.sqlite", env!("CARGO_TARGET_TMPDIR"));
+        let _ = std::fs::remove_file(&path);
+
+        let mut dataset = Dataset::new(DatasetMetadata {
+            name: "Annotated Fixture".to_string(),
+            description: "One title, one public law, one link".to_string(),
+            author: "words_to_data tests".to_string(),
+            source_urls: vec![],
+            license: "MIT".to_string(),
+            version: "1.0.0".to_string(),
+            ..Default::default()
+        });
+        for date in [EARLY, LATE] {
+            let xml = format!("tests/test_data/usc/{date}/{UNCHANGED_TITLE}.xml");
+            dataset
+                .add_uslm_xml(&xml, date, None)
+                .expect("the corpus should parse and load");
+        }
+
+        // The committed download of one real bill. No API key and no expiry:
+        // the fixtures must be read without the network and never deleted for
+        // being old.
+        let client = CongressClient::with_ttl(
+            String::new(),
+            Some("tests/test_data/congress_client_cache".to_string()),
+            None,
+        );
+        let download = client
+            .download_bill("119-hr-1")
+            .expect("the cached bill should read");
+        dataset
+            .load_bill_download(&download)
+            .expect("the download should load");
+
+        let amendment_id = dataset
+            .get_bill("119-hr-1")
+            .expect("the bill should read")
+            .expect("the download holds it")
+            .amendments
+            .keys()
+            .next()
+            .expect("a real public law carries amendments")
+            .clone();
+        let annotation = ChangeAnnotation {
+            operation: AmendingAction::Strike,
+            source_bill: BillReference {
+                bill_id: "119-hr-1".to_string(),
+                amendment_id,
+                causative_text: "by striking 'foo'".to_string(),
+            },
+            paths: vec![format!("{UNCHANGED_WORK}/chapter_1/section_1")],
+            metadata: AnnotationMetadata {
+                status: AnnotationStatus::Pending,
+                confidence: Some(0.9),
+                annotator: "model:test".to_string(),
+                timestamp: time::OffsetDateTime::UNIX_EPOCH,
+                notes: None,
+                reasoning: None,
+            },
+        };
+        let from = ExpressionId::new(WorkId::new(UNCHANGED_WORK), EARLY);
+        let to = ExpressionId::new(WorkId::new(UNCHANGED_WORK), LATE);
+        for link in Link::from_annotation(&annotation, &from, &to) {
+            dataset.add_link(link).expect("the link should be added");
+        }
+
+        dataset
+            .save_to_sqlite(&path)
+            .expect("the fixture should save");
+        path
+    })
+}
+
 /// Run the CLI as a subprocess, the way an agent or a shell would.
 fn run(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_words_to_data"))
@@ -203,6 +291,77 @@ fn should_report_metadata_and_counts_when_info_runs_on_a_dataset() {
     assert_eq!(info["scope"]["held"][0]["work"], AMENDED_WORK);
     assert_eq!(info["scope"]["held"][0]["dates"][0], EARLY);
     assert_eq!(info["scope"]["held"][0]["dates"][1], LATE);
+}
+
+#[test]
+fn should_name_the_link_kind_when_info_reports_links() {
+    let output = run(&["info", annotated_fixture()]);
+
+    assert!(
+        output.status.success(),
+        "info should exit zero, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    // The kind is named in full, namespace included. A reader who meets a
+    // namespace it does not know must see it named rather than folded into a
+    // total (`docs/adr/0002-links-live-in-the-core.md`).
+    assert!(
+        text.contains("legislature.amended_by  1"),
+        "the link breakdown should name the kind and its count, got:\n{text}"
+    );
+    assert!(text.contains("Links:       1"), "got:\n{text}");
+    assert!(text.contains("Members:     432"), "got:\n{text}");
+    assert!(text.contains("Votes:       432"), "got:\n{text}");
+    assert!(text.contains("Roll calls:  1"), "got:\n{text}");
+    assert!(text.contains("Sponsors:    1"), "got:\n{text}");
+    // This dataset holds no evidence, so it says nothing about evidence.
+    assert!(!text.contains("Replies:"), "got:\n{text}");
+}
+
+#[test]
+fn should_carry_the_link_and_legislature_counts_when_info_emits_json() {
+    let output = run(&["info", annotated_fixture(), "--json"]);
+    let info: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("info --json should emit json");
+
+    // `--json` is what an agent reads, so it carries the same counts.
+    assert_eq!(info["link_count"], 1);
+    assert_eq!(info["link_counts_by_kind"]["legislature.amended_by"], 1);
+    assert_eq!(info["member_count"], 432);
+    assert_eq!(info["member_vote_count"], 432);
+    assert_eq!(info["roll_call_count"], 1);
+    assert_eq!(info["sponsor_count"], 1);
+    assert_eq!(info["bill_count"], 1);
+    assert!(
+        info.get("reply_count").is_none(),
+        "a count of zero is left out"
+    );
+}
+
+#[test]
+fn should_omit_a_count_of_zero_when_info_runs_on_a_dataset_without_legislature() {
+    let output = run(&["info", amended_fixture()]);
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    // A dataset with no legislature extension must not grow a wall of zeroes.
+    for label in [
+        "Links:",
+        "Replies:",
+        "Members:",
+        "Sponsors:",
+        "Roll calls:",
+        "Votes:",
+    ] {
+        assert!(
+            !text.contains(label),
+            "{label} is zero here and must not be printed, got:\n{text}"
+        );
+    }
+    // The counts reported before this rule are still reported.
+    assert!(text.contains("Works:       1"), "got:\n{text}");
+    assert!(text.contains("Bills:       0"), "got:\n{text}");
 }
 
 /// Run `diff` over a fixture and return its parsed JSON summary.

--- a/tests/inspect_tests.rs
+++ b/tests/inspect_tests.rs
@@ -8,10 +8,12 @@
 use words_to_data::annotation::{
     AnnotationMetadata, AnnotationStatus, BillReference, ChangeAnnotation,
 };
+use words_to_data::congress::CongressClient;
 use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId};
 use words_to_data::inspect;
 use words_to_data::inspect::AnnotationQuery;
 use words_to_data::legislature::AmendingAction;
+use words_to_data::link::LinkKind;
 use words_to_data::storage::{InMemoryStorage, SqliteStorage};
 use words_to_data::uslm::bill_parser::parse_bill_amendments;
 
@@ -22,6 +24,11 @@ const TITLE_9: &str = "uscode/title_9";
 const USC09_18: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
 const USC09_30: &str = "tests/test_data/usc/2025-07-30/usc09.xml";
 const PL_XML: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml";
+/// The committed download of one real bill: its sponsor, its cosponsors, the
+/// members of the House, and the roll call they voted in.
+const CONGRESS_CACHE: &str = "tests/test_data/congress_client_cache";
+/// Replies a model really emitted, the evidence a sweep keeps (#58).
+const MODEL_REPLIES: &str = "tests/test_data/processed/model_replies.json";
 
 fn at(date: &str) -> ExpressionId {
     ExpressionId::new(WorkId::new(TITLE_9), date)
@@ -75,6 +82,42 @@ fn make_fixture() -> Dataset<InMemoryStorage> {
     dataset
 }
 
+/// The fixture plus everything else an annotated legislative dataset carries:
+/// the bill's sponsor, the members of the House, the roll call they voted in,
+/// and the model replies the links were read out of.
+///
+/// All of it is committed data, read through the same cache the pipeline reads.
+fn make_full_fixture() -> Dataset<InMemoryStorage> {
+    let mut dataset = make_fixture();
+
+    // No API key and no expiry: the fixtures are committed, and a read must
+    // never reach the network or delete them for being old.
+    let client = CongressClient::with_ttl(String::new(), Some(CONGRESS_CACHE.to_string()), None);
+    let download = client
+        .download_bill("119-hr-1")
+        .expect("the cached bill should read");
+    dataset
+        .load_bill_download(&download)
+        .expect("the download should load");
+
+    for reply in recorded_replies() {
+        dataset.add_reply(&reply).expect("the reply should store");
+    }
+    dataset
+}
+
+/// Every reply in the recorded fixture.
+fn recorded_replies() -> Vec<String> {
+    #[derive(serde::Deserialize)]
+    struct RecordedReply {
+        reply: String,
+    }
+    let json = std::fs::read_to_string(MODEL_REPLIES).expect("the fixture should be readable");
+    let replies: Vec<RecordedReply> =
+        serde_json::from_str(&json).expect("the fixture should parse");
+    replies.into_iter().map(|r| r.reply).collect()
+}
+
 /// Round-trip the fixture through SQLite so tests can exercise that backend too.
 ///
 /// `name` must be unique per test: tests run in parallel and each needs its own
@@ -101,6 +144,87 @@ fn should_report_metadata_and_counts_when_given_in_memory_dataset() {
     assert_eq!(info.work_count, 1, "two releases of one title are one work");
     assert_eq!(info.expression_count, 2);
     assert_eq!(info.bill_count, 1);
+}
+
+#[test]
+fn should_count_links_replies_members_sponsors_and_votes_when_the_dataset_holds_them() {
+    let dataset = make_full_fixture();
+
+    let info = inspect::info(&dataset).expect("info");
+
+    // Links are what this project produces; the US Code text is the input.
+    assert_eq!(
+        info.link_count, 1,
+        "the fixture's annotation names one path"
+    );
+    assert_eq!(
+        info.link_counts_by_kind.get(LinkKind::AMENDED_BY).copied(),
+        Some(1),
+        "the kind is named in full, namespace included"
+    );
+    assert_eq!(info.reply_count, 5, "the recorded fixture holds five");
+    assert_eq!(info.member_count, 432);
+    assert_eq!(info.sponsor_count, 1, "one bill, one sponsor record");
+    assert_eq!(info.roll_call_count, 1);
+    assert_eq!(info.member_vote_count, 432);
+}
+
+#[test]
+fn should_omit_a_zero_count_from_json_when_the_dataset_holds_none_of_it() {
+    // Two release points of one title and nothing else: no legislature
+    // extension, no links, no evidence.
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Documents only".to_string(),
+        ..Default::default()
+    });
+    dataset
+        .add_uslm_xml(USC09_18, "2025-07-18", None)
+        .expect("add first version");
+
+    let info = inspect::info(&dataset).expect("info");
+    let json = serde_json::to_value(&info).expect("info should serialize");
+
+    // A wall of zeroes reads as "this tool measured nothing". Absence is the
+    // answer, and it is the same answer for every one of the new counts.
+    for key in [
+        "link_count",
+        "link_counts_by_kind",
+        "reply_count",
+        "member_count",
+        "sponsor_count",
+        "roll_call_count",
+        "member_vote_count",
+    ] {
+        assert!(
+            json.get(key).is_none(),
+            "{key} is zero here and must be left out"
+        );
+    }
+
+    // The counts that were reported before this rule are still reported, so an
+    // agent reading them keeps its fields.
+    assert_eq!(json["work_count"], 1);
+    assert_eq!(json["expression_count"], 1);
+    assert_eq!(json["bill_count"], 0);
+}
+
+#[test]
+fn should_report_identical_counts_for_both_backends() {
+    let fixture = make_full_fixture();
+    let expected = inspect::info(&fixture).expect("info mem");
+
+    let sqlite = to_sqlite(&fixture, "counts");
+    let actual = inspect::info(&sqlite).expect("info sqlite");
+
+    assert_eq!(actual.link_count, expected.link_count);
+    assert_eq!(actual.link_counts_by_kind, expected.link_counts_by_kind);
+    assert_eq!(actual.reply_count, expected.reply_count);
+    assert_eq!(actual.member_count, expected.member_count);
+    assert_eq!(actual.sponsor_count, expected.sponsor_count);
+    assert_eq!(actual.roll_call_count, expected.roll_call_count);
+    assert_eq!(actual.member_vote_count, expected.member_vote_count);
+    // Same numbers, and the numbers the dataset really holds.
+    assert_eq!(actual.member_vote_count, 432);
 }
 
 #[test]


### PR DESCRIPTION
Closes nothing automatically — for #108. The maintainer closes the issue.

## What changed

`info` counted the input and not the output. It now reports what a dataset holds of each thing it can hold:

- **`DatasetInfo`** gains `link_count`, `link_counts_by_kind`, `reply_count`, `member_count`, `sponsor_count`, `roll_call_count` and `member_vote_count`. No existing field is renamed or removed. `bill_count` now comes from the same count as the rest, and answers exactly as before.
- **The storage traits** gain one counting method each, in the trait that owns the thing counted: `LinkReader::count_links_by_kind`, `EvidenceReader::count_replies`, and `LegislatureReader::legislature_counts` (one method for the five legislature counts, returning the new `LegislatureCounts`). Both backends and the `Dataset<S>` delegation implement them.
- **The human output** prints one line per non-zero count, with the link count broken down by kind.

### Count, not load

Every count is a count. SQLite answers with `SELECT COUNT(*)` per table and one `GROUP BY kind` for the links; the in-memory backend reads map lengths. Nothing deserializes a document, a link, or a reply to count it.

`info` on the real 1.9 GB SQLite dataset, release build, warm cache, three runs each:

| | wall time |
| --- | --- |
| before this branch | 0.003, 0.003, 0.004 s |
| after this branch | 0.005, 0.004, 0.004 s |

Seven count queries cost about a millisecond. `info` has not become slower.

### Zero counts

A count is printed only when it is above zero, and **left out of the JSON** when it is zero — the same rule for all seven new fields, so `--json` never carries a wall of zeroes and a consumer reads "absent" as "holds none". `work_count`, `expression_count` and `bill_count` are always emitted, because an agent already reads them and this branch must not change what it reads.

### The link breakdown

The kind is named in full, namespace included, and the breakdown is a map from kind to count. A reader that meets a namespace it does not own must see it named rather than folded into a total, which is the whole point of the kind being an open string (`docs/adr/0002-links-live-in-the-core.md`).

## The real dataset

`words_to_data info` on a copy of the real 1.9 GB dataset (the original was read only, never written):

```
Name:        US Code
Description: US Code release points
Author:      Words to Data LLC
License:     Public Domain
Version:     1.0
Sources:     https://wordstodata.com/mirror/uslm/index.json
Works:       58
Expressions: 116
Bills:       5
Links:       893
  legislature.amended_by  893
Replies:     1237
Members:     435
Sponsors:    5
Roll calls:  3
Votes:       1297
Covers:      58 works, including
  ...
```

893 links of one kind, 1237 replies, 435 members, 1297 member votes, 3 roll calls, 5 sponsors — every number the issue asked for.

## Test evidence

Six new tests, all on real committed data: the two USC release points, the cached download of one real bill (its sponsor, 432 members, one roll call, 432 member votes), and the five recorded model replies in `tests/test_data/processed/model_replies.json`. Nothing is mocked.

- `tests/inspect_tests.rs`
  - `should_count_links_replies_members_sponsors_and_votes_when_the_dataset_holds_them`
  - `should_omit_a_zero_count_from_json_when_the_dataset_holds_none_of_it`
  - `should_report_identical_counts_for_both_backends`
- `tests/cli_tests.rs`
  - `should_name_the_link_kind_when_info_reports_links`
  - `should_carry_the_link_and_legislature_counts_when_info_emits_json`
  - `should_omit_a_count_of_zero_when_info_runs_on_a_dataset_without_legislature`

```
$ cargo test --test inspect_tests --test cli_tests
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
exit 0
```

Full suite, summed over every binary:

```
$ cargo test
{'passed': 319, 'failed': 0, 'ignored': 7}
exit 0
```

The baseline on `vibes` before this branch was `{'passed': 313, 'failed': 0, 'ignored': 7}` — the six new tests, nothing regressed.

```
$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile
exit 0

$ cargo fmt --check
exit 0
```

## What I could not do, and what I left alone

- **The 7-second metadata read on the compact format** is out of scope and is now #117, with measurements: 9.5 s on the 858 MB compact file against 0.004 s on the SQLite of the same data. Linked from #108. No change to the W2D format here.
- **`SCHEMA_VERSION` is untouched** (still 6) and no stored shape changed: these are queries over tables that already exist, so a dataset built before this branch reports its counts without a rebuild.
- **The member type is untouched** (#105 owns it), and no unrelated code was reformatted.
- Three stale SQLite files from an earlier schema were left in `/tmp` by an earlier run and made three `sqlite_tests` fail before I started; deleting them restored the clean baseline. Those tests write to fixed `/tmp` paths, which is a hazard when two agents run the suite at once — not fixed here.

## One decision the brief did not settle

The link count prints as a total **and** a per-kind breakdown, even when there is only one kind:

```
Links:       893
  legislature.amended_by  893
```

The repetition is deliberate: the total is the headline a reader scans for, and the breakdown is the part that survives a dataset gaining a second kind. Dropping the total when there is one kind would make the shape of the output depend on the data. Say the word if you would rather have one line.