### PR TITLE
fix: report the annotations recorded beneath a path

### DIFF
--- a/src/bin/words_to_data/annotations.rs
+++ b/src/bin/words_to_data/annotations.rs
@@ -2,7 +2,7 @@
 
 use clap::Args as ClapArgs;
 use words_to_data::dataset::ExpressionId;
-use words_to_data::inspect::{self, AnnotationQuery};
+use words_to_data::inspect::{self, AnnotationQuery, PathMatch};
 
 use crate::load::{self, with_dataset};
 
@@ -23,9 +23,13 @@ pub struct Args {
     #[arg(long, conflicts_with_all = ["from", "path"])]
     pub bill: Option<String>,
 
-    /// Filter to annotations touching this structural path
+    /// Filter to annotations on this structural path or on any path beneath it
     #[arg(long, conflicts_with_all = ["from", "bill"])]
     pub path: Option<String>,
+
+    /// Match `--path` exactly: keep only annotations recorded on that path itself
+    #[arg(long, requires = "path")]
+    pub exact: bool,
 
     /// Emit JSON instead of human-readable text
     #[arg(long)]
@@ -38,7 +42,10 @@ pub fn run(args: Args) {
     } else if let Some(bill) = &args.bill {
         AnnotationQuery::Bill(bill)
     } else if let Some(path) = &args.path {
-        AnnotationQuery::Path(path)
+        AnnotationQuery::Path {
+            path,
+            matching: path_matching(args.exact),
+        }
     } else {
         eprintln!("Provide a filter: --from/--to, --bill, or --path");
         std::process::exit(2);
@@ -60,6 +67,19 @@ pub fn run(args: Args) {
         println!("    paths: {}", a.paths.join(", "));
     }
     println!("{} annotation(s)", anns.len());
+}
+
+/// Read the `--exact` flag both path-taking commands carry.
+///
+/// The subtree is the default: a person names a section, and a bill amends a
+/// clause inside it. Shared with the `path` command so one flag cannot come to
+/// mean two things.
+pub fn path_matching(exact: bool) -> PathMatch {
+    if exact {
+        PathMatch::Exact
+    } else {
+        PathMatch::Subtree
+    }
 }
 
 /// Print one annotation's headline: status, operation, bill, short amendment id,

--- a/src/bin/words_to_data/path.rs
+++ b/src/bin/words_to_data/path.rs
@@ -12,7 +12,8 @@ pub struct Args {
     /// Dataset file (`.json` compact or `.sqlite`)
     pub dataset: String,
 
-    /// Structural path to inspect (e.g. `uscode/title_9/chapter_1/section_1`)
+    /// Structural path to inspect (e.g. `uscode/title_9/chapter_1/section_1`).
+    /// Annotations on this path and on every path beneath it are reported
     pub path: String,
 
     /// Older expression for field changes, e.g. `uscode/title_9@2025-07-18` (requires `--to`)
@@ -22,6 +23,10 @@ pub struct Args {
     /// Newer expression of the same work (requires `--from`)
     #[arg(long, requires = "from")]
     pub to: Option<ExpressionId>,
+
+    /// Report only the annotations recorded on this path itself, not those beneath it
+    #[arg(long)]
+    pub exact: bool,
 
     /// Emit JSON instead of human-readable text
     #[arg(long)]
@@ -34,9 +39,10 @@ pub fn run(args: Args) {
         _ => None,
     };
 
+    let matching = crate::annotations::path_matching(args.exact);
     let ds = crate::fail::or_exit(load::open(&args.dataset), "Error opening dataset");
     let report = crate::fail::or_exit(
-        with_dataset!(ds, d => inspect::path_report(&d, &args.path, pair)),
+        with_dataset!(ds, d => inspect::path_report(&d, &args.path, pair, matching)),
         "Error building path report",
     );
 
@@ -73,7 +79,14 @@ pub fn run(args: Args) {
         }
     }
 
-    println!("\nAnnotations ({}):", report.annotations.len());
+    // Say which paths the count covers. A bare "Annotations (0)" reads as
+    // "nothing was attributed here", which is a different statement.
+    let scope = if args.exact {
+        "on this path exactly"
+    } else {
+        "at or beneath this path"
+    };
+    println!("\nAnnotations {scope} ({}):", report.annotations.len());
     for a in &report.annotations {
         crate::annotations::print_annotation(a);
     }

--- a/src/dataset/scope.rs
+++ b/src/dataset/scope.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::dataset::{DatasetError, WorkId};
 use crate::storage::DocumentReader;
+use crate::uslm::path::covers_path;
 
 /// Whether a dataset covers something.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -104,14 +105,6 @@ impl Declaration {
     fn intends_path(&self, path: &str) -> bool {
         self.intends.iter().any(|want| covers_path(want, path))
     }
-}
-
-/// Whether `prefix` names `path` or an ancestor of it.
-///
-/// Compares whole segments: `uscode/title_2` must not answer for
-/// `uscode/title_26`.
-fn covers_path(prefix: &str, path: &str) -> bool {
-    path == prefix || path.starts_with(&format!("{prefix}/"))
 }
 
 /// One work a dataset holds, and when it was published.
@@ -214,12 +207,8 @@ impl Scope {
     /// A dataset that declared nothing answers exactly as it did before
     /// declarations existed: held or not held, and no third answer.
     pub fn covers(&self, path: &str) -> Coverage {
-        let inside_held = self
-            .works()
-            .any(|work| path == work.as_str() || path.starts_with(&format!("{work}/")));
-        let ancestor_of_held = self
-            .works()
-            .any(|work| work.as_str().starts_with(&format!("{path}/")));
+        let inside_held = self.works().any(|work| covers_path(work.as_str(), path));
+        let ancestor_of_held = self.works().any(|work| covers_path(path, work.as_str()));
 
         if inside_held || ancestor_of_held {
             return Coverage::InScope;

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -262,10 +262,14 @@ fn field_str(field: &crate::uslm::TextContentField) -> String {
 /// Assemble a combined view of a single path: which expressions hold it and
 /// how many provisions sit there, what happened to each provision across an
 /// optional expression pair, and every annotation that references it.
+///
+/// `matching` decides which annotations reference the path: the whole subtree
+/// beneath it, or that path alone. See [`PathMatch`].
 pub fn path_report<S: Storage>(
     dataset: &S,
     path: &str,
     pair: Option<(&ExpressionId, &ExpressionId)>,
+    matching: PathMatch,
 ) -> Result<PathReport, DatasetError> {
     let present_in = presence_counts(dataset, path)?;
 
@@ -281,7 +285,7 @@ pub fn path_report<S: Storage>(
         None => Vec::new(),
     };
 
-    let annotations = annotations(dataset, AnnotationQuery::Path(path))?;
+    let annotations = annotations(dataset, AnnotationQuery::Path { path, matching })?;
 
     Ok(PathReport {
         path: path.to_string(),
@@ -525,6 +529,33 @@ pub fn validate<S: Storage>(dataset: &S) -> Result<ValidationReport, DatasetErro
     })
 }
 
+/// Which paths a path filter accepts.
+///
+/// A bill amends a subsection, paragraph, subparagraph or clause, so that is
+/// where a change annotation lands. A section is the unit a person names. The
+/// two are therefore almost never the same path, and matching them for equality
+/// answers nothing for most of the annotated law.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PathMatch {
+    /// The path given and every path beneath it. The default, because it is
+    /// what naming a section means.
+    #[default]
+    Subtree,
+    /// Only an annotation recorded on exactly the path given.
+    Exact,
+}
+
+impl PathMatch {
+    /// Whether an annotation recorded on `annotated` answers for `asked`.
+    fn accepts(self, asked: &str, annotated: &str) -> bool {
+        match self {
+            // Segment-aware, so `section_16` does not answer for `section_163`.
+            Self::Subtree => crate::uslm::path::covers_path(asked, annotated),
+            Self::Exact => asked == annotated,
+        }
+    }
+}
+
 /// Which annotations to list. The three variants map to the mutually exclusive
 /// filters of the `annotations` subcommand.
 pub enum AnnotationQuery<'a> {
@@ -536,7 +567,11 @@ pub enum AnnotationQuery<'a> {
     /// Annotations sourced from a specific bill (across all pairs).
     Bill(&'a str),
     /// Annotations touching a specific structural path (across all pairs).
-    Path(&'a str),
+    Path {
+        path: &'a str,
+        /// Which paths count as touching it.
+        matching: PathMatch,
+    },
 }
 
 /// A flattened annotation for display, tagged with the expression pair it belongs to.
@@ -607,10 +642,10 @@ pub fn annotations<S: Storage>(
                 }
             }
         }
-        AnnotationQuery::Path(path) => {
+        AnnotationQuery::Path { path, matching } => {
             for (from, to) in dataset.annotation_pairs()? {
                 for ann in dataset.get_annotations(&from, &to)?.unwrap_or_default() {
-                    if ann.paths.iter().any(|p| p == path) {
+                    if ann.paths.iter().any(|p| matching.accepts(path, p)) {
                         out.push(summarize(&from, &to, &ann));
                     }
                 }

--- a/src/uslm/path.rs
+++ b/src/uslm/path.rs
@@ -1,9 +1,36 @@
-//! Path generation utilities for USLM elements
+//! Path utilities for USLM elements
 //!
-//! This module contains pure functions for generating structural paths
-//! and determining USLM path inclusion for elements.
+//! This module contains pure functions for generating structural paths,
+//! comparing them, and determining USLM path inclusion for elements.
 
 use super::ElementType;
+
+/// Whether `prefix` names `path` or an ancestor of it.
+///
+/// Compares whole segments, so a shorter number is not an ancestor of a longer
+/// one: `section_16` does not cover `section_163`. Every caller that takes a
+/// path and means "this path and everything beneath it" asks here, because a
+/// raw string prefix answers that question wrongly.
+///
+/// # Examples
+///
+/// ```
+/// use words_to_data::uslm::path::covers_path;
+///
+/// // The path itself, and anything beneath it.
+/// assert!(covers_path("uscode/title_26/section_163", "uscode/title_26/section_163"));
+/// assert!(covers_path(
+///     "uscode/title_26/section_163",
+///     "uscode/title_26/section_163/subsection_j/paragraph_8"
+/// ));
+///
+/// // A whole segment, not a string prefix.
+/// assert!(!covers_path("uscode/title_26/section_16", "uscode/title_26/section_163"));
+/// assert!(!covers_path("uscode/title_2", "uscode/title_26"));
+/// ```
+pub fn covers_path(prefix: &str, path: &str) -> bool {
+    path == prefix || path.starts_with(&format!("{prefix}/"))
+}
 
 /// Determines if an element type should be included in the USLM path
 ///

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -19,6 +19,16 @@ use words_to_data::link::Link;
 const EARLY: &str = "2025-07-18";
 const LATE: &str = "2025-07-30";
 
+/// Every statement a real matching run of H.R. 1 recorded.
+const REAL_ANNOTATIONS: &str = "tests/test_data/processed/annotations.json";
+
+/// Section 163 of title 26, the section H.R. 1 changed more than any other.
+/// Every statement recorded there sits beneath the section, because an
+/// amendment acts on a subsection, paragraph, subparagraph or clause.
+const SECTION_163: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_163";
+/// No such section, and a raw string prefix of [`SECTION_163`].
+const SECTION_16: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_16";
+
 /// Title 9 (Arbitration) did not change between the two release points. Its two
 /// files differ by ten bytes of release stamp, which the parser ignores.
 const UNCHANGED_TITLE: &str = "usc09";
@@ -249,6 +259,63 @@ fn annotated_fixture() -> &'static str {
         let to = ExpressionId::new(WorkId::new(UNCHANGED_WORK), LATE);
         for link in Link::from_annotation(&annotation, &from, &to) {
             dataset.add_link(link).expect("the link should be added");
+        }
+
+        dataset
+            .save_to_sqlite(&path)
+            .expect("the fixture should save");
+        path
+    })
+}
+
+/// A dataset carrying every statement a real matching run of H.R. 1 recorded.
+///
+/// Separate from [`annotated_fixture`], which holds one link on purpose so that
+/// `info` can count each kind of fact exactly. This one holds 753 statements
+/// over hundreds of paths, because a path filter is only tested by a real spread
+/// of paths.
+///
+/// The documents are title 9 while the statements name title 26. A path filter
+/// compares paths and never reads a document, so holding the amended title
+/// itself would add a minute of parsing and prove nothing more; `inspect_tests`
+/// says the same of the same fixture file.
+fn matched_statements_fixture() -> &'static str {
+    static FIXTURE: OnceLock<String> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let path = format!(
+            "{}/cli_matched_statements.sqlite",
+            env!("CARGO_TARGET_TMPDIR")
+        );
+        let _ = std::fs::remove_file(&path);
+
+        let mut dataset = Dataset::new(DatasetMetadata {
+            name: "Matched Statements".to_string(),
+            description: "One title, plus the statements a real run recorded".to_string(),
+            author: "words_to_data tests".to_string(),
+            source_urls: vec![],
+            license: "MIT".to_string(),
+            version: "1.0.0".to_string(),
+            ..Default::default()
+        });
+
+        for date in [EARLY, LATE] {
+            let xml = format!("tests/test_data/usc/{date}/{UNCHANGED_TITLE}.xml");
+            dataset
+                .add_uslm_xml(&xml, date, None)
+                .expect("the corpus should parse and load");
+        }
+
+        let file = std::fs::File::open(REAL_ANNOTATIONS).expect("open the recorded annotations");
+        let annotations: Vec<ChangeAnnotation> =
+            serde_json::from_reader(std::io::BufReader::new(file)).expect("read the annotations");
+
+        let work = WorkId::new(UNCHANGED_WORK);
+        let from = ExpressionId::new(work.clone(), EARLY);
+        let to = ExpressionId::new(work, LATE);
+        for annotation in &annotations {
+            for link in Link::from_annotation(annotation, &from, &to) {
+                dataset.add_link(link).expect("the link should be added");
+            }
         }
 
         dataset
@@ -557,6 +624,132 @@ fn should_return_no_annotations_when_the_dataset_has_none() {
         serde_json::from_slice(&output.stdout).expect("annotations --json should emit json");
 
     assert_eq!(annotations.as_array().expect("an array").len(), 0);
+}
+
+/// The annotation list of a `path` or `annotations` run, as JSON.
+fn annotation_list(args: &[&str]) -> Vec<serde_json::Value> {
+    let output = run(args);
+    assert!(
+        output.status.success(),
+        "{args:?} should exit zero, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("--json should emit json");
+    // `path` wraps its annotations in a report; `annotations` emits the list.
+    let list = match json.get("annotations") {
+        Some(annotations) => annotations,
+        None => &json,
+    };
+    list.as_array().expect("an array").clone()
+}
+
+#[test]
+fn should_report_the_annotations_beneath_a_section_when_path_names_a_section() {
+    let dataset = matched_statements_fixture();
+
+    let by_default = annotation_list(&["path", dataset, SECTION_163, "--json"]);
+    let exactly_there = annotation_list(&["path", dataset, SECTION_163, "--exact", "--json"]);
+
+    assert_eq!(
+        by_default.len(),
+        9,
+        "naming a section must report the records held beneath it"
+    );
+    assert!(
+        exactly_there.is_empty(),
+        "--exact keeps the answer this section used to give"
+    );
+}
+
+#[test]
+fn should_report_the_annotations_beneath_a_section_when_annotations_is_given_one() {
+    let dataset = matched_statements_fixture();
+
+    let by_default = annotation_list(&["annotations", dataset, "--path", SECTION_163, "--json"]);
+    let exactly_there = annotation_list(&[
+        "annotations",
+        dataset,
+        "--path",
+        SECTION_163,
+        "--exact",
+        "--json",
+    ]);
+
+    assert_eq!(
+        by_default.len(),
+        9,
+        "both commands must answer a section the same way"
+    );
+    assert!(exactly_there.is_empty(), "--exact means exactly");
+}
+
+#[test]
+fn should_not_report_a_longer_section_number_when_the_path_is_a_string_prefix() {
+    let dataset = matched_statements_fixture();
+
+    let shorter_number = annotation_list(&["annotations", dataset, "--path", SECTION_16, "--json"]);
+
+    assert!(
+        shorter_number.is_empty(),
+        "§16 is not §163: a path matches whole segments, not characters"
+    );
+}
+
+/// The subtree changes which annotations are listed, and nothing else. An agent
+/// reading `--json` must not have to change how it reads the answer.
+#[test]
+fn should_keep_the_annotation_fields_when_reporting_a_subtree() {
+    let dataset = matched_statements_fixture();
+
+    let reported = annotation_list(&["annotations", dataset, "--path", SECTION_163, "--json"]);
+
+    let first = reported.first().expect("a reported annotation");
+    for field in [
+        "work",
+        "from",
+        "to",
+        "from_date",
+        "to_date",
+        "operation",
+        "bill_id",
+        "amendment_id",
+        "causative_text",
+        "status",
+        "confidence",
+        "annotator",
+        "paths",
+    ] {
+        assert!(
+            first.get(field).is_some(),
+            "the annotation shape must not change, {field} is missing from {first}"
+        );
+    }
+}
+
+#[test]
+fn should_say_which_paths_the_filter_matches_when_either_command_is_asked_for_help() {
+    let annotations = String::from_utf8_lossy(&run(&["annotations", "--help"]).stdout).to_string();
+    let path = String::from_utf8_lossy(&run(&["path", "--help"]).stdout).to_string();
+
+    for help in [&annotations, &path] {
+        assert!(
+            help.contains("beneath"),
+            "the help must say the filter takes the subtree, got: {help}"
+        );
+        assert!(
+            help.contains("--exact"),
+            "the help must offer the exact rule, got: {help}"
+        );
+    }
+    assert!(
+        annotations.contains("path itself"),
+        "the exact rule must say what it matches, got: {annotations}"
+    );
+    assert!(
+        path.contains("this path itself"),
+        "the exact rule must say what it matches, got: {path}"
+    );
 }
 
 /// `annotations` needs one of three filters. Asking for everything is a usage

--- a/tests/duplicate_path_tests.rs
+++ b/tests/duplicate_path_tests.rs
@@ -5,6 +5,7 @@
 //! site renders both. Code that assumes a path is unique within an expression
 //! does not fail loudly — it picks one and discards the other.
 
+use words_to_data::inspect::PathMatch;
 use words_to_data::uslm::{USLMElement, parser::parse};
 
 const USC26_18: &str = "tests/test_data/usc/2025-07-18/usc26.xml";
@@ -169,8 +170,8 @@ fn should_say_which_provision_was_added_when_a_path_gains_one() {
     let dataset = title_26_both_expressions();
     let (from, to) = (title_26_at("2025-07-18"), title_26_at("2025-07-30"));
 
-    let report =
-        inspect::path_report(&dataset, DUPLICATED, Some((&from, &to))).expect("path_report");
+    let report = inspect::path_report(&dataset, DUPLICATED, Some((&from, &to)), PathMatch::Subtree)
+        .expect("path_report");
 
     // Each expression is named once, with the number of provisions it holds.
     // Naming the later expression twice was the whole defect (#90).
@@ -233,7 +234,8 @@ fn should_say_which_provision_was_removed_when_a_path_loses_one() {
     let dataset = title_26_both_expressions();
     let (from, to) = (title_26_at("2025-07-18"), title_26_at("2025-07-30"));
 
-    let report = inspect::path_report(&dataset, LOST_ONE, Some((&from, &to))).expect("path_report");
+    let report = inspect::path_report(&dataset, LOST_ONE, Some((&from, &to)), PathMatch::Subtree)
+        .expect("path_report");
 
     let presence: Vec<(&str, usize)> = report
         .present_in
@@ -288,8 +290,8 @@ fn should_report_every_provision_as_removed_when_a_path_disappears() {
     let dataset = title_26_both_expressions();
     let (from, to) = (title_26_at("2025-07-18"), title_26_at("2025-07-30"));
 
-    let report =
-        inspect::path_report(&dataset, LOST_BOTH, Some((&from, &to))).expect("path_report");
+    let report = inspect::path_report(&dataset, LOST_BOTH, Some((&from, &to)), PathMatch::Subtree)
+        .expect("path_report");
 
     // Only the earlier expression holds the path at all.
     assert_eq!(report.present_in.len(), 1);
@@ -314,8 +316,13 @@ fn should_report_every_provision_as_added_when_a_path_is_new() {
     let dataset = title_26_both_expressions();
     let (from, to) = (title_26_at("2025-07-18"), title_26_at("2025-07-30"));
 
-    let report =
-        inspect::path_report(&dataset, GAINED_BOTH, Some((&from, &to))).expect("path_report");
+    let report = inspect::path_report(
+        &dataset,
+        GAINED_BOTH,
+        Some((&from, &to)),
+        PathMatch::Subtree,
+    )
+    .expect("path_report");
 
     assert_eq!(report.present_in.len(), 1);
     assert_eq!(
@@ -338,7 +345,8 @@ fn should_report_counts_but_no_provisions_when_no_expression_pair_is_given() {
 
     let dataset = title_26_both_expressions();
 
-    let report = inspect::path_report(&dataset, DUPLICATED, None).expect("path_report");
+    let report =
+        inspect::path_report(&dataset, DUPLICATED, None, PathMatch::Subtree).expect("path_report");
 
     // Without a pair there is nothing to compare, but where the path lives is
     // still answerable and is still the question `present_in` exists for.

--- a/tests/inspect_tests.rs
+++ b/tests/inspect_tests.rs
@@ -11,7 +11,7 @@ use words_to_data::annotation::{
 use words_to_data::congress::CongressClient;
 use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId};
 use words_to_data::inspect;
-use words_to_data::inspect::AnnotationQuery;
+use words_to_data::inspect::{AnnotationQuery, PathMatch};
 use words_to_data::legislature::AmendingAction;
 use words_to_data::link::LinkKind;
 use words_to_data::storage::{InMemoryStorage, SqliteStorage};
@@ -29,6 +29,20 @@ const PL_XML: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public
 const CONGRESS_CACHE: &str = "tests/test_data/congress_client_cache";
 /// Replies a model really emitted, the evidence a sweep keeps (#58).
 const MODEL_REPLIES: &str = "tests/test_data/processed/model_replies.json";
+/// Every statement a real matching run of H.R. 1 recorded.
+const REAL_ANNOTATIONS: &str = "tests/test_data/processed/annotations.json";
+
+/// Section 163 of title 26 (interest deduction), the section H.R. 1 changed
+/// more than any other. Every statement recorded there sits *beneath* the
+/// section, because an amendment acts on a subsection, paragraph, subparagraph
+/// or clause.
+const SECTION_163: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_163";
+/// Section 181 carries statements on the section itself as well as beneath it,
+/// so it says whether "at or beneath" really includes the path given.
+const SECTION_181: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_181";
+/// No such section. It is a raw string prefix of [`SECTION_163`], so a filter
+/// that compared strings rather than whole segments would answer §163 here.
+const SECTION_16: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_16";
 
 fn at(date: &str) -> ExpressionId {
     ExpressionId::new(WorkId::new(TITLE_9), date)
@@ -116,6 +130,46 @@ fn recorded_replies() -> Vec<String> {
     let replies: Vec<RecordedReply> =
         serde_json::from_str(&json).expect("the fixture should parse");
     replies.into_iter().map(|r| r.reply).collect()
+}
+
+/// A dataset holding every statement a real matching run of H.R. 1 recorded.
+///
+/// Separate from [`make_full_fixture`], which holds one statement so that a
+/// count of each kind of fact can be checked exactly. A path filter instead
+/// needs a real spread of paths, and this fixture holds 753 statements.
+///
+/// The documents are title 9 while the statements name title 26. That is on
+/// purpose: a path filter compares paths and never reads a document, and
+/// loading the two 52 MB title 26 releases to show the same thing would cost a
+/// minute of test time. The statements are real —
+/// `tests/test_data/processed/annotations.json` is the output of a matching
+/// run, and `dataset_tests` reads the same file.
+fn matched_statements_fixture() -> Dataset<InMemoryStorage> {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "Matched Statements".to_string(),
+        description: "Every statement one matching run of H.R. 1 recorded".to_string(),
+        author: "Tester".to_string(),
+        source_urls: vec![],
+        license: "Public Domain".to_string(),
+        version: "1.0".to_string(),
+        ..Default::default()
+    });
+    dataset
+        .add_uslm_xml(USC09_18, "2025-07-18", None)
+        .expect("add first version");
+    dataset
+        .add_uslm_xml(USC09_30, "2025-07-30", None)
+        .expect("add second version");
+
+    let file = std::fs::File::open(REAL_ANNOTATIONS).expect("open the recorded annotations");
+    let annotations: Vec<ChangeAnnotation> =
+        serde_json::from_reader(std::io::BufReader::new(file)).expect("read the annotations");
+
+    let (from, to) = pair();
+    for annotation in annotations {
+        store_annotation(&mut dataset, annotation, &from, &to);
+    }
+    dataset
 }
 
 /// Round-trip the fixture through SQLite so tests can exercise that backend too.
@@ -425,14 +479,108 @@ fn should_list_annotations_filtered_by_bill_and_path() {
         inspect::annotations(&dataset, AnnotationQuery::Bill("119-hr-1")).expect("by bill");
     assert_eq!(by_bill.len(), 1);
 
-    let by_path =
-        inspect::annotations(&dataset, AnnotationQuery::Path(ANNOTATED_PATH)).expect("by path");
+    let by_path = inspect::annotations(
+        &dataset,
+        AnnotationQuery::Path {
+            path: ANNOTATED_PATH,
+            matching: PathMatch::Subtree,
+        },
+    )
+    .expect("by path");
     assert_eq!(by_path.len(), 1);
     assert_eq!(by_path[0].from_date, "2025-07-18");
     assert_eq!(by_path[0].to_date, "2025-07-30");
 
     let missing = inspect::annotations(&dataset, AnnotationQuery::Bill("000-none")).expect("none");
     assert!(missing.is_empty());
+}
+
+/// Every annotation the dataset reports for one path, under one matching rule.
+fn annotations_at(
+    dataset: &Dataset<InMemoryStorage>,
+    path: &str,
+    matching: PathMatch,
+) -> Vec<inspect::AnnotationSummary> {
+    inspect::annotations(dataset, AnnotationQuery::Path { path, matching }).expect("annotations")
+}
+
+#[test]
+fn should_report_the_annotations_beneath_a_section_when_given_that_section() {
+    let dataset = matched_statements_fixture();
+
+    let exactly_there = annotations_at(&dataset, SECTION_163, PathMatch::Exact);
+    let beneath = annotations_at(&dataset, SECTION_163, PathMatch::default());
+
+    assert!(
+        exactly_there.is_empty(),
+        "no statement of this run sits on the section itself"
+    );
+    // Nine records answer, not 44. A record groups every statement one
+    // amendment asserted, so the records are fewer than the statements the run
+    // recorded beneath the section.
+    assert_eq!(
+        beneath.len(),
+        9,
+        "naming a section must report what was recorded beneath it"
+    );
+}
+
+#[test]
+fn should_report_an_annotation_on_the_path_itself_when_matching_the_subtree() {
+    // The default is "at or beneath", not "beneath only". Section 181 carries
+    // statements on the section itself as well as under it.
+    let dataset = matched_statements_fixture();
+
+    let on_the_section = annotations_at(&dataset, SECTION_181, PathMatch::Exact);
+    let subtree = annotations_at(&dataset, SECTION_181, PathMatch::default());
+
+    assert_eq!(on_the_section.len(), 7, "the section itself is annotated");
+    assert_eq!(subtree.len(), 8, "and one more record sits beneath it");
+    for ann in &on_the_section {
+        assert!(
+            subtree
+                .iter()
+                .any(|reported| reported.amendment_id == ann.amendment_id),
+            "the subtree must keep every annotation an exact match finds"
+        );
+    }
+}
+
+#[test]
+fn should_carry_the_subtree_annotations_into_a_path_report_by_default() {
+    let dataset = matched_statements_fixture();
+
+    let by_default =
+        inspect::path_report(&dataset, SECTION_163, None, PathMatch::default()).expect("subtree");
+    let exactly_there =
+        inspect::path_report(&dataset, SECTION_163, None, PathMatch::Exact).expect("exact");
+
+    assert_eq!(
+        by_default.annotations.len(),
+        9,
+        "a path report answers with the subtree, as the annotation list does"
+    );
+    assert!(
+        exactly_there.annotations.is_empty(),
+        "the exact rule keeps the answer this section used to give"
+    );
+}
+
+#[test]
+fn should_not_report_a_longer_section_number_when_the_path_is_a_string_prefix() {
+    // There is no §16 here, but `section_16` is a string prefix of
+    // `section_163`. A filter that compared raw strings would hand §163's
+    // statements to a reader who asked about a different section.
+    let dataset = matched_statements_fixture();
+
+    assert!(
+        annotations_at(&dataset, SECTION_16, PathMatch::default()).is_empty(),
+        "a path must match whole segments, not characters"
+    );
+    assert!(
+        !annotations_at(&dataset, SECTION_163, PathMatch::default()).is_empty(),
+        "§163 does hold the statements a string prefix would have borrowed"
+    );
 }
 
 #[test]
@@ -532,8 +680,13 @@ fn should_report_annotations_for_a_path() {
     let dataset = make_fixture();
 
     let (from, to) = pair();
-    let report =
-        inspect::path_report(&dataset, ANNOTATED_PATH, Some((&from, &to))).expect("path_report");
+    let report = inspect::path_report(
+        &dataset,
+        ANNOTATED_PATH,
+        Some((&from, &to)),
+        PathMatch::Subtree,
+    )
+    .expect("path_report");
 
     assert_eq!(report.path, ANNOTATED_PATH);
     assert_eq!(report.annotations.len(), 1);
@@ -559,8 +712,8 @@ fn should_report_presence_and_field_changes_for_a_real_path() {
     let tree = dataset.compute_diff(&from, &to).expect("diff");
     let expected_changes = tree.find(&real_path).map(|n| n.changes.len()).unwrap_or(0);
 
-    let report =
-        inspect::path_report(&dataset, &real_path, Some((&from, &to))).expect("path_report");
+    let report = inspect::path_report(&dataset, &real_path, Some((&from, &to)), PathMatch::Subtree)
+        .expect("path_report");
 
     assert!(
         report
@@ -587,8 +740,13 @@ fn should_report_one_provision_in_both_when_an_ordinary_path_is_unchanged() {
 
     // Title 9 section 1 is in both expressions. Whatever it did or did not do
     // to its own fields, it is one provision and it survived.
-    let report =
-        inspect::path_report(&dataset, ANNOTATED_PATH, Some((&from, &to))).expect("path_report");
+    let report = inspect::path_report(
+        &dataset,
+        ANNOTATED_PATH,
+        Some((&from, &to)),
+        PathMatch::Subtree,
+    )
+    .expect("path_report");
 
     assert_eq!(
         report.present_in.len(),
@@ -610,10 +768,20 @@ fn should_report_the_same_provisions_on_both_backends() {
     let sqlite = to_sqlite(&fixture, "path_provisions");
     let (from, to) = pair();
 
-    let from_memory =
-        inspect::path_report(&fixture, ANNOTATED_PATH, Some((&from, &to))).expect("memory");
-    let from_sqlite =
-        inspect::path_report(&sqlite, ANNOTATED_PATH, Some((&from, &to))).expect("sqlite");
+    let from_memory = inspect::path_report(
+        &fixture,
+        ANNOTATED_PATH,
+        Some((&from, &to)),
+        PathMatch::Subtree,
+    )
+    .expect("memory");
+    let from_sqlite = inspect::path_report(
+        &sqlite,
+        ANNOTATED_PATH,
+        Some((&from, &to)),
+        PathMatch::Subtree,
+    )
+    .expect("sqlite");
 
     // Storage must not change the answer. Both backends must agree on the
     // counts, the verdicts, and the positions.
@@ -637,7 +805,8 @@ fn should_report_path_annotations_on_sqlite_backend() {
     let fixture = make_fixture();
     let sqlite = to_sqlite(&fixture, "path_report");
 
-    let report = inspect::path_report(&sqlite, ANNOTATED_PATH, None).expect("path_report sqlite");
+    let report = inspect::path_report(&sqlite, ANNOTATED_PATH, None, PathMatch::Subtree)
+        .expect("path_report sqlite");
     assert_eq!(report.annotations.len(), 1);
 }
 


### PR DESCRIPTION
Fixes the filter behind `path` and `annotations --path`, for #106. Option 1 of the issue, as decided at triage: the subtree is the default, and exact matching stays behind a flag.

## What changed

**The filter.** `inspect::annotations` takes a match mode with `AnnotationQuery::Path { path, matching }`, and `inspect::path_report` takes the same mode. `PathMatch::Subtree` is the `Default`: an annotation answers when the path given is the annotation's path **or an ancestor of it**. `PathMatch::Exact` keeps the old rule.

**The shared path helper.** The scope module held a private `covers_path` for exclusions. It is now `words_to_data::uslm::path::covers_path`, with a doc test. One implementation, and the callers are the scope module and the annotation filter. `Scope::covers` also had two inline copies of the same rule written out by hand; they now ask the helper as well. The comparison is by whole path segment, so `section_16` cannot answer for `section_163`.

**The flags.** `--exact` on both commands, the same name on each. On `annotations` it `requires = "path"`, because it means nothing on its own.

```
annotations:
      --path <PATH>  Filter to annotations on this structural path or on any path beneath it
      --exact        Match `--path` exactly: keep only annotations recorded on that path itself

path:
  <PATH>     Structural path to inspect (...). Annotations on this path and on every path beneath it are reported
      --exact        Report only the annotations recorded on this path itself, not those beneath it
```

**The `path` heading.** `Annotations (0):` now reads `Annotations at or beneath this path (0):` or `Annotations on this path exactly (0):`. A count with no stated scope was the part of this bug that misled a reader, so the human output names the rule it used.

**`--json` shape is unchanged.** `path` still emits `path`, `present_in`, `provisions`, `annotations`; each annotation still carries `work`, `from`, `to`, `from_date`, `to_date`, `operation`, `bill_id`, `amendment_id`, `causative_text`, `status`, `confidence`, `annotator`, `paths`. Only the contents of the annotation list change. A test asserts the fields.

## Evidence: the section from the issue

§163 of title 26 in the real 1.9 GB dataset (read from a copy; the commands are read-only but `SqliteStorage::open` runs `CREATE TABLE IF NOT EXISTS`, so the original was never opened).

Before:

```
$ words_to_data path dataset.sqlite .../part_VI/section_163 --from uscode/title_26@2025-07-18 --to uscode/title_26@2025-07-30
Annotations (0):
$ words_to_data annotations dataset.sqlite --path .../part_VI/section_163
0 annotation(s)
```

After:

```
$ words_to_data path dataset.sqlite .../part_VI/section_163 --from ... --to ...
Annotations at or beneath this path (9):
  [Pending] uscode/title_26 2025-07-18 -> 2025-07-30  amend 119-hr-1 amd 0760f39c72ef (conf 1.00, by model:deepseek-v4-flash)
  ...

$ words_to_data annotations dataset.sqlite --path .../part_VI/section_163
9 annotation(s)

$ words_to_data annotations dataset.sqlite --path .../part_VI/section_163 --exact
0 annotation(s)

$ words_to_data annotations dataset.sqlite --path .../part_VI/section_16
0 annotation(s)
```

**On 38 against 9.** The issue counted 38 *links* beneath §163. These commands report *annotation records*, and a record groups every statement one amendment asserted, so 9 records carry exactly those 38 statements:

```
$ words_to_data path dataset.sqlite .../section_163 --json | jq '[.annotations[].paths[]] | length'
38
```

The 38 the issue asks for is therefore reported, as 9 records holding 38 paths. Nothing beneath the section is lost, and `--exact` still answers 0.

## Tests

Real data only: `tests/test_data/processed/annotations.json`, the 753 statements one matching run of H.R. 1 recorded, is loaded as links onto a title 9 pair. The documents are title 9 while the statements name title 26 on purpose — a path filter compares paths and never reads a document, and parsing the two 52 MB title 26 releases per test would cost a minute and prove nothing more. `dataset_tests` and `sqlite_tests` already use the same file the same way.

New tests, in `tests/inspect_tests.rs` (in memory) and `tests/cli_tests.rs` (the binary over SQLite):

- naming §163 reports the 9 records beneath it, and exact matching reports none;
- §181, which is annotated on the section itself as well as below it, reports 7 records exactly and 8 in the subtree, and every record the exact rule finds is still in the subtree — the default is "at or beneath", not "beneath only";
- `section_16` reports nothing while `section_163` reports records: the segment-boundary rule, asserted directly at both levels;
- a path report carries the subtree by default and the old answer with `PathMatch::Exact`;
- the `--json` annotation fields are unchanged;
- `annotations --help` and `path --help` each state both modes;
- a doc test on `covers_path` pins the rule, `section_16` against `section_163` included.

```
$ cargo test --all
exit 0 — 323 passed, 0 failed, 7 ignored

baseline on vibes (8ee2eb5), same command:
exit 0 — 313 passed, 0 failed, 7 ignored
```

The 10 new results are 9 integration tests and 1 doc test.

```
$ cargo clippy --all-targets -- -D warnings
exit 0

$ cargo fmt --check
exit 0
```

## What I did not do

- `LinkReader::annotations_for_path` (and `Dataset::annotations_for_path` over it) still matches a path exactly. No command reads it, only tests do, and the brief scopes this issue to the filter the two commands use. It is a candidate for the same treatment if a caller ever wants it.
- Where a change annotation is recorded is untouched. A clause is the unit the law changes.
- `--exact` on `path` is accepted even when the reader asks for nothing else; it changes only the annotation list, which is the only thing the mode governs.
