### PR TITLE
docs: say that a sponsor field holds a bioguide id, not a name

### DIFF
--- a/src/congress/sponsor.rs
+++ b/src/congress/sponsor.rs
@@ -10,6 +10,12 @@ pub struct CosponsorRecord {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SponsorInfo {
     pub bill_id: String,
+    /// The sponsor's bioguide id, not their name. Use it to read the Member.
+    ///
+    /// The field name says `sponsor` and the type says `String`, so this reads
+    /// like a name and is not one. A rename would change the key stored in a
+    /// W2D file, which is a break for readability alone, so the name stays and
+    /// this comment carries the meaning instead.
     pub sponsor: String,
     pub cosponsors: Vec<CosponsorRecord>,
 }


### PR DESCRIPTION
Part of #104.

`SponsorInfo.sponsor` is typed `String` and named `sponsor`, so it reads as a person's name. It holds a bioguide id. `load_bill_download` takes it from the API's `bioguideId`, and the real dataset stores it that way:

```
119-hr-1     {"sponsor":"A000375","cosponsors":[]}
119-hr-618   {"sponsor":"H001066","cosponsors":[3 records]}
```

I misread the field during triage of #104 and told the maintainer a break was needed to make a sponsor joinable to a member. It already is. This comment records that, so the next reader does not repeat the mistake.

**No rename.** The field name is part of the key stored in a W2D file, so renaming it is a break, and a break for readability alone is not worth a rebuild. Decided with the maintainer.

`cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both exit 0. Comment only; no behaviour changes, so no test changes.