### PR TITLE
feat: extract U.S.C. citations and link an opinion to a provision (#52)

### DIFF
--- a/src/citation/mod.rs
+++ b/src/citation/mod.rs
@@ -1,0 +1,145 @@
+//! Citations found in the text of an opinion, and the links they become.
+//!
+//! An opinion citing a statute is the link this project exists to record, and
+//! nobody publishes it. CourtListener finds a statute citation with eyecite,
+//! fails to resolve it, and throws it away: the resolver routes a
+//! `FullLawCitation` to `NO_MATCH_RESOURCE`, the citation graph is opinion-to-
+//! opinion and cannot hold a statute, and the only trace left is display markup
+//! with no identifier, `<span class="citation no-link">21 U.S.C. § 846</span>`.
+//! The evidence is in `docs/research/courtlistener-formats.md`, section 8.
+//!
+//! So the extractor is ours. [`usc`] reads the citations; [`resolve`] says what
+//! this dataset can point at; [`cites_links`] turns the pair into links.
+//!
+//! # What a citation resolves to
+//!
+//! A structural path, and no more. A provision has no identity of its own in the
+//! model yet (#93), so a link names where a provision sits rather than what it
+//! is (`docs/adr/0001-structural-paths-locate-not-identify.md`). Every link made
+//! here moves when identity arrives, which is why the citation text travels with
+//! it as evidence.
+//!
+//! # What is in scope
+//!
+//! The U.S. Code, and nothing else. `laws.json` holds 371 keys; the rest arrive
+//! with the corpus that needs them. `Pub. L.`, `Stat.` and `C.F.R.` are named in
+//! #52 as out of scope, along with the two eyecite defects that belong to them.
+
+pub mod resolve;
+pub mod usc;
+
+use serde_json::json;
+
+use crate::link::{Evidence, Link, LinkKind, Provenance, Target, VerificationState};
+use resolve::{CitedSection, Resolution};
+use usc::UscCitation;
+
+/// The opinion a citation was read out of.
+///
+/// An opinion is not a work in the core model yet, so it is named as something
+/// outside the core, in the namespace of the link that mentions it. That is the
+/// same shape `link::amendment_reference` uses for an amendment, which is also
+/// not core.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Opinion {
+    /// How this opinion is identified where it came from, such as a
+    /// CourtListener opinion id.
+    pub id: String,
+    /// What to call it on a page: `Obergefell v. Hodges, 576 U.S. 644 (2015)`.
+    pub display: String,
+}
+
+impl Opinion {
+    pub fn new(id: impl Into<String>, display: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            display: display.into(),
+        }
+    }
+
+    /// How an opinion is named as a link target: `judicial.opinion:11103682`.
+    pub fn reference(&self) -> String {
+        format!("judicial.opinion:{}", self.id)
+    }
+
+    fn target(&self) -> Target {
+        Target::External {
+            reference: self.reference(),
+            display: self.display.clone(),
+        }
+    }
+}
+
+/// A link for every provision a citation resolved to, saying the opinion cites
+/// it.
+///
+/// A section that did not resolve makes no link. A link is a statement that can
+/// be checked, and a path the dataset does not hold cannot be checked by the
+/// party reading it; the [`Resolution`] still carries "out of scope" for a
+/// caller to report, which is the answer a researcher needs and is never "not
+/// found".
+///
+/// The state is always [`VerificationState::MachineSuggested`]: a rule matched
+/// some text, and no person has looked at it.
+pub fn cites_links(opinion: &Opinion, citation: &UscCitation, cited: &[CitedSection]) -> Vec<Link> {
+    cited
+        .iter()
+        .flat_map(|section| {
+            let paths = match &section.resolution {
+                Resolution::Provision { paths } => paths.as_slice(),
+                _ => &[],
+            };
+            paths
+                .iter()
+                .map(|path| cites_link(opinion, citation, section, path))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+/// One link: this opinion cites the provision at this path.
+fn cites_link(
+    opinion: &Opinion,
+    citation: &UscCitation,
+    section: &CitedSection,
+    path: &str,
+) -> Link {
+    let kind = LinkKind::new(LinkKind::CITES);
+    let provenance = Provenance {
+        source: "rule:usc_citation".to_string(),
+        method: Some("reporters-db laws.json U.S.C. patterns".to_string()),
+        verification: VerificationState::MachineSuggested,
+        // The matched text, so a reviewer can read what the rule read. A rule
+        // has no reasoning beyond the text that satisfied it.
+        evidence: Some(Evidence {
+            reasoning: Some(citation.text.clone()),
+            ..Evidence::default()
+        }),
+        raw_score: None,
+        // No clock reading. Nothing about this statement depends on when the
+        // rule ran, and the same text gives the same answer on any day.
+        timestamp: None,
+        corroboration: None,
+    };
+
+    Link {
+        subject: opinion.target(),
+        // The namespace is read from the kind rather than written again, so the
+        // two cannot drift apart.
+        payload: Some(crate::link::KindPayload {
+            namespace: kind.namespace().to_string(),
+            value: json!({
+                "title": citation.title,
+                // As the opinion wrote it, brackets and all. The path stops at
+                // the section, so this is the only record that the opinion named
+                // a subsection.
+                "section": section.section,
+                "uslm_id": section.uslm_id,
+                "start": citation.start,
+            }),
+        }),
+        kind,
+        object: Target::Provision(path.to_string()),
+        provenance,
+    }
+}

--- a/src/citation/resolve.rs
+++ b/src/citation/resolve.rs
@@ -1,0 +1,141 @@
+//! What a citation can point at in this dataset.
+//!
+//! Two questions, in this order.
+//!
+//! Does the dataset carry the title at all? If it does not, the answer is
+//! [`Resolution::OutOfScope`]. A dataset holding title 26 knows nothing about
+//! title 42, and reporting "not found" would tell a researcher that no such
+//! authority exists (`src/dataset/scope.rs`).
+//!
+//! If it does carry the title, where is the section? A structural path is the
+//! answer, because a provision has no identity of its own yet
+//! (`docs/adr/0001-structural-paths-locate-not-identify.md`). A citation gives a
+//! title and a section number, and a structural path also carries the chapters
+//! and parts between them — `uscode/title_26/subtitle_A/chapter_1/subchapter_B/
+//! part_VI/section_174` — so the path cannot be built from the citation alone.
+//! [`SectionPaths`] is the index that closes the gap, built from the works the
+//! caller already has in hand.
+//!
+//! Reading the index from a parsed work, rather than from storage, keeps this
+//! module out of the way of the storage trait: a caller that has a dataset, a
+//! file, or one title in memory can all resolve the same way.
+
+use std::collections::BTreeMap;
+
+use crate::dataset::{Coverage, Scope};
+use crate::uslm::{ElementType, USLMElement};
+
+use super::usc::UscCitation;
+
+/// Where the sections of a dataset are, by USLM identifier.
+///
+/// The identifier `/us/usc/t26/s174` is what a citation can be turned into
+/// without reading anything; the structural path is what the model uses. This
+/// maps the first to the second.
+#[derive(Debug, Clone, Default)]
+pub struct SectionPaths {
+    paths: BTreeMap<String, Vec<String>>,
+}
+
+impl SectionPaths {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Index every section of one parsed work, such as a title of the U.S. Code.
+    ///
+    /// Call it once per work held. Indexing the same work twice would report its
+    /// sections twice.
+    pub fn add_work(&mut self, work: &USLMElement) {
+        if work.data.element_type == ElementType::Section
+            && let Some(uslm_id) = &work.data.uslm_id
+        {
+            self.paths
+                .entry(uslm_id.to_string())
+                .or_default()
+                .push(work.data.path.to_string());
+        }
+        for child in &work.children {
+            self.add_work(child);
+        }
+    }
+
+    /// Every path a USLM identifier names, in document order.
+    ///
+    /// More than one is possible: the law sometimes numbers two provisions
+    /// alike, and the document records both, so reporting only the first would
+    /// be a silent loss (`USLMElement::find_all`).
+    pub fn paths_of(&self, uslm_id: &str) -> &[String] {
+        self.paths.get(uslm_id).map_or(&[], Vec::as_slice)
+    }
+
+    /// How many identifiers are indexed.
+    pub fn len(&self) -> usize {
+        self.paths.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+}
+
+/// What one cited section came to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// The dataset holds the title, and these paths locate the section in it.
+    Provision { paths: Vec<String> },
+    /// The dataset holds the title, and it has no section with this number.
+    ///
+    /// A statement about the law as this dataset records it, not about our
+    /// coverage. A citation to a repealed or misprinted section lands here.
+    Absent,
+    /// The dataset does not carry this title, so it can say nothing about the
+    /// section. This is the answer to give, never "not found".
+    OutOfScope,
+    /// The dataset said it would carry this title and does not: a fault in the
+    /// build rather than a statement about the law.
+    Gap,
+}
+
+/// One section a citation named, and what it came to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CitedSection {
+    /// As the citation wrote it: `981(a)(l)(C)`.
+    pub section: String,
+    /// The section it names: `/us/usc/t18/s981`. A subsection is dropped here,
+    /// because the citation cannot be trusted at that depth
+    /// ([`UscCitation::uslm_id`]).
+    pub uslm_id: String,
+    pub resolution: Resolution,
+}
+
+/// Resolve every section a citation names.
+///
+/// One entry per section, in the order the citation wrote them, so a caller can
+/// report the whole citation rather than the part of it that resolved.
+pub fn resolve(citation: &UscCitation, scope: &Scope, paths: &SectionPaths) -> Vec<CitedSection> {
+    let coverage = scope.covers(citation.work().as_str());
+
+    citation
+        .sections
+        .iter()
+        .map(|section| {
+            let uslm_id = citation.uslm_id(section);
+            let resolution = match coverage {
+                Coverage::OutOfScope => Resolution::OutOfScope,
+                Coverage::Gap => Resolution::Gap,
+                Coverage::InScope => match paths.paths_of(&uslm_id) {
+                    [] => Resolution::Absent,
+                    found => Resolution::Provision {
+                        paths: found.to_vec(),
+                    },
+                },
+            };
+            CitedSection {
+                section: section.clone(),
+                uslm_id,
+                resolution,
+            }
+        })
+        .collect()
+}

--- a/src/citation/usc.rs
+++ b/src/citation/usc.rs
@@ -1,0 +1,257 @@
+//! Reading U.S. Code citations out of text.
+//!
+//! # Where the patterns come from
+//!
+//! The patterns below are the `U.S.C.` entry of `reporters_db/data/laws.json`
+//! and the `law.section` and `section_marker` templates of
+//! `reporters_db/data/regexes.json`, from Free Law Project's `reporters-db`:
+//!
+//! > BSD 2-Clause License. Copyright (c) 2020, Free Law Project.
+//! > <https://github.com/freelawproject/reporters-db>
+//!
+//! They are copied in rather than fetched, so a build needs no network and a
+//! reader of this file can see exactly what is matched. One change was needed to
+//! compile them with the Rust `regex` crate: Python writes a bounded repeat with
+//! an open lower bound, `{,3}`, and Rust requires `{0,3}`. Nothing else differs.
+//!
+//! # Two limits this shares with eyecite
+//!
+//! Both follow from the vendored patterns, and both fail by finding nothing
+//! rather than by naming the wrong provision.
+//!
+//! A citation with no section marker, `16 U.S.C. 1533`, is not matched: the
+//! pattern requires a `§` or a `Section`. The U.S. Code's own notes are written
+//! that way, so this is worth fixing, with its own fixtures.
+//!
+//! A section number that ends in a letter, `21 U.S.C. § 355a`, is not matched
+//! either, because `law.section` allows no letters outside brackets. Reporting
+//! section 355 instead would be worse than reporting nothing: it names a
+//! different provision.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::dataset::WorkId;
+
+/// How the reporter is spelled: the `U.S.C.` key of `laws.json`, then its seven
+/// `variations`, verbatim.
+///
+/// Longest first, so `U.S.C.A.` is preferred over `U.S.C.` followed by a stray
+/// `A.`; the alternation takes the first spelling that lets the whole citation
+/// match.
+const REPORTERS: [&str; 8] = [
+    "United States Code",
+    "U.S.C.A.",
+    "U.S.C.S.",
+    "U.S.C.U.",
+    "U.S. Code",
+    "U. S. C.",
+    "U.S.C.",
+    "USC",
+];
+
+/// `section_marker` from `regexes.json`, verbatim: `§`, `§§`, `Section`,
+/// `Sections`, `sec.`, `S.`, and the rest of that family.
+const SECTION_MARKER: &str = r"((§§?)|([Ss]((ec)(tion)?)?s?\.?))";
+
+/// `law.section` from `regexes.json`, with its group name removed so it can be
+/// used more than once in one pattern: a section number such as `1-2-3`, `1.2.3`
+/// or `981(a)(l)(C)`.
+///
+/// Two changes from the published pattern.
+///
+/// `{,3}` is written `{0,3}`, because Python accepts an open lower bound and
+/// Rust does not. That is mechanical.
+///
+/// The two alternatives are the other way round, so a section with a subsection
+/// is read whole. In the published order the plain-number branch is preferred
+/// and `981(a)(l)(C)` stops at `981`; eyecite reads the published example that
+/// way, and CourtListener's own markup shows the cost — in opinion 11103682 the
+/// `(g)(1)` of `18 U.S.C. § 922(g)(1)` falls outside the citation span
+/// (`docs/research/courtlistener-formats.md`, section 8.3). What the opinion
+/// named is what we keep.
+const LAW_SECTION: &str = r"(?:\d+(?:\((?:[a-zA-Z]{1}|\d{1,2})\))+)|(?:\d+(?:[\-.:]\d+){0,3})";
+
+/// The `U.S.C.` regex of `laws.json`:
+/// `(?P<title>\d+),?\s+$reporter,?\s+$section_marker\s*$law_section`.
+///
+/// `\b` in front keeps the title from starting inside a longer word.
+static CITATION: LazyLock<Regex> = LazyLock::new(|| {
+    let reporters = reporters_pattern();
+    Regex::new(&format!(
+        r"\b(?P<title>\d+),?\s+(?P<reporter>{reporters}),?\s+{SECTION_MARKER}\s*(?P<section>{LAW_SECTION})"
+    ))
+    .expect("the vendored U.S.C. pattern must compile")
+});
+
+/// A further section of the same citation: `, 1988` or ` and 1477`.
+///
+/// Anchored, because it is matched against the text that follows a citation and
+/// a match anywhere later would belong to something else.
+static FURTHER_SECTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(&format!(
+        r"^(?:\s*,\s*|\s+and\s+)(?P<section>{LAW_SECTION})"
+    ))
+    .expect("the further-section pattern must compile")
+});
+
+/// The start of another citation: a number we have just read turns out to be the
+/// title of the next one.
+static ANOTHER_CITATION: LazyLock<Regex> = LazyLock::new(|| {
+    let reporters = reporters_pattern();
+    Regex::new(&format!(r"^,?\s+(?:{reporters})"))
+        .expect("the further-citation pattern must compile")
+});
+
+/// Every spelling of the reporter, as one alternation.
+///
+/// Each spelling is escaped, and any run of whitespace may stand where it has a
+/// space: opinions wrap lines and scanned text widens spacing, so a single
+/// literal space would miss `United\nStates Code`.
+fn reporters_pattern() -> String {
+    REPORTERS
+        .iter()
+        .map(|spelling| {
+            spelling
+                .split(' ')
+                .map(regex::escape)
+                .collect::<Vec<_>>()
+                .join(r"\s+")
+        })
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+/// A citation to the U.S. Code, as one piece of text wrote it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UscCitation {
+    /// The title: `26` in `26 U.S.C. § 174`.
+    pub title: String,
+    /// Every section the citation names, in the order written.
+    ///
+    /// `42 U.S.C. §§ 1983, 1988` names two. One citation naming two provisions
+    /// is two links, so keeping only the first would lose a link.
+    ///
+    /// Each is written as the text wrote it, brackets and all: `981(a)(l)(C)`.
+    pub sections: Vec<String>,
+    /// The text matched, verbatim.
+    ///
+    /// This is the evidence a reviewer checks a link against, so it is never
+    /// tidied up.
+    pub text: String,
+    /// Where `text` starts in the text it was found in, in bytes.
+    pub start: usize,
+}
+
+impl UscCitation {
+    /// Where `text` ends, in bytes.
+    pub fn end(&self) -> usize {
+        self.start + self.text.len()
+    }
+
+    /// The work this citation is into: `uscode/title_26`.
+    ///
+    /// The same shape storage keys a title under, so a caller can ask the
+    /// dataset whether it holds the title at all.
+    pub fn work(&self) -> WorkId {
+        WorkId::new(format!("uscode/title_{}", self.title))
+    }
+
+    /// The USLM identifier of one cited section: `/us/usc/t26/s174`.
+    ///
+    /// A subsection the citation names is deliberately dropped, so
+    /// `981(a)(l)(C)` resolves to section 981. The published example shows why:
+    /// its `(l)` is a lower-case L where the provision has a paragraph `(1)`.
+    /// Text that cannot be trusted at that depth must not be resolved at that
+    /// depth.
+    pub fn uslm_id(&self, section: &str) -> String {
+        format!("/us/usc/t{}/s{}", self.title, section_number(section))
+    }
+}
+
+/// The number of the section itself, without any subsection: `981` for
+/// `981(a)(l)(C)`.
+pub fn section_number(section: &str) -> &str {
+    section
+        .split_once('(')
+        .map_or(section, |(number, _)| number)
+}
+
+/// Every U.S. Code citation in a piece of text, in the order they appear.
+///
+/// ```
+/// use words_to_data::citation::usc;
+///
+/// let found = usc::find("See 26 U.S.C. § 174 (2018), and 42 U.S.C. §§ 1983, 1988.");
+///
+/// assert_eq!(found.len(), 2);
+/// assert_eq!(found[0].sections, ["174"]);
+/// // The second section of a list is kept, which is where eyecite loses one.
+/// assert_eq!(found[1].sections, ["1983", "1988"]);
+/// ```
+pub fn find(text: &str) -> Vec<UscCitation> {
+    let mut found = Vec::new();
+
+    for capture in CITATION.captures_iter(text) {
+        let whole = capture.get(0).expect("a match always has a whole");
+        let first = capture
+            .name("section")
+            .expect("the pattern names a section")
+            .as_str();
+        if !ends_cleanly(text, whole.end()) {
+            // The section number runs on into letters, as in `§ 355a`. What we
+            // matched is a different provision from the one cited.
+            continue;
+        }
+
+        let mut sections = vec![first.to_string()];
+        let mut end = whole.end();
+        while let Some((start, stop)) = further_section(text, end) {
+            sections.push(text[start..stop].to_string());
+            end = stop;
+        }
+
+        found.push(UscCitation {
+            title: capture
+                .name("title")
+                .expect("the pattern names a title")
+                .as_str()
+                .to_string(),
+            sections,
+            text: text[whole.start()..end].to_string(),
+            start: whole.start(),
+        });
+    }
+
+    found
+}
+
+/// Where the next section of the citation that ends at `end` sits, if the text
+/// carries on with one.
+///
+/// A list continues while each item is a section number and nothing more. A
+/// number followed by a reporter is the title of the next citation, not a
+/// further section of this one: in `26 U.S.C. § 174, 42 U.S.C. § 1983` the `42`
+/// belongs to the second citation.
+fn further_section(text: &str, end: usize) -> Option<(usize, usize)> {
+    let rest = &text[end..];
+    let section = FURTHER_SECTION.captures(rest)?.name("section")?;
+    let (start, stop) = (end + section.start(), end + section.end());
+
+    if ANOTHER_CITATION.is_match(&text[stop..]) || !ends_cleanly(text, stop) {
+        return None;
+    }
+    Some((start, stop))
+}
+
+/// Whether a citation that ends here ends at the end of its section number.
+///
+/// A letter or a digit straight after it means the number was cut short, and a
+/// section number cut short names the wrong provision.
+fn ends_cleanly(text: &str, end: usize) -> bool {
+    !text[end..]
+        .chars()
+        .next()
+        .is_some_and(|next| next.is_alphanumeric())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 // Library exports for testing and external use
 
 pub mod annotation;
+pub mod citation;
 pub mod compact;
 pub mod congress;
 pub mod constants;

--- a/tests/usc_citation_link_tests.rs
+++ b/tests/usc_citation_link_tests.rs
@@ -1,0 +1,244 @@
+//! An opinion citing the U.S. Code becomes a link (#52).
+//!
+//! The dataset under test is the real U.S. Code: title 26 and title 1 of the
+//! 2025-07-30 release point, from `tests/test_data/usc`. Every path asserted
+//! below is a path that release point actually publishes.
+//!
+//! What a citation resolves to is a structural path, because the model has no
+//! provision identity yet (#93,
+//! `docs/adr/0001-structural-paths-locate-not-identify.md`). Where the dataset
+//! does not carry the title, the answer is "out of scope" and never "not found".
+
+use words_to_data::citation::resolve::{Resolution, SectionPaths, resolve};
+use words_to_data::citation::{Opinion, cites_links, usc};
+use words_to_data::dataset::{Dataset, DatasetMetadata, ExpressionId, WorkId};
+use words_to_data::link::{LinkKind, Target, VerificationState};
+use words_to_data::storage::{InMemoryStorage, LinkReader};
+
+const RELEASE: &str = "2025-07-30";
+const TITLE_1: &str = "tests/test_data/usc/2025-07-30/usc01.xml";
+const TITLE_26: &str = "tests/test_data/usc/2025-07-30/usc26.xml";
+
+/// Section 174 as the 2025-07-30 release point publishes it.
+const SECTION_174: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174";
+
+/// A dataset holding the titles named, and an index of where their sections are.
+fn dataset_holding(titles: &[(&str, &str)]) -> (Dataset<InMemoryStorage>, SectionPaths) {
+    let mut dataset = Dataset::new(DatasetMetadata {
+        name: "U.S.C. citation fixture".to_string(),
+        ..Default::default()
+    });
+    let mut paths = SectionPaths::new();
+
+    for (file, work) in titles {
+        dataset
+            .add_uslm_xml(file, RELEASE, None)
+            .unwrap_or_else(|error| panic!("{file} should parse: {error}"));
+        let id = ExpressionId::new(WorkId::new(*work), RELEASE);
+        let expression = dataset
+            .get_expression(&id)
+            .expect("storage should answer")
+            .unwrap_or_else(|| panic!("{work} should be held"));
+        paths.add_work(&expression.element);
+    }
+
+    (dataset, paths)
+}
+
+fn obergefell() -> Opinion {
+    Opinion::new("2812209", "Obergefell v. Hodges, 576 U.S. 644 (2015)")
+}
+
+#[test]
+fn should_link_the_opinion_to_the_provision_when_the_dataset_holds_the_title() {
+    let (dataset, paths) = dataset_holding(&[(TITLE_26, "uscode/title_26")]);
+    let scope = dataset.scope().expect("scope should derive");
+
+    let found = usc::find("Research costs are amortized under 26 U.S.C. § 174 (2018).");
+    let citation = found.first().expect("one citation");
+    let cited = resolve(citation, &scope, &paths);
+
+    assert_eq!(
+        cited[0].uslm_id, "/us/usc/t26/s174",
+        "a citation names a title and a section, which is a USLM identifier"
+    );
+    assert_eq!(
+        cited[0].resolution,
+        Resolution::Provision {
+            paths: vec![SECTION_174.to_string()]
+        },
+        "the dataset holds title 26, so the citation resolves to where \
+         section 174 sits in it"
+    );
+
+    let links = cites_links(&obergefell(), citation, &cited);
+
+    assert_eq!(links.len(), 1);
+    let link = &links[0];
+    assert_eq!(link.kind, LinkKind::new(LinkKind::CITES));
+    assert_eq!(link.object, Target::Provision(SECTION_174.to_string()));
+    assert_eq!(
+        link.subject,
+        Target::External {
+            reference: "judicial.opinion:2812209".to_string(),
+            display: "Obergefell v. Hodges, 576 U.S. 644 (2015)".to_string(),
+        },
+        "an opinion is not a work in the core model yet, so it is named \
+         in the namespace of the link that mentions it"
+    );
+    assert_eq!(
+        link.provenance.verification,
+        VerificationState::MachineSuggested,
+        "a rule matched some text and no person has looked at it"
+    );
+    assert_eq!(
+        link.provenance
+            .evidence
+            .as_ref()
+            .and_then(|evidence| evidence.reasoning.as_deref()),
+        Some("26 U.S.C. § 174"),
+        "the matched text is the evidence, so a reviewer can read what the \
+         rule read"
+    );
+    assert_eq!(
+        link.payload
+            .as_ref()
+            .map(|payload| payload.namespace.as_str()),
+        Some("judicial"),
+        "the payload belongs to the extension that defines the kind"
+    );
+}
+
+#[test]
+fn should_keep_the_subsection_in_the_payload_when_the_citation_names_one() {
+    let (dataset, paths) = dataset_holding(&[(TITLE_26, "uscode/title_26")]);
+    let scope = dataset.scope().expect("scope should derive");
+
+    let found = usc::find("the election under 26 U.S.C. § 174(a)");
+    let citation = found.first().expect("one citation");
+    assert_eq!(
+        citation.sections,
+        ["174(a)"],
+        "read whole, brackets and all"
+    );
+
+    let cited = resolve(citation, &scope, &paths);
+    let links = cites_links(&obergefell(), citation, &cited);
+
+    // The path stops at the section. A citation's own subsection cannot be
+    // trusted at that depth -- the published example `981(a)(l)(C)` has a
+    // lower-case L where the provision has a paragraph (1) -- so the subsection
+    // is recorded as written instead of resolved.
+    assert_eq!(links[0].object, Target::Provision(SECTION_174.to_string()));
+    assert_eq!(
+        links[0].payload.as_ref().expect("a payload").value["section"],
+        "174(a)"
+    );
+}
+
+#[test]
+fn should_link_every_section_when_one_citation_names_a_list_of_them() {
+    // Title 1 has both a section 1 and a section 2, so both halves of the list
+    // resolve. This is the eyecite defect that #52 names: it keeps the first
+    // section of a list and loses the rest, which loses a link.
+    let (dataset, paths) = dataset_holding(&[(TITLE_1, "uscode/title_1")]);
+    let scope = dataset.scope().expect("scope should derive");
+
+    let found = usc::find("See 1 U.S.C. §§ 1, 2.");
+    let citation = found.first().expect("one citation");
+    let cited = resolve(citation, &scope, &paths);
+
+    assert_eq!(cited.len(), 2, "one citation, two provisions");
+    let links = cites_links(&obergefell(), citation, &cited);
+    let objects: Vec<&Target> = links.iter().map(|link| &link.object).collect();
+    assert_eq!(
+        objects,
+        vec![
+            &Target::Provision("uscode/title_1/chapter_1/section_1".to_string()),
+            &Target::Provision("uscode/title_1/chapter_1/section_2".to_string()),
+        ],
+        "each provision is its own statement, so each is its own link"
+    );
+    for link in &links {
+        assert_eq!(
+            link.provenance
+                .evidence
+                .as_ref()
+                .and_then(|evidence| evidence.reasoning.as_deref()),
+            Some("1 U.S.C. §§ 1, 2"),
+            "the evidence is the whole citation, because the whole citation is \
+             what was read"
+        );
+    }
+}
+
+#[test]
+fn should_say_out_of_scope_when_the_dataset_does_not_carry_the_title() {
+    let (dataset, paths) = dataset_holding(&[(TITLE_1, "uscode/title_1")]);
+    let scope = dataset.scope().expect("scope should derive");
+
+    let found = usc::find("brought under 42 U.S.C. §§ 1983, 1988");
+    let citation = found.first().expect("one citation");
+    let cited = resolve(citation, &scope, &paths);
+
+    // A dataset holding title 1 knows nothing about title 42. Reporting "not
+    // found" would tell a reader that no such authority exists.
+    assert_eq!(cited.len(), 2);
+    for section in &cited {
+        assert_eq!(section.resolution, Resolution::OutOfScope, "{section:?}");
+    }
+    assert!(
+        cites_links(&obergefell(), citation, &cited).is_empty(),
+        "a link into material the dataset does not hold could not be checked \
+         by the party reading it"
+    );
+}
+
+#[test]
+fn should_say_absent_when_the_dataset_holds_the_title_and_it_has_no_such_section() {
+    let (dataset, paths) = dataset_holding(&[(TITLE_1, "uscode/title_1")]);
+    let scope = dataset.scope().expect("scope should derive");
+
+    // `1 U.S.C.U. §§ 1-2` is one of the published examples. The hyphenated form
+    // stays as it is written, because whether it means one section numbered
+    // `1-2` or sections 1 through 2 cannot be decided from the text: the code
+    // does have sections such as `300gg-11`. Title 1 has no section `1-2`, and
+    // saying so is an answer about the law, not about our coverage.
+    let found = usc::find("1 U.S.C.U. §§ 1-2");
+    let citation = found.first().expect("one citation");
+    let cited = resolve(citation, &scope, &paths);
+
+    assert_eq!(cited[0].section, "1-2");
+    assert_eq!(cited[0].uslm_id, "/us/usc/t1/s1-2");
+    assert_eq!(cited[0].resolution, Resolution::Absent);
+    assert!(cites_links(&obergefell(), citation, &cited).is_empty());
+}
+
+#[test]
+fn should_carry_a_citation_link_through_storage_when_the_dataset_is_saved() {
+    let (mut dataset, paths) = dataset_holding(&[(TITLE_1, "uscode/title_1")]);
+    let scope = dataset.scope().expect("scope should derive");
+
+    let found = usc::find("under 1 U.S.C. § 1");
+    let citation = found.first().expect("one citation");
+    let cited = resolve(citation, &scope, &paths);
+    for link in cites_links(&obergefell(), citation, &cited) {
+        dataset.add_link(link).expect("a link should store");
+    }
+
+    let stored = dataset
+        .links_by_kind(LinkKind::CITES)
+        .expect("links should read back");
+
+    // A link nobody can read back is not a link. The core carries a kind it
+    // does not act on (docs/adr/0002-links-live-in-the-core.md).
+    assert_eq!(stored.len(), 1);
+    assert_eq!(
+        stored[0].object,
+        Target::Provision("uscode/title_1/chapter_1/section_1".to_string())
+    );
+    assert_eq!(
+        stored[0].provenance.verification,
+        VerificationState::MachineSuggested
+    );
+}

--- a/tests/usc_citation_tests.rs
+++ b/tests/usc_citation_tests.rs
@@ -1,0 +1,202 @@
+//! Reading U.S. Code citations out of text (#52).
+//!
+//! The fixtures are the `examples` array of the `U.S.C.` entry of
+//! `reporters_db/data/laws.json` (BSD-2-Clause, Free Law Project). They are
+//! published test data, so they are used exactly as they are written there,
+//! awkward forms and all: `1 U.S.C.U. §§ 1-2`, `1 USC S. 1-2`,
+//! `21, United States Code, Section 853`.
+//!
+//! The prose fixtures are the Federal Rules of Bankruptcy Procedure, in
+//! `tests/test_data/usc/2025-07-30/usc11a.xml`. They are real published
+//! judicial-style prose that cites the U.S. Code many hundreds of times.
+
+use words_to_data::citation::usc;
+
+/// The `examples` array of the `U.S.C.` entry of `laws.json`, verbatim, with the
+/// title and the sections each one names.
+///
+/// A hyphenated form such as `1-2` stays as it is written. Whether it means one
+/// section numbered `1-2` or sections 1 through 2 cannot be decided from the
+/// text alone, and the U.S. Code does have sections such as `300gg-11`.
+const LAWS_JSON_EXAMPLES: [(&str, &str, &[&str]); 11] = [
+    ("1 U.S.C. § 1", "1", &["1"]),
+    ("1 U.S.C.A. § 1", "1", &["1"]),
+    ("1 U.S.C.S. § 1", "1", &["1"]),
+    ("1 U.S.C.U. §§ 1-2", "1", &["1-2"]),
+    ("1 U.S.C. sec. 1", "1", &["1"]),
+    ("1 U.S.C. Sections 1-2", "1", &["1-2"]),
+    ("1 USC S. 1-2", "1", &["1-2"]),
+    ("1 U.S. Code §1", "1", &["1"]),
+    ("21, United States Code, Section 853", "21", &["853"]),
+    ("18, United States Code, Section 3500", "18", &["3500"]),
+    (
+        "18, United States Code, Section 981(a)(l)(C)",
+        "18",
+        &["981(a)(l)(C)"],
+    ),
+];
+
+#[test]
+fn should_read_the_title_and_the_section_when_the_text_is_a_plain_citation() {
+    let found = usc::find("See 26 U.S.C. § 174 (2018).");
+
+    assert_eq!(found.len(), 1, "one citation, got {found:?}");
+    assert_eq!(found[0].title, "26");
+    assert_eq!(found[0].sections, ["174"]);
+    assert_eq!(
+        found[0].text, "26 U.S.C. § 174",
+        "the matched text is the evidence for the link, so it is kept verbatim"
+    );
+}
+
+#[test]
+fn should_cover_every_published_example_when_the_examples_come_from_laws_json() {
+    let mut missed = Vec::new();
+
+    for (example, title, sections) in LAWS_JSON_EXAMPLES {
+        let found = usc::find(example);
+        let matched = found.first().map(|citation| {
+            (
+                citation.title.as_str(),
+                citation.sections.iter().map(String::as_str).collect(),
+                citation.text.as_str(),
+            )
+        });
+        if matched != Some((title, sections.to_vec(), example)) {
+            missed.push(format!("{example:?} -> {found:?}"));
+        }
+    }
+
+    assert!(
+        missed.is_empty(),
+        "every published example must be read whole:\n{}",
+        missed.join("\n")
+    );
+}
+
+#[test]
+fn should_read_both_sections_when_a_citation_names_a_list_of_them() {
+    // eyecite reads this as one citation to section 1983 and loses 1988
+    // (docs/research/courtlistener-formats.md, section 8.1). A lost section is
+    // a lost link.
+    let found = usc::find("under 42 U.S.C. §§ 1983, 1988");
+
+    assert_eq!(found.len(), 1, "one citation, not two, got {found:?}");
+    assert_eq!(found[0].title, "42");
+    assert_eq!(found[0].sections, ["1983", "1988"]);
+    assert_eq!(
+        found[0].text, "42 U.S.C. §§ 1983, 1988",
+        "the evidence covers the whole list, because the whole list is the citation"
+    );
+}
+
+#[test]
+fn should_stop_the_list_when_the_next_number_is_the_title_of_another_citation() {
+    // The comma here separates two citations. Reading 42 as a further section of
+    // title 26 would invent a provision and lose a real one.
+    let found = usc::find("26 U.S.C. § 174, 42 U.S.C. § 1983");
+
+    assert_eq!(found.len(), 2, "two citations, got {found:?}");
+    assert_eq!(found[0].sections, ["174"]);
+    assert_eq!(found[1].title, "42");
+    assert_eq!(found[1].sections, ["1983"]);
+}
+
+#[test]
+fn should_read_every_section_when_real_prose_lists_three_of_them() {
+    // From the Federal Rules of Bankruptcy Procedure, in usc11a.xml.
+    let found = usc::find("11 U.S.C. §§ 727(a)(11), 1328(g)(2), 1141(d)(3)(C). ");
+
+    assert_eq!(found.len(), 1);
+    assert_eq!(
+        found[0].sections,
+        ["727(a)(11)", "1328(g)(2)", "1141(d)(3)(C)"]
+    );
+}
+
+#[test]
+fn should_read_both_sections_when_real_prose_joins_them_with_and() {
+    // Also from usc11a.xml. `and` joins a list as often as a comma does.
+    let found = usc::find("28 U.S.C. §§ 1475 and 1477 and clarifies the procedure");
+
+    assert_eq!(found.len(), 1, "got {found:?}");
+    assert_eq!(found[0].sections, ["1475", "1477"]);
+}
+
+#[test]
+fn should_find_every_citation_in_real_prose_except_a_section_ending_in_a_letter() {
+    // Real prose rather than a hand-written string: the notes of the Federal
+    // Rules of Bankruptcy Procedure cite the U.S. Code throughout.
+    let rules = std::fs::read_to_string("tests/test_data/usc/2025-07-30/usc11a.xml")
+        .expect("the bankruptcy rules should be in tests/test_data");
+
+    let found = usc::find(&rules);
+
+    assert!(
+        found.len() > 190,
+        "the rules cite the code throughout, got {}",
+        found.len()
+    );
+    // `28 U.S.C. § 1334` from the notes to Rule 9001. The document sets the
+    // space after the section mark as U+202F, a narrow no-break space, so the
+    // text is compared by what it says rather than by byte.
+    assert!(
+        found
+            .iter()
+            .any(|citation| citation.title == "28" && citation.sections == ["1334"]),
+        "`28 U.S.C. § 1334` is in the notes to Rule 9001"
+    );
+
+    // Every mention in the document must be accounted for. The one kind that is
+    // allowed to be missed is a section number ending in a letter, such as
+    // `15 U.S.C. § 78aaa`: the published `law.section` pattern has no room for
+    // it, and naming section 78 instead would name a different provision.
+    let mention =
+        regex::Regex::new(r"\d+ U\.S\.C\. §\s*(?P<section>[0-9A-Za-z\-.:]+)").expect("a pattern");
+    let mut mentions = 0;
+    for hit in mention.captures_iter(&rules) {
+        mentions += 1;
+        let at = hit.get(0).expect("a whole match").start();
+        if found
+            .iter()
+            .any(|citation| citation.start <= at && citation.end() > at)
+        {
+            continue;
+        }
+        let section = hit.name("section").expect("a section").as_str();
+        assert!(
+            section.ends_with(|last: char| last.is_ascii_alphabetic()),
+            "citation at {at} was missed and its section {section:?} does not end in a letter"
+        );
+    }
+    assert!(mentions > 190, "the document should be full of mentions");
+
+    // Every citation must name a title and at least one section, or it is not a
+    // citation and must not have been reported as one.
+    for citation in &found {
+        assert!(!citation.title.is_empty(), "no title in {citation:?}");
+        assert!(!citation.sections.is_empty(), "no section in {citation:?}");
+        assert_eq!(
+            &rules[citation.start..citation.end()],
+            citation.text,
+            "the recorded span must be where the text was found"
+        );
+    }
+}
+
+#[test]
+fn should_name_the_section_and_drop_the_subsection_when_asked_for_an_identifier() {
+    let found = usc::find("18, United States Code, Section 981(a)(l)(C)");
+    let citation = found.first().expect("one citation");
+
+    assert_eq!(citation.work().as_str(), "uscode/title_18");
+    // The `(l)` in the published example is a lower-case L where the provision
+    // has a paragraph (1). Text that cannot be trusted at that depth must not be
+    // resolved at that depth, so the identifier names the section.
+    assert_eq!(citation.uslm_id("981(a)(l)(C)"), "/us/usc/t18/s981");
+}
+
+#[test]
+fn should_find_nothing_when_the_text_has_no_citation() {
+    assert!(usc::find("The Fourteenth Amendment requires no such thing.").is_empty());
+}


### PR DESCRIPTION
Closes nothing. Work for #52. Do not close the issue.

## What this adds

A new module, `src/citation/`, and nothing outside it except one line in `src/lib.rs`.

- `src/citation/usc.rs` — reads U.S. Code citations out of text.
- `src/citation/resolve.rs` — says what a citation can point at in this dataset.
- `src/citation/mod.rs` — turns the pair into `judicial.cites` links.

Nothing in `src/uslm/`, nothing in `src/storage/`, no new trait method, no change to `src/link.rs`.

## Attribution

The patterns are the `U.S.C.` entry of `reporters_db/data/laws.json` and the `law.section` and
`section_marker` templates of `reporters_db/data/regexes.json`, from Free Law Project's
`reporters-db`, **BSD-2-Clause**. The licence, the copyright line and the source URL are in the
module documentation of `src/citation/usc.rs`, at the top, where a reader meets them before the
patterns.

The one mechanical change the issue names is made and marked: Python writes a bounded repeat with
an open lower bound, `{,3}`, and Rust requires `{0,3}`.

One further change to the vendored pattern, also marked in the source: the two alternatives of
`law.section` are the other way round, so `981(a)(l)(C)` is read whole. In the published order the
plain-number branch wins and the section stops at `981`. eyecite reads the published example that
way, and CourtListener's markup shows the cost — in opinion 11103682 the `(g)(1)` of
`18 U.S.C. § 922(g)(1)` falls outside the citation span (research doc, section 8.3).

## The `laws.json` examples

All 11 pass, each read whole, with the title, the sections and the matched text asserted:

| Example | Title | Sections |
|---|---|---|
| `1 U.S.C. § 1` | 1 | `1` |
| `1 U.S.C.A. § 1` | 1 | `1` |
| `1 U.S.C.S. § 1` | 1 | `1` |
| `1 U.S.C.U. §§ 1-2` | 1 | `1-2` |
| `1 U.S.C. sec. 1` | 1 | `1` |
| `1 U.S.C. Sections 1-2` | 1 | `1-2` |
| `1 USC S. 1-2` | 1 | `1-2` |
| `1 U.S. Code §1` | 1 | `1` |
| `21, United States Code, Section 853` | 21 | `853` |
| `18, United States Code, Section 3500` | 18 | `3500` |
| `18, United States Code, Section 981(a)(l)(C)` | 18 | `981(a)(l)(C)` |

A hyphenated form stays as it is written. Whether `1-2` means one section numbered `1-2` or
sections 1 through 2 cannot be decided from the text, and the code does have sections such as
`300gg-11`. Expanding it would name provisions the text never wrote, so it is not expanded and the
decision is recorded in the tests.

## The `§§ 1983, 1988` defect

`42 U.S.C. §§ 1983, 1988` gives **both** sections. eyecite gives only `1983` (research doc,
section 8.1). One citation names several provisions, and each provision is its own link, so a lost
section is a lost link.

A list continues while each item is a section number and nothing more. A number followed by a
reporter is the title of the next citation, so `26 U.S.C. § 174, 42 U.S.C. § 1983` stays two
citations and does not invent a section 42 of title 26. `and` joins a list as well as a comma does,
because real prose does: `28 U.S.C. §§ 1475 and 1477` is from the committed test data.

The `Pub. L.`/`Stat.` collapse and the `C.F.R.`-without-`§` miss are **not** touched. They are out
of scope for #52.

## What a citation resolves to

**A structural path, and no more.** A provision has no identity of its own in the model (#93 is not
done, #129 is changing the core node type), so the link object is
`Target::Provision("uscode/title_26/subtitle_A/chapter_1/subchapter_B/part_VI/section_174")`. A path
locates rather than identifies (ADR 0001), so every link made here moves when identity arrives,
which is why the citation text travels with it as evidence.

A citation gives a title and a section number; a structural path also carries the subtitles,
chapters and parts between them, and cannot be built from the citation alone. `SectionPaths` closes
that gap: it maps the USLM identifier a citation *can* be turned into, `/us/usc/t26/s174`, onto the
path the model uses. It is built from parsed works the caller already holds, which is why this
module needs no storage access and stays out of the way of #127.

Resolution has four answers:

- `Provision { paths }` — the dataset holds the title and these paths locate the section. More than
  one path is possible, because the law sometimes numbers two provisions alike.
- `Absent` — the dataset holds the title and it has no such section. A statement about the law.
- `OutOfScope` — the dataset does not carry the title. **This is the answer, never "not found".**
- `Gap` — declared and not held, so a fault in the build.

Only a resolved section becomes a link. A link into material the dataset does not hold could not be
checked by the party reading it; the resolution still carries "out of scope" for a caller to report.

A subsection is kept as written and is not resolved. The published example says why: `981(a)(l)(C)`
has a lower-case L where the provision has a paragraph `(1)`. Text that cannot be trusted at that
depth must not be resolved at that depth, so the path stops at the section and the payload records
`174(a)` as the opinion wrote it.

## The link

`kind` `judicial.cites`; `subject` the opinion, as
`Target::External { reference: "judicial.opinion:2812209", … }`, because an opinion is not a work in
the core model yet; `object` the provision path; `verification` `MachineSuggested`; `evidence.reasoning`
the matched text, verbatim; payload in the `judicial` namespace with the title, the section as
written, the USLM identifier and the byte offset. The namespace is read from the kind rather than
written again, so the two cannot drift.

## Known limits, both shared with eyecite

Both fail by finding nothing rather than by naming the wrong provision.

1. No section marker, `16 U.S.C. 1533`, is not matched. The pattern requires a `§` or a `Section`.
   The U.S. Code's own notes are written that way, so this is worth its own issue.
2. A section number ending in a letter, `15 U.S.C. § 78aaa`, is not matched. `law.section` has no
   room for it, and reporting section 78 would name a different provision.

## Test evidence

Fixtures are real: the `laws.json` examples, and the Federal Rules of Bankruptcy Procedure and
titles 1 and 26 of the 2025-07-30 release point from `tests/test_data`. Nothing is invented.

```
$ cargo test --test usc_citation_tests --test usc_citation_link_tests
exit 0
test result: ok. 9 passed; 0 failed; 0 ignored  (usc_citation_tests)
test result: ok. 6 passed; 0 failed; 0 ignored  (usc_citation_link_tests)
```

Red first: the extraction tests failed before the module existed, and then on two assertions that
drove both pattern decisions:

```
---- should_cover_every_published_example_when_the_examples_come_from_laws_json stdout ----
"18, United States Code, Section 981(a)(l)(C)" -> [UscCitation { title: "18", sections: ["981"], … }]
---- should_read_every_section_when_real_prose_lists_three_of_them stdout ----
  left: ["727"]
 right: ["727(a)(11)", "1328(g)(2)", "1141(d)(3)(C)"]
```

Over real prose, 198 of the 199 `N U.S.C. §` mentions in `usc11a.xml` are read; the one miss is
`15 U.S.C. § 78aaa`, limit 2 above. The test asserts every mention is accounted for and allows only
that shape to be missed, so a regression breaks it.

Full suite, clippy and fmt:

```
$ cargo test --no-fail-fast
exit 0
44 targets: 365 passed; 0 failed; 7 ignored     (baseline 0 failed, 7 ignored)

$ cargo clippy --all-targets --all-features -- -D warnings
exit 0

$ cargo fmt --all --check
exit 0
```

Off-suite check, for the record rather than as a test: run against the cached CourtListener
opinion, Obergefell v. Hodges, 209,682 characters of real judicial prose. One citation found,
`1 U. S. C. §7` — the spaced-out official print style, which is the `U. S. C.` variation in
`laws.json` — and no false positives, although the text carries 27 other `§` marks belonging to
state codes and to the Constitution. That file is a local cache and not committed, so it is not a
test.

## Notes for review

- `Citation` and `Opinion` are new domain terms and are **not** in `CONTEXT.md`. Per
  `docs/agents/domain.md` the glossary is written by `/domain-modeling` rather than by the work that
  raises the term, so this is noted rather than done. `judicial.cites` now has a producer, which the
  glossary entry for Link may want to say.
- #53 is unblocked by this.
