### PR TITLE
test: give each test its own directory instead of a fixed path (#120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +564,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -975,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1313,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1556,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1892,6 +1940,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "similar",
+ "tempfile",
  "thiserror",
  "time",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,7 @@ rstest = "0.18"
 # Tests forge a dataset written by an older build, which needs raw SQL: the
 # public API can only produce files this build considers current.
 rusqlite = { version = "0.35", features = ["bundled", "serialize"] }
+# Each test that writes a file gets its own directory, removed when the test
+# ends. A fixed path is shared by every run, every checkout and every user of
+# the machine, so a leftover file or a second run failed the suite (#120).
+tempfile = "3"

--- a/tests/cache_tests.rs
+++ b/tests/cache_tests.rs
@@ -2,15 +2,10 @@ use std::time::Duration;
 
 use words_to_data::congress::ResponseCache;
 
-fn temp_dir(tag: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join(format!("w2d_cache_test_{}_{}", std::process::id(), tag));
-    let _ = std::fs::remove_dir_all(&dir);
-    dir
-}
-
 #[test]
 fn should_keep_file_on_disk_when_entry_expired() {
-    let dir = temp_dir("keep");
+    let temp = tempfile::tempdir().expect("a temporary directory");
+    let dir = temp.path().join("cache");
     let cache = ResponseCache::new(Some(Duration::ZERO), Some(dir.clone()));
 
     cache.set("bill/x.json", "payload").unwrap();
@@ -23,14 +18,13 @@ fn should_keep_file_on_disk_when_entry_expired() {
         dir.join("bill/x.json").exists(),
         "expired read must not delete the cached file"
     );
-
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn should_never_expire_when_ttl_none() {
-    let dir = temp_dir("never");
-    let cache = ResponseCache::new(None, Some(dir.clone()));
+    let temp = tempfile::tempdir().expect("a temporary directory");
+    let dir = temp.path().join("cache");
+    let cache = ResponseCache::new(None, Some(dir));
 
     cache.set("member/A000375.json", "payload").unwrap();
 
@@ -39,6 +33,4 @@ fn should_never_expire_when_ttl_none() {
         cache.get("member/A000375.json"),
         Some("payload".to_string())
     );
-
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/congress_tests.rs
+++ b/tests/congress_tests.rs
@@ -5,8 +5,8 @@ const TEST_CONGRESS_CACHE_DIR: &str = "tests/test_data/congress_client_cache";
 #[test]
 #[ignore] // Requires live API key - run with: cargo test -- --ignored
 fn should_download_bill_data_live() {
-    let cache_dir = std::env::temp_dir().join("congress_download_test");
-    let _ = std::fs::remove_dir_all(&cache_dir);
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let cache_dir = dir.path().join("cache");
 
     let api_key =
         std::env::var("CONGRESS_API_KEY").expect("Set CONGRESS_API_KEY env var to run this test");
@@ -19,8 +19,6 @@ fn should_download_bill_data_live() {
     assert!(!download.bill_xml.is_empty());
     assert!(!download.bill_metadata_json.is_empty());
     assert!(!download.member_jsons.is_empty());
-
-    let _ = std::fs::remove_dir_all(&cache_dir);
 }
 
 #[test]

--- a/tests/dataset_tests.rs
+++ b/tests/dataset_tests.rs
@@ -62,7 +62,9 @@ fn should_serialize_roundtrip_json() {
     }
 
     // Save and load via Compact format (JSON with tuple keys requires file-based roundtrip)
-    let path = "/tmp/dataset_test_roundtrip.json";
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("roundtrip.json");
+    let path = path.to_str().expect("a utf-8 path");
     dataset.save(path, Format::Compact).unwrap();
     let roundtripped = Dataset::load(path, Format::Compact).unwrap();
 
@@ -106,8 +108,6 @@ fn should_serialize_roundtrip_json() {
             .unwrap()
             .is_none()
     );
-
-    std::fs::remove_file(path).ok();
 }
 
 fn make_test_dataset() -> Dataset<InMemoryStorage> {
@@ -259,7 +259,9 @@ fn should_save_and_load_file() {
         .add_expression(make_expression("2024-01-01", Some("First")))
         .unwrap();
 
-    let path = "/tmp/dataset_test_save_load.json";
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("save_load.json");
+    let path = path.to_str().expect("a utf-8 path");
 
     // Save
     dataset
@@ -274,9 +276,6 @@ fn should_save_and_load_file() {
     let expressions = loaded.expressions(&title_7()).unwrap();
     assert_eq!(expressions.len(), 1);
     assert_eq!(expressions[0].id, at("2024-01-01"));
-
-    // Cleanup
-    std::fs::remove_file(path).ok();
 }
 
 #[test]

--- a/tests/declared_scope_tests.rs
+++ b/tests/declared_scope_tests.rs
@@ -125,10 +125,8 @@ fn should_carry_the_declaration_through_sqlite() {
     };
     let memory = dataset_declaring(Some(declaration.clone()));
 
-    let dir = std::path::Path::new("target/declared_scope_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let file = dir.join("declaration.sqlite");
-    std::fs::remove_file(&file).ok();
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let file = dir.path().join("declaration.sqlite");
     memory.save_to_sqlite(&file).expect("save to sqlite");
     let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
 
@@ -177,11 +175,9 @@ fn should_hold_no_legislature_when_it_declares_none_and_has_none() {
 }
 
 /// Save a dataset and run `info` against it the way a person or an agent would.
-fn info_output(dataset: &Dataset<InMemoryStorage>, name: &str) -> String {
-    let dir = std::path::Path::new("target/declared_scope_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let file = dir.join(format!("{name}.sqlite"));
-    std::fs::remove_file(&file).ok();
+fn info_output(dataset: &Dataset<InMemoryStorage>) -> String {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let file = dir.path().join("dataset.sqlite");
     dataset.save_to_sqlite(&file).expect("save to sqlite");
 
     let output = std::process::Command::new(env!("CARGO_BIN_EXE_words_to_data"))
@@ -199,7 +195,7 @@ fn should_print_an_incomplete_line_when_the_build_left_a_gap() {
         ..Default::default()
     }));
 
-    let stdout = info_output(&dataset, "gap");
+    let stdout = info_output(&dataset);
 
     // A silent gap is the failure mode this feature exists to remove, so the
     // one thing `info` must not do is print a dataset like this as if it were
@@ -216,7 +212,7 @@ fn should_print_an_incomplete_line_when_the_build_left_a_gap() {
 
 #[test]
 fn should_print_no_declaration_lines_when_nothing_was_declared() {
-    let stdout = info_output(&dataset_declaring(None), "undeclared");
+    let stdout = info_output(&dataset_declaring(None));
 
     // Every dataset is undeclared until it is rebuilt, so this output is what
     // almost every reader sees and it must not have changed.

--- a/tests/duplicate_path_tests.rs
+++ b/tests/duplicate_path_tests.rs
@@ -362,9 +362,11 @@ fn should_report_counts_but_no_provisions_when_no_expression_pair_is_given() {
 }
 
 /// Title 26 at one release point, held both ways.
-fn dataset_both_backends(
-    name: &str,
-) -> (
+///
+/// The caller must keep the returned directory in scope: dropping it removes the
+/// SQLite database.
+fn dataset_both_backends() -> (
+    tempfile::TempDir,
     words_to_data::dataset::Dataset<words_to_data::storage::InMemoryStorage>,
     words_to_data::dataset::Dataset<words_to_data::storage::SqliteStorage>,
 ) {
@@ -383,19 +385,17 @@ fn dataset_both_backends(
         .add_uslm_xml(USC26_30, "2025-07-30", None)
         .expect("the fixture should parse");
 
-    let dir = std::path::Path::new("target/duplicate_path_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let file = dir.join(format!("{name}.sqlite"));
-    std::fs::remove_file(&file).ok();
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let file = dir.path().join("dataset.sqlite");
     memory.save_to_sqlite(&file).expect("save to sqlite");
     let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
 
-    (memory, sqlite)
+    (dir, memory, sqlite)
 }
 
 #[test]
 fn should_hold_every_provision_sharing_a_path_on_both_backends() {
-    let (memory, sqlite) = dataset_both_backends("find_element");
+    let (_dir, memory, sqlite) = dataset_both_backends();
 
     let from_memory = memory.find_element(DUPLICATED).expect("find in memory");
     let from_sqlite = sqlite.find_element(DUPLICATED).expect("find in sqlite");
@@ -433,7 +433,7 @@ const ABSENT: &str = "uscode/title_26/subtitle_A/chapter_1/subchapter_A/part_IV/
 fn should_say_whether_a_path_exists_on_both_backends() {
     use words_to_data::storage::DocumentReader;
 
-    let (memory, sqlite) = dataset_both_backends("has_element");
+    let (_dir, memory, sqlite) = dataset_both_backends();
 
     assert!(
         memory.has_element(DUPLICATED).expect("ask memory"),
@@ -458,7 +458,7 @@ fn should_say_whether_a_path_exists_on_both_backends() {
 fn should_say_a_path_exists_when_it_names_more_than_one_provision() {
     use words_to_data::storage::DocumentReader;
 
-    let (memory, sqlite) = dataset_both_backends("has_element_duplicate");
+    let (_dir, memory, sqlite) = dataset_both_backends();
 
     // The question is whether at least one provision sits at the path. Two
     // paragraphs (4) sit at this one, and a check which expects a path to name

--- a/tests/inspect_tests.rs
+++ b/tests/inspect_tests.rs
@@ -5,6 +5,7 @@
 //! one real fixture from committed USC XML + a real public-law bill, then asserts
 //! against both backends.
 
+use tempfile::TempDir;
 use words_to_data::annotation::{
     AnnotationMetadata, AnnotationStatus, BillReference, ChangeAnnotation,
 };
@@ -174,16 +175,16 @@ fn matched_statements_fixture() -> Dataset<InMemoryStorage> {
 
 /// Round-trip the fixture through SQLite so tests can exercise that backend too.
 ///
-/// `name` must be unique per test: tests run in parallel and each needs its own
-/// database file (SQLite also needs a writable directory for its journal, so we
-/// use `target/`, which is always writable).
-fn to_sqlite(fixture: &Dataset<InMemoryStorage>, name: &str) -> Dataset<SqliteStorage> {
-    let dir = std::path::Path::new("target/inspect_test_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let path = dir.join(format!("{name}.sqlite"));
-    std::fs::remove_file(&path).ok();
+/// The database goes in a directory this call owns, so tests running in parallel
+/// cannot reach each other's file (SQLite also needs a writable directory for
+/// its journal). The caller must keep the returned directory in scope: dropping
+/// it removes the database.
+fn to_sqlite(fixture: &Dataset<InMemoryStorage>) -> (TempDir, Dataset<SqliteStorage>) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("dataset.sqlite");
     fixture.save_to_sqlite(&path).expect("save to sqlite");
-    Dataset::open_sqlite(&path).expect("open sqlite")
+    let sqlite = Dataset::open_sqlite(&path).expect("open sqlite");
+    (dir, sqlite)
 }
 
 #[test]
@@ -267,7 +268,7 @@ fn should_report_identical_counts_for_both_backends() {
     let fixture = make_full_fixture();
     let expected = inspect::info(&fixture).expect("info mem");
 
-    let sqlite = to_sqlite(&fixture, "counts");
+    let (_dir, sqlite) = to_sqlite(&fixture);
     let actual = inspect::info(&sqlite).expect("info sqlite");
 
     assert_eq!(actual.link_count, expected.link_count);
@@ -317,7 +318,7 @@ fn should_list_identical_expressions_for_sqlite_backend() {
     let fixture = make_fixture();
     let expected = inspect::expressions(&fixture, None).expect("expressions mem");
 
-    let sqlite = to_sqlite(&fixture, "expressions");
+    let (_dir, sqlite) = to_sqlite(&fixture);
     let actual = inspect::expressions(&sqlite, None).expect("expressions sqlite");
 
     assert_eq!(actual.len(), expected.len());
@@ -361,7 +362,7 @@ fn should_summarize_identical_bill_for_sqlite_backend() {
         .expect("mem")
         .expect("bill");
 
-    let sqlite = to_sqlite(&fixture, "show_bill");
+    let (_dir, sqlite) = to_sqlite(&fixture);
     let actual = inspect::show_bill(&sqlite, "119-hr-1")
         .expect("sqlite")
         .expect("bill");
@@ -388,7 +389,7 @@ fn should_find_matching_text_in_headings() {
 #[test]
 fn should_find_heading_matches_on_sqlite_backend() {
     let fixture = make_fixture();
-    let sqlite = to_sqlite(&fixture, "search");
+    let (_dir, sqlite) = to_sqlite(&fixture);
 
     // SQLite indexes headings + content, so a heading term must still be found.
     let hits = inspect::search(&sqlite, "arbitration").expect("search sqlite");
@@ -435,7 +436,7 @@ fn should_produce_identical_diff_summary_for_sqlite_backend() {
     let (from, to) = pair();
     let expected = inspect::diff(&fixture, &from, &to).expect("mem");
 
-    let sqlite = to_sqlite(&fixture, "diff");
+    let (_dir, sqlite) = to_sqlite(&fixture);
     let actual = inspect::diff(&sqlite, &from, &to).expect("sqlite");
 
     assert_eq!(actual.changed_paths, expected.changed_paths);
@@ -586,7 +587,7 @@ fn should_not_report_a_longer_section_number_when_the_path_is_a_string_prefix() 
 #[test]
 fn should_list_identical_annotations_for_sqlite_backend() {
     let fixture = make_fixture();
-    let sqlite = to_sqlite(&fixture, "annotations");
+    let (_dir, sqlite) = to_sqlite(&fixture);
 
     let anns = inspect::annotations(&sqlite, AnnotationQuery::Bill("119-hr-1")).expect("sqlite");
     assert_eq!(anns.len(), 1);
@@ -765,7 +766,7 @@ fn should_report_one_provision_in_both_when_an_ordinary_path_is_unchanged() {
 #[test]
 fn should_report_the_same_provisions_on_both_backends() {
     let fixture = make_fixture();
-    let sqlite = to_sqlite(&fixture, "path_provisions");
+    let (_dir, sqlite) = to_sqlite(&fixture);
     let (from, to) = pair();
 
     let from_memory = inspect::path_report(
@@ -803,7 +804,7 @@ fn should_report_the_same_provisions_on_both_backends() {
 #[test]
 fn should_report_path_annotations_on_sqlite_backend() {
     let fixture = make_fixture();
-    let sqlite = to_sqlite(&fixture, "path_report");
+    let (_dir, sqlite) = to_sqlite(&fixture);
 
     let report = inspect::path_report(&sqlite, ANNOTATED_PATH, None, PathMatch::Subtree)
         .expect("path_report sqlite");
@@ -920,7 +921,7 @@ fn should_report_identical_info_for_sqlite_backend() {
     let fixture = make_fixture();
     let expected = inspect::info(&fixture).expect("info mem");
 
-    let sqlite = to_sqlite(&fixture, "info");
+    let (_dir, sqlite) = to_sqlite(&fixture);
     let actual = inspect::info(&sqlite).expect("info sqlite");
 
     assert_eq!(actual.name, expected.name);
@@ -977,7 +978,7 @@ fn should_name_the_absent_path_when_an_annotation_points_nowhere_on_sqlite() {
         &from,
         &to,
     );
-    let sqlite = to_sqlite(&fixture, "validate_absent_path");
+    let (_dir, sqlite) = to_sqlite(&fixture);
 
     let report = inspect::validate(&sqlite).expect("validate");
 

--- a/tests/link_storage_tests.rs
+++ b/tests/link_storage_tests.rs
@@ -183,16 +183,20 @@ fn empty_dataset() -> Dataset<InMemoryStorage> {
 }
 
 /// Round-trip a dataset through SQLite so both backends are exercised.
+///
+/// The caller must keep the returned directory in scope: dropping it removes the
+/// database.
 fn through_sqlite(
     dataset: &Dataset<InMemoryStorage>,
-    name: &str,
-) -> Dataset<words_to_data::storage::SqliteStorage> {
-    let dir = std::path::Path::new("target/link_storage_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let file = dir.join(format!("{name}.sqlite"));
-    std::fs::remove_file(&file).ok();
+) -> (
+    tempfile::TempDir,
+    Dataset<words_to_data::storage::SqliteStorage>,
+) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let file = dir.path().join("dataset.sqlite");
     dataset.save_to_sqlite(&file).expect("save to sqlite");
-    Dataset::open_sqlite(&file).expect("open sqlite")
+    let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
+    (dir, sqlite)
 }
 
 #[test]
@@ -203,14 +207,10 @@ fn should_carry_a_link_of_a_kind_this_build_has_never_seen() {
         dataset.add_link(link).expect("the link should be stored");
     }
 
+    let (_dir, sqlite) = through_sqlite(&dataset);
     for (label, stored) in [
         ("memory", dataset.links_by_namespace("westlaw").unwrap()),
-        (
-            "sqlite",
-            through_sqlite(&dataset, "unknown_kind")
-                .links_by_namespace("westlaw")
-                .unwrap(),
-        ),
+        ("sqlite", sqlite.links_by_namespace("westlaw").unwrap()),
     ] {
         // A reader that does not understand `westlaw.headnote` must still find
         // it, report it, and hand it back byte-identical. Silent loss is the
@@ -305,7 +305,7 @@ fn should_find_links_by_kind_and_by_the_path_they_are_about() {
     for link in fixture.clone() {
         dataset.add_link(link).expect("stored");
     }
-    let sqlite = through_sqlite(&dataset, "queries");
+    let (_dir, sqlite) = through_sqlite(&dataset);
 
     let Target::Change { path, .. } = &fixture[0].subject else {
         panic!("the fixture's subject is a change");
@@ -367,7 +367,7 @@ fn should_carry_an_unreadable_payload_through_storage_untouched() {
 
     let mut dataset = empty_dataset();
     dataset.add_link(link).expect("stored");
-    let sqlite = through_sqlite(&dataset, "payload");
+    let (_dir, sqlite) = through_sqlite(&dataset);
 
     // The core stores it, hands it back unchanged, and never reads it.
     let stored = sqlite.links_by_namespace("westlaw").unwrap();

--- a/tests/readme_example_tests.rs
+++ b/tests/readme_example_tests.rs
@@ -78,14 +78,12 @@ fn readme_example_dataset_workflow() {
         panic!("Section 174(a) not found in diff - README example path may be wrong");
     }
 
-    // Save dataset (to temp file)
-    let temp_path = std::env::temp_dir().join("readme_test_dataset.json");
+    // Save dataset (to a directory this test owns, removed when it ends)
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let temp_path = dir.path().join("dataset.json");
     dataset
-        .save(temp_path.to_str().unwrap(), Format::Compact)
+        .save(temp_path.to_str().expect("a utf-8 path"), Format::Compact)
         .expect("Failed to save dataset");
-
-    // Cleanup
-    let _ = std::fs::remove_file(temp_path);
 }
 
 /// Verifies the Dataset example produces expected results.

--- a/tests/reply_evidence_tests.rs
+++ b/tests/reply_evidence_tests.rs
@@ -183,10 +183,8 @@ fn should_carry_replies_and_evidence_through_sqlite() {
         })))
         .expect("link stored");
 
-    let dir = std::path::Path::new("target/reply_evidence_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let file = dir.join("evidence.sqlite");
-    std::fs::remove_file(&file).ok();
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let file = dir.path().join("evidence.sqlite");
     memory.save_to_sqlite(&file).expect("save to sqlite");
     let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
 
@@ -261,10 +259,8 @@ fn should_say_a_model_produced_an_amendments_word_level_changes() {
         },
     );
 
-    let dir = std::path::Path::new("target/reply_evidence_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let file = dir.join("amendment_provenance.sqlite");
-    std::fs::remove_file(&file).ok();
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let file = dir.path().join("amendment_provenance.sqlite");
     dataset.save_to_sqlite(&file).expect("save to sqlite");
     let sqlite = Dataset::open_sqlite(&file).expect("open sqlite");
 

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -4,6 +4,7 @@
 //! "no" because it never indexed the field the text sits in is worse than one
 //! that errors: the reader is told the law is absent (#82).
 
+use tempfile::TempDir;
 use words_to_data::dataset::{Dataset, DatasetMetadata, SearchResult};
 use words_to_data::inspect;
 use words_to_data::storage::{InMemoryStorage, SqliteStorage};
@@ -49,13 +50,14 @@ fn title_26() -> Dataset<InMemoryStorage> {
     dataset
 }
 
-fn to_sqlite(fixture: &Dataset<InMemoryStorage>, name: &str) -> Dataset<SqliteStorage> {
-    let dir = std::path::Path::new("target/search_test_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let path = dir.join(format!("{name}.sqlite"));
-    std::fs::remove_file(&path).ok();
+/// Round-trip the fixture through SQLite. The caller must keep the returned
+/// directory in scope: dropping it removes the database.
+fn to_sqlite(fixture: &Dataset<InMemoryStorage>) -> (TempDir, Dataset<SqliteStorage>) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("dataset.sqlite");
     fixture.save_to_sqlite(&path).expect("save to sqlite");
-    Dataset::open_sqlite(&path).expect("open sqlite")
+    let sqlite = Dataset::open_sqlite(&path).expect("open sqlite");
+    (dir, sqlite)
 }
 
 /// The comparable shape of a hit: which field of which path matched.
@@ -69,7 +71,7 @@ fn hits(results: &[SearchResult]) -> Vec<(String, String, String)> {
 #[test]
 fn should_find_chapeau_text_on_both_backends_when_searching() {
     let memory = title_9();
-    let sqlite = to_sqlite(&memory, "chapeau");
+    let (_dir, sqlite) = to_sqlite(&memory);
 
     let from_memory = inspect::search(&memory, CHAPEAU_TEXT).expect("search memory");
     let from_sqlite = inspect::search(&sqlite, CHAPEAU_TEXT).expect("search sqlite");
@@ -89,7 +91,7 @@ fn should_find_chapeau_text_on_both_backends_when_searching() {
 #[test]
 fn should_find_proviso_and_continuation_text_on_both_backends_when_searching() {
     let memory = title_26();
-    let sqlite = to_sqlite(&memory, "proviso_continuation");
+    let (_dir, sqlite) = to_sqlite(&memory);
 
     // Real text from title 26. The proviso is the only one in the title.
     for (field, query) in [
@@ -121,7 +123,7 @@ fn should_find_proviso_and_continuation_text_on_both_backends_when_searching() {
 #[test]
 fn should_return_results_in_the_same_order_on_both_backends_when_a_query_matches_widely() {
     let memory = title_9();
-    let sqlite = to_sqlite(&memory, "ordering");
+    let (_dir, sqlite) = to_sqlite(&memory);
 
     // Title 9 is the Federal Arbitration Act, so this matches throughout it.
     let from_memory = inspect::search(&memory, "arbitration").expect("search memory");
@@ -142,7 +144,7 @@ fn should_return_results_in_the_same_order_on_both_backends_when_a_query_matches
 #[test]
 fn should_return_the_same_results_when_the_same_query_runs_twice() {
     let memory = title_9();
-    let sqlite = to_sqlite(&memory, "repeatable");
+    let (_dir, sqlite) = to_sqlite(&memory);
 
     for (label, first, second) in [
         (
@@ -167,11 +169,12 @@ fn should_return_the_same_results_when_the_same_query_runs_twice() {
 /// Forge the element index an older build wrote: heading and content only, and
 /// no document position. The public API cannot produce one, because this build
 /// always writes the full shape.
-fn stale_index_dataset(name: &str) -> std::path::PathBuf {
-    let dir = std::path::Path::new("target/search_test_dbs");
-    std::fs::create_dir_all(dir).expect("create sqlite test dir");
-    let path = dir.join(format!("{name}.sqlite"));
-    std::fs::remove_file(&path).ok();
+///
+/// The caller must keep the returned directory in scope: dropping it removes the
+/// database.
+fn stale_index_dataset() -> (TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("stale.sqlite");
 
     let conn = rusqlite::Connection::open(&path).expect("open forged db");
     // The schema version must be current, or the version guard answers first
@@ -188,12 +191,12 @@ fn stale_index_dataset(name: &str) -> std::path::PathBuf {
     ))
     .expect("forge the older index");
     drop(conn);
-    path
+    (dir, path)
 }
 
 #[test]
 fn should_refuse_a_dataset_whose_search_index_predates_this_build() {
-    let path = stale_index_dataset("stale");
+    let (_dir, path) = stale_index_dataset();
 
     let opened = Dataset::open_sqlite(&path);
 

--- a/tests/sqlite_tests.rs
+++ b/tests/sqlite_tests.rs
@@ -67,13 +67,14 @@ fn should_save_and_load_sqlite_format() {
         .add_expression(make_expression("2024-06-01", None))
         .unwrap();
 
-    let path = "/tmp/test_dataset.db";
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("dataset.db");
 
     // Save as SQLite
-    dataset.save_to_sqlite(path).expect("save should succeed");
+    dataset.save_to_sqlite(&path).expect("save should succeed");
 
     // Load from SQLite
-    let loaded = Dataset::open_sqlite(path)
+    let loaded = Dataset::open_sqlite(&path)
         .expect("open should succeed")
         .to_memory()
         .expect("to_memory should succeed");
@@ -90,9 +91,6 @@ fn should_save_and_load_sqlite_format() {
     // Verify element data preserved, rooted at the work
     let expression = loaded.get_expression(&at("2024-01-01")).unwrap().unwrap();
     assert_eq!(expression.element.data.path.as_ref(), TITLE_7);
-
-    // Cleanup
-    std::fs::remove_file(path).ok();
 }
 
 const PL_XML_PATH: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml";
@@ -127,10 +125,11 @@ fn should_roundtrip_bills_and_annotations_sqlite() {
         );
     }
 
-    let path = "/tmp/test_dataset_full.db";
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("dataset_full.db");
 
-    dataset.save_to_sqlite(path).unwrap();
-    let loaded = Dataset::open_sqlite(path).unwrap().to_memory().unwrap();
+    dataset.save_to_sqlite(&path).unwrap();
+    let loaded = Dataset::open_sqlite(&path).unwrap().to_memory().unwrap();
 
     // Verify bill
     assert_eq!(loaded.storage().bills.len(), 1);
@@ -147,13 +146,12 @@ fn should_roundtrip_bills_and_annotations_sqlite() {
     assert_eq!(anns.len(), 317);
     let paths: usize = anns.iter().map(|a| a.paths.len()).sum();
     assert_eq!(paths, 718, "every statement must survive the round trip");
-
-    std::fs::remove_file(path).ok();
 }
 
 #[test]
 fn should_support_incremental_save_sqlite() {
-    let path = "/tmp/test_incremental.db";
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("incremental.db");
 
     // First save with one expression
     {
@@ -161,22 +159,22 @@ fn should_support_incremental_save_sqlite() {
         dataset
             .add_expression(make_expression("2024-01-01", Some("V1")))
             .unwrap();
-        dataset.save_to_sqlite(path).unwrap();
+        dataset.save_to_sqlite(&path).unwrap();
     }
 
     // Load, add another expression, save again
     {
-        let mut dataset = Dataset::open_sqlite(path).unwrap().to_memory().unwrap();
+        let mut dataset = Dataset::open_sqlite(&path).unwrap().to_memory().unwrap();
         assert_eq!(listed(&dataset).len(), 1);
 
         dataset
             .add_expression(make_expression("2024-06-01", Some("V2")))
             .unwrap();
-        dataset.save_to_sqlite(path).unwrap();
+        dataset.save_to_sqlite(&path).unwrap();
     }
 
     // Verify both expressions present
-    let loaded = Dataset::open_sqlite(path).unwrap().to_memory().unwrap();
+    let loaded = Dataset::open_sqlite(&path).unwrap().to_memory().unwrap();
     assert_eq!(
         listed(&loaded),
         vec![
@@ -184,8 +182,6 @@ fn should_support_incremental_save_sqlite() {
             (at("2024-06-01"), Some("V2".to_string())),
         ]
     );
-
-    std::fs::remove_file(path).ok();
 }
 
 #[test]
@@ -211,8 +207,9 @@ fn should_query_via_trait_interface() {
         );
     }
 
-    let path = "/tmp/test_trait_query.db";
-    dataset.save_to_sqlite(path).unwrap();
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("trait_query.db");
+    dataset.save_to_sqlite(&path).unwrap();
 
     // Query via trait - works for both Dataset and SqliteStorage
     fn check_reader(reader: &(impl DocumentReader + LinkReader + LegislatureReader)) {
@@ -259,10 +256,8 @@ fn should_query_via_trait_interface() {
     check_reader(&dataset);
 
     // Test with SqliteStorage
-    let storage = SqliteStorage::open(path).unwrap();
+    let storage = SqliteStorage::open(&path).unwrap();
     check_reader(&storage);
-
-    std::fs::remove_file(path).ok();
 }
 
 #[test]
@@ -294,11 +289,12 @@ fn should_load_window_with_two_expressions() {
         );
     }
 
-    let path = "/tmp/test_load_window.db";
-    dataset.save_to_sqlite(path).unwrap();
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("load_window.db");
+    dataset.save_to_sqlite(&path).unwrap();
 
     // Load window with just 2 expressions (returns InMemoryStorage)
-    let storage = SqliteStorage::open(path).unwrap();
+    let storage = SqliteStorage::open(&path).unwrap();
     let windowed = storage
         .load_window(&at("2024-01-01"), &at("2024-06-01"))
         .unwrap();
@@ -329,8 +325,6 @@ fn should_load_window_with_two_expressions() {
 
     // Bills/members/sponsors should be empty (query from storage when needed)
     assert!(windowed.bills.is_empty());
-
-    std::fs::remove_file(path).ok();
 }
 
 #[test]
@@ -352,8 +346,9 @@ fn should_query_annotations_for_path_via_trait() {
         );
     }
 
-    let path = "/tmp/test_ann_path.db";
-    dataset.save_to_sqlite(path).unwrap();
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let path = dir.path().join("ann_path.db");
+    dataset.save_to_sqlite(&path).unwrap();
 
     // Test via trait - should work for both
     fn check_annotations_for_path(reader: &impl LinkReader) {
@@ -367,10 +362,8 @@ fn should_query_annotations_for_path_via_trait() {
 
     check_annotations_for_path(&dataset);
 
-    let storage = SqliteStorage::open(path).unwrap();
+    let storage = SqliteStorage::open(&path).unwrap();
     check_annotations_for_path(&storage);
-
-    std::fs::remove_file(path).ok();
 }
 
 /// Store an annotation the way the pipeline does: one link per path it names.

--- a/tests/uscode_tests.rs
+++ b/tests/uscode_tests.rs
@@ -16,8 +16,8 @@ fn should_look_up_download_url_by_date_when_present_in_manifest() {
 #[test]
 fn should_extract_all_xml_files_flat_when_given_a_release_zip() {
     let zip_bytes = std::fs::read("tests/test_data/mirror/sample.zip").unwrap();
-    let dest = std::env::temp_dir().join("w2d_extract_test");
-    let _ = std::fs::remove_dir_all(&dest);
+    let dir = tempfile::tempdir().expect("a temporary directory");
+    let dest = dir.path().join("release");
 
     extract_release(&zip_bytes, &dest).unwrap();
 
@@ -28,6 +28,4 @@ fn should_extract_all_xml_files_flat_when_given_a_release_zip() {
         .collect();
     names.sort();
     assert_eq!(names, vec!["usc01.xml", "usc09.xml"]);
-
-    std::fs::remove_dir_all(&dest).unwrap();
 }


### PR DESCRIPTION
Closes nothing. Refers to #120 — please do not close the issue with this PR.

## What the defect was

A test that names a fixed path shares that path with every run, every checkout and every user of the machine. Two faults followed, and two agents hit them independently.

- A leftover file failed the suite. A `.db` written at an older `SCHEMA_VERSION` was opened by the next run and refused, so the test reported a schema fault when the cause was a file from an earlier run.
- Two runs at the same time failed each other, because two checkouts shared `/tmp/test_dataset.db`.

## Files changed

| File | What it named before |
| --- | --- |
| `Cargo.toml`, `Cargo.lock` | `tempfile = "3"` added as a dev-dependency |
| `tests/sqlite_tests.rs` | `/tmp/test_dataset.db`, `/tmp/test_dataset_full.db`, `/tmp/test_incremental.db`, `/tmp/test_trait_query.db`, `/tmp/test_load_window.db`, `/tmp/test_ann_path.db` |
| `tests/dataset_tests.rs` | `/tmp/dataset_test_roundtrip.json`, `/tmp/dataset_test_save_load.json` |
| `tests/uscode_tests.rs` | `env::temp_dir()/w2d_extract_test` |
| `tests/congress_tests.rs` | `env::temp_dir()/congress_download_test` |
| `tests/readme_example_tests.rs` | `env::temp_dir()/readme_test_dataset.json` |
| `tests/cache_tests.rs` | `env::temp_dir()/w2d_cache_test_{pid}_{tag}` (two directories) |
| `tests/inspect_tests.rs` | `target/inspect_test_dbs/{name}.sqlite` (ten names) |
| `tests/search_tests.rs` | `target/search_test_dbs/{name}.sqlite` (five names) |
| `tests/duplicate_path_tests.rs` | `target/duplicate_path_dbs/{name}.sqlite` (three names) |
| `tests/link_storage_tests.rs` | `target/link_storage_dbs/{name}.sqlite` (three names) |
| `tests/reply_evidence_tests.rs` | `target/reply_evidence_dbs/{evidence,amendment_provenance}.sqlite` |
| `tests/declared_scope_tests.rs` | `target/declared_scope_dbs/{name}.sqlite` (three names) |

Each of these tests now makes its own directory with `tempfile::tempdir()`, and the directory goes away when the test ends. The manual `remove_file` and `create_dir_all` calls go with it, so cleanup also happens when a test panics. Where a helper hands a SQLite dataset back to the test, it now returns the directory as well, because dropping the directory removes the file.

No test asserts anything new or different. Only the place a test writes changed.

## What I found beyond the eight paths in the issue

**Five more fixed paths under `/tmp`.** Three tests reached `/tmp` through `std::env::temp_dir()` rather than a literal, so a search for `/tmp` did not find them: `tests/uscode_tests.rs`, `tests/congress_tests.rs` and `tests/readme_example_tests.rs`. `tests/cache_tests.rs` made two more directories under `/tmp`, with the process id in the name. The id made a collision unlikely, but the directory stayed behind when a test panicked, and the name was still a name another program could pick. These five are the same fault as the eight, and they are fixed here. That makes 13 paths in total.

**Six test files kept databases in a hand-made directory under `target/`.** That directory belongs to the checkout, so it did not break a second checkout. But the file name inside it was fixed, one per test, and the comment in `inspect_tests.rs` said the names must stay unique by hand. Two tests that took the same name would race, because tests in one binary run in parallel. These are fixed here too, and the helpers no longer take a name.

**Four test files keep `CARGO_TARGET_TMPDIR`, on purpose.** `tests/cli_tests.rs`, `tests/cli_llm_tests.rs`, `tests/schema_version_tests.rs` and `tests/member_party_tests.rs` write there. Cargo makes that directory for the test target, inside the build directory of the checkout, so no other checkout and no other user can name it. It is also the only place the shared fixtures in `cli_tests.rs` can live: a `OnceLock` fixture is built once and read for the life of the test binary, which a directory that goes away at the end of one test cannot hold. Each of these writes a fresh file, so a leftover file cannot be read either.

**The schema guard is unchanged.** The guard is correct; the shared path was the fault.

## Test evidence

### Baseline, before the change

```
$ cargo test --all-features
exit 0
passed=349 failed=0 ignored=7
```

### Full suite, after the change

```
$ cargo test --all-features
exit 0
passed=349 failed=0 ignored=7
```

### The defect, reproduced before the fix

A second checkout at `vibes` (pre-fix), with the old files put back at the old shape — real SQLite files carrying `schema_version = 1`:

```
$ cargo test --test sqlite_tests
thread 'should_query_via_trait_interface' panicked at tests/sqlite_tests.rs:215:34:
called `Result::unwrap()` on an `Err` value: SchemaVersionMismatch { found: 1, expected: 7 }
...
failures:
    should_load_window_with_two_expressions
    should_query_annotations_for_path_via_trait
    should_query_via_trait_interface
    should_roundtrip_bills_and_annotations_sqlite
    should_save_and_load_sqlite_format
    should_support_incremental_save_sqlite

test result: FAILED. 0 passed; 6 failed; 0 ignored
```

This is the failure the issue describes: a schema fault reported for a file an earlier run left behind.

### The suite passes with a leftover file of the old shape present

The same files in place, this branch:

```
$ cargo test --all-features
exit 0
passed=349 failed=0 ignored=7
```

And again, targeted at the files that used to name those paths:

```
$ cargo test --all-features --test sqlite_tests --test dataset_tests \
      --test uscode_tests --test cache_tests --test readme_example_tests
test result: ok. 2 passed; 0 failed   (cache_tests)
test result: ok. 13 passed; 0 failed  (dataset_tests)
test result: ok. 2 passed; 0 failed   (readme_example_tests)
test result: ok. 6 passed; 0 failed   (sqlite_tests)
test result: ok. 2 passed; 0 failed   (uscode_tests)
```

Afterwards `/tmp/test_dataset.db` and `/tmp/dataset_test_roundtrip.json` were still on disk, unchanged, which is the point: no test reads or writes them any more.

### The full suite passes twice at the same time, from two checkouts

Checkout A is this branch in a git worktree at `.../worktrees/agent-a0aba5d0dd4ccc5cc`. Checkout B is a separate clone of the same branch at `/tmp/w2d_120_second`, with its own `target/` directory. Both ran `cargo test --all-features`, started within seconds of each other.

Overlap, sampled while both were running:

```
Sat Sep 12 01:04:47 PM CDT 2026
=== A ===  11 test binaries finished, now running diff_tests
=== B ===  11 test binaries finished, now running diff_tests
```

Result:

```
Sat Sep 12 01:10:58 PM CDT 2026
=== A ===  exit 0  passed=349 failed=0 ignored=7
=== B ===  exit 0  passed=349 failed=0 ignored=7
```

### Lint and format

```
$ cargo clippy --all-targets --all-features -- -D warnings
exit 0, no warnings

$ cargo fmt --all -- --check
exit 0, no output
```

## Notes for review

- No behaviour of the library or the CLI changes. Only tests and the dev-dependency list.
- The edits keep to the path concern. Where a helper lost its `name` argument, it was only there to keep the fixed file names apart.
