### PR TITLE
Drop the legislature extension from the core Storage bound (#127)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,5 +161,5 @@ _Avoid_: Match, mapping, label
 **Extension**:
 A named set of facts that only some datasets carry, such as the legislature facts (Bill, Sponsor, Roll call) or the judicial facts (court, opinion type). The core data model carries no extension concept: a Link's kind is an open namespaced string, and the facts only one kind understands sit in a Kind payload the core stores and never reads.
 
-**The storage layer does not yet hold that line.** The core `Storage` trait requires `LegislatureReader`, whose methods have no default bodies, so every backend must implement bills, sponsors, members and votes — including one that will only ever hold court opinions. The separation is real in the data model and incomplete in the traits beneath it. #127 is the work, and #53 will meet it first.
+The storage traits hold the same line. The core `Storage` trait requires documents, links and evidence, and no extension, so a backend that will only ever hold court opinions implements it without writing a word about bills. Code that needs legislature facts asks for them — `S: Storage + LegislatureReader` — and a dataset arriving from another party is asked at run time, through `Storage::legislature`, which answers `None` for "not a concept here" rather than an empty list (#127).
 _Avoid_: Plugin, module, add-on

--- a/src/bin/words_to_data/score_amendments.rs
+++ b/src/bin/words_to_data/score_amendments.rs
@@ -12,7 +12,7 @@ use clap::Args as ClapArgs;
 use serde::Serialize;
 use words_to_data::dataset::Dataset;
 use words_to_data::diff::AmendmentSimilarity;
-use words_to_data::storage::Storage;
+use words_to_data::storage::{LegislatureReader, Storage};
 
 use crate::load::{self, with_dataset};
 use crate::span::Span;
@@ -74,7 +74,10 @@ pub fn run(args: Args) {
 
 /// Score every expression pair the span resolves to, returning the per-work
 /// scores and the total kept above the cutoff.
-fn score(args: &Args, dataset: &Dataset<impl Storage>) -> (Vec<ScoredWork>, usize) {
+fn score(
+    args: &Args,
+    dataset: &Dataset<impl Storage + LegislatureReader>,
+) -> (Vec<ScoredWork>, usize) {
     let bills: Vec<_> = crate::fail::or_exit(dataset.list_bill_ids(), "Error listing bills")
         .into_iter()
         .map(|id| {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -175,40 +175,12 @@ impl<S: Storage> Dataset<S> {
 
     // --- Delegate reader methods ---
 
-    pub fn get_bill(&self, bill_id: &str) -> Result<Option<Bill>, DatasetError> {
-        self.storage.get_bill(bill_id)
-    }
-
-    /// List the IDs of every bill in the dataset.
-    ///
-    /// Pair with [`Dataset::get_bill`] to iterate over all bills:
-    /// ```ignore
-    /// for id in dataset.list_bill_ids()? {
-    ///     let bill = dataset.get_bill(&id)?.unwrap();
-    /// }
-    /// ```
-    pub fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
-        self.storage.list_bill_ids()
-    }
-
     pub fn get_annotations(
         &self,
         from: &ExpressionId,
         to: &ExpressionId,
     ) -> Result<Option<Vec<ChangeAnnotation>>, DatasetError> {
         self.storage.get_annotations(from, to)
-    }
-
-    pub fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
-        self.storage.get_member(bioguide_id)
-    }
-
-    pub fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
-        self.storage.get_sponsor_info(bill_id)
-    }
-
-    pub fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
-        self.storage.get_bill_votes(bill_id)
     }
 
     pub fn compute_diff(
@@ -245,13 +217,6 @@ impl<S: Storage> Dataset<S> {
         self.storage.find_element(path)
     }
 
-    pub fn votes_by_member(
-        &self,
-        bioguide_id: &str,
-    ) -> Result<Vec<(HouseRollCall, VotePosition)>, DatasetError> {
-        self.storage.votes_by_member(bioguide_id)
-    }
-
     // --- Delegate DatasetWriter methods ---
 
     pub fn metadata(&self) -> &DatasetMetadata {
@@ -264,10 +229,6 @@ impl<S: Storage> Dataset<S> {
 
     pub fn add_expression(&mut self, expression: Expression) -> Result<(), DatasetError> {
         self.storage.add_expression(expression)
-    }
-
-    pub fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
-        self.storage.add_bill(bill)
     }
 
     /// Record a verbatim model reply and return its id.
@@ -288,18 +249,6 @@ impl<S: Storage> Dataset<S> {
     /// (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
     pub fn add_link(&mut self, link: Link) -> Result<(), DatasetError> {
         self.storage.add_link(link)
-    }
-
-    pub fn add_member(&mut self, member: Member) -> Result<(), DatasetError> {
-        self.storage.add_member(member)
-    }
-
-    pub fn add_sponsor_info(&mut self, info: SponsorInfo) -> Result<(), DatasetError> {
-        self.storage.add_sponsor_info(info)
-    }
-
-    pub fn add_bill_votes(&mut self, votes: BillVotes) -> Result<(), DatasetError> {
-        self.storage.add_bill_votes(votes)
     }
 
     /// Get paths that have annotations for an expression pair
@@ -344,6 +293,74 @@ impl<S: Storage> Dataset<S> {
         for child in &diff.child_diffs {
             Self::collect_paths_with_changes(child, paths);
         }
+    }
+}
+
+// --- Legislature extension ---
+//
+// One impl block per extension trait rather than a `where` clause on each of
+// the ten methods. The requirement is then stated once, in the place a reader
+// looks for it, and the block itself says which methods exist only because the
+// backend speaks the extension. Ten repetitions of the same clause says the
+// same thing to the compiler and less to a person (#127).
+//
+// The bound is not on the struct: a dataset of court opinions is a dataset, and
+// it keeps every core method above.
+
+/// Reading the legislature, for a dataset whose backend holds one.
+impl<S: Storage + LegislatureReader> Dataset<S> {
+    pub fn get_bill(&self, bill_id: &str) -> Result<Option<Bill>, DatasetError> {
+        self.storage.get_bill(bill_id)
+    }
+
+    /// List the IDs of every bill in the dataset.
+    ///
+    /// Pair with [`Dataset::get_bill`] to iterate over all bills:
+    /// ```ignore
+    /// for id in dataset.list_bill_ids()? {
+    ///     let bill = dataset.get_bill(&id)?.unwrap();
+    /// }
+    /// ```
+    pub fn list_bill_ids(&self) -> Result<Vec<String>, DatasetError> {
+        self.storage.list_bill_ids()
+    }
+
+    pub fn get_member(&self, bioguide_id: &str) -> Result<Option<Member>, DatasetError> {
+        self.storage.get_member(bioguide_id)
+    }
+
+    pub fn get_sponsor_info(&self, bill_id: &str) -> Result<Option<SponsorInfo>, DatasetError> {
+        self.storage.get_sponsor_info(bill_id)
+    }
+
+    pub fn get_bill_votes(&self, bill_id: &str) -> Result<Option<BillVotes>, DatasetError> {
+        self.storage.get_bill_votes(bill_id)
+    }
+
+    pub fn votes_by_member(
+        &self,
+        bioguide_id: &str,
+    ) -> Result<Vec<(HouseRollCall, VotePosition)>, DatasetError> {
+        self.storage.votes_by_member(bioguide_id)
+    }
+}
+
+/// Writing the legislature, for a dataset whose backend holds one.
+impl<S: Storage + LegislatureWriter> Dataset<S> {
+    pub fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
+        self.storage.add_bill(bill)
+    }
+
+    pub fn add_member(&mut self, member: Member) -> Result<(), DatasetError> {
+        self.storage.add_member(member)
+    }
+
+    pub fn add_sponsor_info(&mut self, info: SponsorInfo) -> Result<(), DatasetError> {
+        self.storage.add_sponsor_info(info)
+    }
+
+    pub fn add_bill_votes(&mut self, votes: BillVotes) -> Result<(), DatasetError> {
+        self.storage.add_bill_votes(votes)
     }
 }
 
@@ -688,7 +705,7 @@ impl<S: Storage> EvidenceWriter for Dataset<S> {
     }
 }
 
-impl<S: Storage> LegislatureReader for Dataset<S> {
+impl<S: Storage + LegislatureReader> LegislatureReader for Dataset<S> {
     fn get_bill(&self, id: &str) -> Result<Option<Bill>, DatasetError> {
         self.storage.get_bill(id)
     }
@@ -737,7 +754,7 @@ impl<S: Storage> LinkWriter for Dataset<S> {
     }
 }
 
-impl<S: Storage> LegislatureWriter for Dataset<S> {
+impl<S: Storage + LegislatureWriter> LegislatureWriter for Dataset<S> {
     fn add_bill(&mut self, bill: Bill) -> Result<(), DatasetError> {
         self.storage.add_bill(bill)
     }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -17,7 +17,7 @@ use crate::annotation::ChangeAnnotation;
 use crate::congress::{Party, PartyOnDate, VotePosition};
 use crate::dataset::{DatasetError, ExpressionId, Scope, SearchResult, WorkId};
 use crate::diff::TreeDiff;
-use crate::storage::Storage;
+use crate::storage::{LegislatureReader, Storage};
 use crate::uslm::USLMElement;
 
 /// Top-level summary of a dataset: its metadata plus headline counts.
@@ -119,7 +119,9 @@ pub struct BillListing {
 /// Without this a bill id could only be learned from outside the tool:
 /// `show-bill` demands one, `info` reports a count, and annotations carry ids
 /// but a dataset has none until `match-amendments` has run (#83).
-pub fn bills<S: Storage>(dataset: &S) -> Result<Vec<BillListing>, DatasetError> {
+pub fn bills<S: Storage + LegislatureReader>(
+    dataset: &S,
+) -> Result<Vec<BillListing>, DatasetError> {
     let mut ids = dataset.list_bill_ids()?;
     ids.sort();
 
@@ -467,7 +469,9 @@ pub struct ValidationReport {
 /// - every annotation's expression pair actually exists,
 /// - every annotation's `amendment_id` resolves to a real bill amendment,
 /// - every annotation path names an element present in some expression.
-pub fn validate<S: Storage>(dataset: &S) -> Result<ValidationReport, DatasetError> {
+pub fn validate<S: Storage + LegislatureReader>(
+    dataset: &S,
+) -> Result<ValidationReport, DatasetError> {
     let mut issues = Vec::new();
 
     // 1. Dates strictly ascending and unique *within each work*. Across works
@@ -829,7 +833,7 @@ fn action_str(action: &crate::legislature::AmendingAction) -> String {
 }
 
 /// Summarize a single bill's amendments, or `None` if the bill isn't present.
-pub fn show_bill<S: Storage>(
+pub fn show_bill<S: Storage + LegislatureReader>(
     dataset: &S,
     bill_id: &str,
 ) -> Result<Option<BillSummary>, DatasetError> {
@@ -897,7 +901,7 @@ pub struct RollCallTally {
 }
 
 /// Tally every roll call on one bill, or `None` if the bill has no votes here.
-pub fn votes<S: Storage>(
+pub fn votes<S: Storage + LegislatureReader>(
     dataset: &S,
     bill_id: &str,
 ) -> Result<Option<Vec<RollCallTally>>, DatasetError> {
@@ -958,7 +962,12 @@ pub fn votes<S: Storage>(
 }
 
 /// Summarize a dataset's metadata and contents.
-pub fn info<S: Storage>(dataset: &S) -> Result<DatasetInfo, DatasetError> {
+///
+/// [`LegislatureReader`] is required because [`DatasetInfo`] reports the bill,
+/// member, sponsor and vote counts as plain numbers, and a plain number cannot
+/// say "not a concept here". Reporting a documents-only dataset needs those
+/// fields to carry the difference, which is a wider change than #127 made.
+pub fn info<S: Storage + LegislatureReader>(dataset: &S) -> Result<DatasetInfo, DatasetError> {
     let meta = dataset.metadata();
     let scope = Scope::derive(dataset)?;
     // Counted, never loaded: a count query costs the same on a 2 GB dataset as

--- a/src/matching.rs
+++ b/src/matching.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use crate::dataset::Dataset;
 use crate::diff::{AmendmentSimilarity, MentionMatch, TreeDiff};
 use crate::legislature::AmendingAction;
-use crate::storage::Storage;
+use crate::storage::{LegislatureReader, Storage};
 
 /// A candidate US Code diff that an amendment might have caused.
 pub struct Candidate {
@@ -67,7 +67,7 @@ pub const DEFAULT_SIMILARITY_CUTOFF: f32 = 0.4;
 /// per path it used to return, so the cutoff is what holds the candidate volume
 /// down (#75).
 pub fn build_matches(
-    dataset: &Dataset<impl Storage>,
+    dataset: &Dataset<impl Storage + LegislatureReader>,
     diff: &TreeDiff,
     similarity_cutoff: f32,
 ) -> Vec<AmendmentMatch> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,8 +12,11 @@
 //!   only in datasets that hold legislative material. A dataset of court
 //!   opinions has none of them, and must not have to pretend otherwise.
 //!
-//! `Storage` is the full set that both first-party backends implement today. A
-//! backend that holds only documents implements [`DocumentReader`] alone.
+//! [`Storage`] is the core set, and it requires no extension: a backend that
+//! holds only documents and links implements it in full without naming a bill
+//! (#127). Both first-party backends add the legislature on top of it, and code
+//! that needs legislature facts asks for `S: Storage + LegislatureReader`. A
+//! backend that only reads documents implements [`DocumentReader`] alone.
 //!
 //! The unit a backend stores is an **expression**: one work as it read on one
 //! date, with its own tree. There is no table of release dates above it, so
@@ -350,20 +353,26 @@ pub trait LegislatureWriter {
     fn add_bill_votes(&mut self, votes: BillVotes) -> Result<(), DatasetError>;
 }
 
-/// The full set of capabilities, which both first-party backends provide.
+/// Everything a backend must answer, whatever document class it holds.
 ///
-/// Code that needs everything binds to this. Code that needs only documents
-/// should bind to [`DocumentReader`] instead, so it keeps working against a
-/// dataset that carries no legislative material.
+/// The core only: documents, links, and evidence, read and written. No
+/// extension is required here. A backend of court opinions implements this and
+/// writes nothing about bills, which is what `CONTEXT.md` and
+/// `docs/adr/0002-links-live-in-the-core.md` already claim of the data model
+/// (#127).
+///
+/// Code that needs legislature facts asks for them, and lets the compiler hold
+/// it: `S: Storage + LegislatureReader`. That bound is deliberately not given a
+/// cheaper form. Default method bodies returning empty were rejected, because
+/// then "this dataset holds no bills" and "bills are not a concept here" arrive
+/// as the same answer, and [`Scope`], [`Coverage::Gap`] and [`Exclusion`] exist
+/// to keep those apart.
+///
+/// [`Scope`]: crate::dataset::Scope
+/// [`Coverage::Gap`]: crate::dataset::Coverage::Gap
+/// [`Exclusion`]: crate::dataset::Exclusion
 pub trait Storage:
-    DocumentReader
-    + LinkReader
-    + EvidenceReader
-    + LegislatureReader
-    + DocumentWriter
-    + LinkWriter
-    + EvidenceWriter
-    + LegislatureWriter
+    DocumentReader + LinkReader + EvidenceReader + DocumentWriter + LinkWriter + EvidenceWriter
 {
     /// The legislature extension, when this dataset actually carries one.
     ///

--- a/tests/storage_traits_tests.rs
+++ b/tests/storage_traits_tests.rs
@@ -9,13 +9,25 @@
 //!
 //! Before the split that was impossible: `DatasetReader` demanded `get_bill`,
 //! `get_member`, `get_sponsor_info`, and `get_bill_votes` from every backend.
+//!
+//! `DocumentsAndLinks` goes further and implements the whole of `Storage`, which
+//! `DocumentsOnly` cannot: until #127 the `Storage` bound itself required the
+//! legislature extension, so a full backend had to answer six questions about
+//! bills to say nothing about bills. It names no bill, member, sponsor or vote,
+//! and the only thing it says about the legislature is that it has none.
+
+use std::collections::BTreeMap;
 
 use words_to_data::dataset::{
     Coverage, Dataset, DatasetError, DatasetMetadata, Expression, ExpressionId, ExpressionInfo,
-    SearchResult, WorkId,
+    ExpressionPair, SearchResult, WorkId,
 };
 use words_to_data::diff::TreeDiff;
-use words_to_data::storage::{DocumentReader, DocumentWriter, InMemoryStorage};
+use words_to_data::link::{Link, LinkKind, Provenance, Target, VerificationState};
+use words_to_data::storage::{
+    DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, InMemoryStorage,
+    LegislatureReader, LinkReader, LinkWriter, Storage,
+};
 use words_to_data::uslm::USLMElement;
 use words_to_data::uslm::bill_parser::parse_bill_amendments;
 use words_to_data::uslm::parser::parse;
@@ -209,6 +221,212 @@ fn should_report_out_of_scope_for_material_the_dataset_never_held() {
         scope.covers("uscode/title_26/subtitle_A/chapter_1/section_174"),
         Coverage::OutOfScope,
         "title 26 was never in this dataset"
+    );
+}
+
+/// A backend that holds documents and links, and nothing else.
+///
+/// This is the shape a judicial backend has: an opinion cites a provision, so
+/// links are needed, and there is no bill, member, sponsor or vote anywhere in
+/// the data. It implements every trait the `Storage` bound asks for, and it
+/// mentions the legislature exactly once — to say it holds none.
+///
+/// It delegates to real storage, so the data under test is the real corpus.
+struct DocumentsAndLinks(InMemoryStorage);
+
+impl DocumentReader for DocumentsAndLinks {
+    fn metadata(&self) -> &DatasetMetadata {
+        self.0.metadata()
+    }
+
+    fn works(&self) -> Result<Vec<WorkId>, DatasetError> {
+        self.0.works()
+    }
+
+    fn expressions(&self, work: &WorkId) -> Result<Vec<ExpressionInfo>, DatasetError> {
+        self.0.expressions(work)
+    }
+
+    fn get_expression(&self, id: &ExpressionId) -> Result<Option<Expression>, DatasetError> {
+        self.0.get_expression(id)
+    }
+
+    fn next_expression(&self, id: &ExpressionId) -> Result<Option<Expression>, DatasetError> {
+        self.0.next_expression(id)
+    }
+
+    fn prev_expression(&self, id: &ExpressionId) -> Result<Option<Expression>, DatasetError> {
+        self.0.prev_expression(id)
+    }
+
+    fn compute_diff(
+        &self,
+        from: &ExpressionId,
+        to: &ExpressionId,
+    ) -> Result<TreeDiff, DatasetError> {
+        self.0.compute_diff(from, to)
+    }
+
+    fn search_text(&self, query: &str) -> Result<Vec<SearchResult>, DatasetError> {
+        self.0.search_text(query)
+    }
+
+    fn find_element(&self, path: &str) -> Result<Vec<(ExpressionId, USLMElement)>, DatasetError> {
+        self.0.find_element(path)
+    }
+
+    fn has_element(&self, path: &str) -> Result<bool, DatasetError> {
+        self.0.has_element(path)
+    }
+}
+
+impl LinkReader for DocumentsAndLinks {
+    fn links_for_path(&self, path: &str) -> Result<Vec<Link>, DatasetError> {
+        self.0.links_for_path(path)
+    }
+
+    fn links_for_pair(
+        &self,
+        from: &ExpressionId,
+        to: &ExpressionId,
+    ) -> Result<Vec<Link>, DatasetError> {
+        self.0.links_for_pair(from, to)
+    }
+
+    fn links_by_kind(&self, kind: &str) -> Result<Vec<Link>, DatasetError> {
+        self.0.links_by_kind(kind)
+    }
+
+    fn links_by_namespace(&self, namespace: &str) -> Result<Vec<Link>, DatasetError> {
+        self.0.links_by_namespace(namespace)
+    }
+
+    fn links_for_object_prefix(&self, prefix: &str) -> Result<Vec<Link>, DatasetError> {
+        self.0.links_for_object_prefix(prefix)
+    }
+
+    fn link_pairs(&self) -> Result<Vec<ExpressionPair>, DatasetError> {
+        self.0.link_pairs()
+    }
+
+    fn count_links_by_kind(&self) -> Result<BTreeMap<String, usize>, DatasetError> {
+        self.0.count_links_by_kind()
+    }
+}
+
+impl EvidenceReader for DocumentsAndLinks {
+    fn get_reply(&self, id: &str) -> Result<Option<String>, DatasetError> {
+        self.0.get_reply(id)
+    }
+
+    fn replies(&self) -> Result<Vec<String>, DatasetError> {
+        self.0.replies()
+    }
+
+    fn count_replies(&self) -> Result<usize, DatasetError> {
+        self.0.count_replies()
+    }
+}
+
+impl DocumentWriter for DocumentsAndLinks {
+    fn set_metadata(&mut self, metadata: DatasetMetadata) {
+        self.0.set_metadata(metadata)
+    }
+
+    fn add_expression(&mut self, expression: Expression) -> Result<(), DatasetError> {
+        self.0.add_expression(expression)
+    }
+}
+
+impl LinkWriter for DocumentsAndLinks {
+    fn add_link(&mut self, link: Link) -> Result<(), DatasetError> {
+        self.0.add_link(link)
+    }
+}
+
+impl EvidenceWriter for DocumentsAndLinks {
+    fn add_reply(&mut self, reply: &str) -> Result<String, DatasetError> {
+        self.0.add_reply(reply)
+    }
+}
+
+impl Storage for DocumentsAndLinks {
+    /// No legislature at all, which is not the same answer as "no bills".
+    fn legislature(&self) -> Option<&dyn LegislatureReader> {
+        None
+    }
+}
+
+/// One opinion citing a provision of title 9, as a link of a kind the core
+/// stores and does not interpret.
+fn citation_link() -> Link {
+    Link {
+        subject: Target::Provision("uscode/title_9/chapter_1/section_3".to_string()),
+        kind: LinkKind::new(LinkKind::CITES),
+        object: Target::External {
+            reference: "judicial.opinion:us/570/1".to_string(),
+            display: "Opinion".to_string(),
+        },
+        provenance: Provenance {
+            source: "human:words_to_data tests".to_string(),
+            method: None,
+            verification: VerificationState::Asserted,
+            evidence: None,
+            raw_score: None,
+            timestamp: None,
+            corroboration: None,
+        },
+        payload: None,
+    }
+}
+
+/// The compiling witness for #127: a full `Storage` backend that says nothing
+/// about bills.
+///
+/// The assertions matter less than the fact that this file builds. `Dataset<S>`
+/// and the generic `inspect` readers both bind to `Storage`, so the test also
+/// proves that a legislature-free backend can be handed to them.
+#[test]
+fn should_implement_storage_without_the_legislature_extension() {
+    let mut storage = InMemoryStorage::new(DatasetMetadata {
+        name: "Documents and links".to_string(),
+        description: "One title and one citation, no bills".to_string(),
+        author: "words_to_data tests".to_string(),
+        source_urls: vec![],
+        license: "MIT".to_string(),
+        version: "1.0.0".to_string(),
+        ..Default::default()
+    });
+    storage
+        .add_expression(title_9_expression(None))
+        .expect("an expression should be added");
+
+    let mut dataset = Dataset::with_storage(DocumentsAndLinks(storage));
+    dataset
+        .add_link(citation_link())
+        .expect("the citation should be added");
+
+    // The core readers answer, through the generic code that used to demand the
+    // legislature extension as well.
+    assert_eq!(
+        words_to_data::inspect::expressions(&dataset, None)
+            .expect("expressions should list")
+            .len(),
+        1
+    );
+    assert_eq!(
+        dataset
+            .links_by_namespace("judicial")
+            .expect("links should list")
+            .len(),
+        1,
+        "a link of a kind the core does not interpret is still stored and returned"
+    );
+
+    // And the one thing it says about the legislature is that it has none.
+    assert!(
+        dataset.legislature().is_none(),
+        "a documents-and-links backend holds no legislative material"
     );
 }
 


### PR DESCRIPTION
Closes nothing. Implements #127, which stays open for the maintainer.

## What changed

`Storage` required the legislature extension:

```rust
pub trait Storage:
    DocumentReader + LinkReader + EvidenceReader
    + LegislatureReader          // an extension, required of every backend
    + DocumentWriter + LinkWriter + EvidenceWriter
    + LegislatureWriter
```

It now requires the core only:

```rust
pub trait Storage:
    DocumentReader + LinkReader + EvidenceReader + DocumentWriter + LinkWriter + EvidenceWriter
```

Code that needs legislature facts asks for them: `S: Storage + LegislatureReader`. The run-time door `Storage::legislature` is untouched, and still answers `None` for a dataset that carries no legislature at all.

**`LegislatureWriter` left the bound as well as `LegislatureReader`.** The issue names the reader, but the acceptance criterion asks for a witness that "does not mention bills, members, sponsors or votes", and `LegislatureWriter` is `add_bill`, `add_member`, `add_sponsor_info` and `add_bill_votes`. Dropping only the reader would have left a judicial backend writing four methods about bills to say nothing about bills, which is the same fault with a smaller number. This is the one decision the brief did not settle.

Default method bodies stay rejected, and the trait now says why, so the cheap form is not put back by accident: a default that answers empty makes "this dataset holds no bills" and "bills are not a concept here" the same answer, and `Scope`, `Coverage::Gap` and `Exclusion` exist to keep those apart.

## Call-site churn

Seven generic call sites gained `+ LegislatureReader`:

| File | Site |
| --- | --- |
| `src/inspect.rs` | `bills`, `validate`, `show_bill`, `votes`, `info` |
| `src/matching.rs` | `build_matches` |
| `src/bin/words_to_data/score_amendments.rs` | `score` |

Nothing else needed it. Four `inspect` readers (`expressions`, `path_report`, `diff`, `coverage`, `search`, `annotations`) keep the plain `Storage` bound, the `with_dataset!` macro needed no change because it expands over two concrete backends that both hold a legislature, and the three `store_annotation<S: Storage>` helpers in the test suite write links only. The churn was much smaller than the issue expected.

`info` is the one uncomfortable one. It is not a legislature command, but `DatasetInfo` reports the counts as plain `usize`, and a `usize` cannot say "not a concept here". Reporting a documents-only dataset needs those fields to carry an absence, which is wider than this issue. Filed as #133, with a note on `info` itself saying so.

## Dataset: one impl block per extension trait, not a per-method `where`

The brief asked which and why. `Dataset<S>` keeps the plain `Storage` bound on the struct — a dataset of court opinions is a dataset, and it keeps every core method. Its ten legislature methods moved into two blocks:

```rust
impl<S: Storage + LegislatureReader> Dataset<S> { /* get_bill, list_bill_ids, ... */ }
impl<S: Storage + LegislatureWriter> Dataset<S> { /* add_bill, add_member, ... */ }
```

rather than a `where S: LegislatureReader` on each of the ten. Callers cannot tell the two apart — both give "the method exists, but its trait bounds were not satisfied" — so the choice is a readability one, and `CLAUDE.md` ranks readability first. The block states the requirement once, in the place a reader looks for it, and says which methods exist only because the backend speaks the extension. Ten copies of the same clause say the same thing to the compiler and less to a person.

The two trait impls followed: `impl<S: Storage + LegislatureReader> LegislatureReader for Dataset<S>`, and the same for the writer.

## Test evidence

**The compiling witness** is `DocumentsAndLinks` in `tests/storage_traits_tests.rs`, beside the existing `DocumentsOnly` backend and following its pattern. It implements the whole of `Storage` — `DocumentReader`, `LinkReader`, `EvidenceReader`, `DocumentWriter`, `LinkWriter`, `EvidenceWriter` — and names no bill, member, sponsor or vote. The only thing it says about the legislature is `fn legislature(&self) -> Option<&dyn LegislatureReader> { None }`, which is the honest statement the issue asked for. It delegates to `InMemoryStorage`, so the data under test is the real corpus: title 9 from `tests/test_data/usc/2025-07-18/usc09.xml`, plus one `judicial.cites` link of a kind the core stores and does not interpret.

`should_implement_storage_without_the_legislature_extension` then hands it to `Dataset` and to `inspect::expressions`, which is where the old bound used to be picked up for free.

It was a real RED. Before the change:

```
$ rtk proxy cargo test --test storage_traits_tests
error[E0277]: the trait bound `DocumentsAndLinks: LegislatureReader` is not satisfied
    --> tests/storage_traits_tests.rs:235:1
note: required by a bound in `Storage`
    --> src/storage/mod.rs:362:7
 362 |     + LegislatureReader
     |       ^^^^^^^^^^^^^^^^^ required by this bound in `Storage`
error: could not compile `words-to-data` (test "storage_traits_tests") due to 2 previous errors
```

After: `6 passed; 0 failed`.

**Full suite**: `rtk proxy cargo test -p words-to-data --no-fail-fast` — exit 0, 42 binaries, **350 passed, 0 failed, 7 ignored**. Baseline was 349 passed, 0 failed, 7 ignored; the extra pass is the witness.

`cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` both exit 0.

**Commands, on a copy of the real 1.9 GB schema-7 dataset** (copied aside, because `SqliteStorage::open` writes to the file it opens):

| Command | Result |
| --- | --- |
| `info` | 58 works, 116 expressions, 5 bills, 899 links, 435 members, 5 sponsors, 3 roll calls, 1297 votes |
| `bills` | 5 bills, `119-hr-1` with 603 amendments, all with changes |
| `show-bill 119-hr-42` | 1 amendment, amending text intact |
| `votes 119-hr-1` | roll call 190, 212 Democrat Nay / 218 Republican Yea / 2 Republican Nay |
| `annotations --bill 119-hr-1` | annotations listed with paths and provenance |
| `coverage` on title 10 | 11 changed paths, 5 annotated, 45.5% |

`info` still reports the legislature counts, which was an acceptance criterion.

## No schema change

`SCHEMA_VERSION` stays at 7. Nothing about stored data moved: this is a trait-shape change, and the real dataset above was read by this build without a rebuild.

## Docs

`CONTEXT.md`'s **Extension** entry carried a bold paragraph beginning "The storage layer does not yet hold that line". It is now true, so the paragraph says so instead, in one sentence about where the requirement lives and one about the run-time door. The module doc on `src/storage/mod.rs` and the doc on `Storage` were updated to match.

## A note for whoever runs CI

Six `tests/sqlite_tests.rs` tests failed twice during this work, with `SchemaVersionMismatch { found: 1, expected: 7 }` and then with data that did not match. The cause is not in this diff: those tests write to hardcoded shared paths (`/tmp/test_dataset.db`, `/tmp/test_trait_query.db`, and four more), and there are nine agent worktrees on this machine right now whose `SCHEMA_VERSION` ranges from 6 to 8. They pass every time in isolation, and the clean full run above has them green. Worth a separate issue if agents keep running in parallel.
