### PR TITLE
fix: give a numberless container a readable path segment, and recognise <article>

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,13 +53,14 @@ _Avoid_: Section, node, element
 **Structural path**:
 The address of an element, derived from the hierarchy that the parser found. It locates a Provision at one point in time. It does not identify one. Two provisions can share one path: the law sometimes numbers two provisions alike, and the document records both. A path and a position together locate one provision within one Expression. They still do not identify it.
 
-Independence from the source document holds only where an element carries a number. Where it carries none, the segment falls back to the one identifier the source does supply — the element's XML id — and the path becomes something no person can read or type:
+Independence from the source document holds only where an element carries a number. A container that groups a body of law usually carries none: the Federal Rules sit in a `courtRules` element with no number of its own. Such a container takes its segment from the publisher instead — first from the `identifier` attribute, reduced to its last segment, and where there is no identifier, from the heading, which is the only name the publisher gives it:
 
 ```
-uscode/appendix_28a/level_id2e47c0a6-b17c-11ef-b971-e82c9e4f66ce/title_I/level_1
+uscode/appendix_28a/level_Civil/title_I/level_1
+uscode/appendix_11a/level_federal-rules-of-bankruptcy-procedure
 ```
 
-**The exception is common, not marginal.** The regenerated dataset holds **14,484** such paths: 12,748 in the four US Code appendices, and **1,736 across nine ordinary titles**, including 792 in title 29 and 286 in title 38. So a reader naming a provision in labour or veterans' law may have to quote a uuid to do it. #115 is the work, and #122 will add more of them.
+**This is common, not marginal.** 118 containers per release point carry no identifier and take their segment from a heading, and a dataset built from the two committed release points holds **6,962** paths at or below one, across thirteen works. Per release point: 2,363 in the title 11 appendix, 240 in the title 28 appendix, 396 in title 29, 143 in title 38, 132 in title 25, 99 in title 19 and 77 in title 12. Those segments are readable, but they are only as stable as the publisher's wording. Where the publisher rewords a heading, every path below it moves.
 _Avoid_: Path, breadcrumb
 
 **USLM ID**:

--- a/docs/adr/0001-structural-paths-locate-not-identify.md
+++ b/docs/adr/0001-structural-paths-locate-not-identify.md
@@ -12,13 +12,15 @@ So this ADR records an accepted decision and a partly-built one. #93 is the work
 
 ### A gap this ADR did not anticipate
 
-A derived path was meant to owe the source document nothing. It does, where an element carries a number. Where an element carries **no** number the path segment falls back to the element's XML id, so the address becomes unreadable:
+A derived path was meant to owe the source document nothing. It does, where an element carries a number. Where an element carries **no** number — which is the usual case for a container that groups a body of law — the segment has to come from the source. It used to fall back to the element's XML id, and **14,484** paths in the dataset read like this, of which 1,736 sat in nine ordinary titles:
 
 ```
 uscode/appendix_28a/level_id2e47c0a6-b17c-11ef-b971-e82c9e4f66ce/title_I/level_1
 ```
 
-This is common rather than marginal: **14,484** such paths in the regenerated dataset, of which 1,736 sit in nine ordinary titles, including 792 in title 29. It does not weaken the decision — an unreadable locator is still a locator — but it does mean a person cannot always name a provision to ask about it, which is a cost this ADR never counted. #115 holds the decision about what a numberless container should contribute to a path, and #122 will add more of them.
+#115 replaced that with the publisher's own name for the container: the `identifier` attribute reduced to its last segment, and where there is none, the heading. No uuid segment remains in a dataset built from the committed release points, and Rule 1 of the Federal Rules of Civil Procedure is now at `uscode/appendix_28a/level_Civil/title_I/level_1`.
+
+The dependence is smaller but it did not go away, and where the segment comes from a heading it took a new shape. **6,962** paths across the two committed release points sit at or below a container named by its heading, in thirteen works, the largest groups being the title 11 appendix, title 29, the title 28 appendix and title 38. A heading is stable against a sibling being inserted above the container, which is why it was preferred to numbering by position, but it is not stable against the publisher rewording it. That is the same class of movement this ADR already describes for `Redesignate` and `Move`, and the same answer applies: a locator moves, and only a minted identity does not.
 
 Legal sources often supply no usable identifier, so we derive a structural path from the hierarchy the parser found, such as `uscode/title_26/subtitle_F/chapter_61/subchapter_A/part_III/subpart_B/section_6041/subsection_d`. This works well against messy documents and we keep it. But a derived path is an address, and an address changes. `AmendingAction` already contains `Redesignate` and `Move` (`src/uslm/mod.rs`), which are exactly the operations that keep a provision alive and move it. A path also changes when our own parser improves.
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -44,6 +44,13 @@ use crate::uslm::bill_parser::Bill;
 /// break. Both on-disk forms carry this number and refuse a file that does not
 /// match, because a break that is not loud reads as an empty dataset.
 ///
+/// 8 gives a container that carries no number a readable path segment, from the
+/// publisher's `identifier` or heading in place of an XML uuid, and holds the
+/// Federal Rules of Evidence, which `<article>` grouped under a name the parser
+/// did not know (#115, #122). No column changes. The number still goes up: a
+/// path is what `element_index` is keyed on and what `Target::Provision` names,
+/// so a dataset built with uuid paths, read by a build that generates readable
+/// ones, would find nothing and say nothing.
 /// 7 dates a member's party: the whole party history is kept, in place of the
 /// one undated field that reported a 2025 vote through a 2026 affiliation
 /// (#105).
@@ -61,7 +68,7 @@ use crate::uslm::bill_parser::Bill;
 /// bumping this would have rejected valid JSON datasets to fix a SQLite table.
 /// That case is caught where it happens, when the database is opened, rather
 /// than here. A change that alters both forms still belongs to this number.
-pub const SCHEMA_VERSION: i32 = 7;
+pub const SCHEMA_VERSION: i32 = 8;
 
 /// Reading the documents a dataset holds.
 ///

--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -243,13 +243,16 @@ impl std::str::FromStr for ElementType {
             // carries no number of its own, so each one reads as a level: the
             // Federal Rules sit in `courtRules`, one rule in `courtRule`, an act
             // reprinted in an appendix in `compiledAct`, and the reorganization
-            // plans in `reorganizationPlans` and `reorganizationPlan`. They group
-            // law; they are not a new unit of law (#110).
+            // plans in `reorganizationPlans` and `reorganizationPlan`. An
+            // `article` groups the rules of the Federal Rules of Evidence, which
+            // were absent from every dataset while the name was unknown (#122).
+            // They group law; they are not a new unit of law (#110).
             "courtrules"
             | "courtrule"
             | "compiledact"
             | "reorganizationplans"
-            | "reorganizationplan" => Ok(Self::Level),
+            | "reorganizationplan"
+            | "article" => Ok(Self::Level),
             "publiclaw" | "public_law" | "plaw" => Ok(Self::PublicLawDocument),
             "uscode" | "us_code" | "uscdoc" => Ok(Self::USCodeDocument),
             "appendix" => Ok(Self::Appendix),

--- a/src/uslm/parser.rs
+++ b/src/uslm/parser.rs
@@ -6,7 +6,8 @@ use crate::{
     io::load_xml_file,
     uslm::{
         self, BillType, DocumentType, ElementData, ElementType, RefPair, SourceCredit, USCType,
-        USLMElement, USLMError, path::should_include_in_uslm_path,
+        USLMElement, USLMError,
+        path::{path_segment_from_heading, should_include_in_uslm_path},
     },
 };
 
@@ -745,6 +746,67 @@ fn parse_element(
     Ok(element)
 }
 
+/// True when an element inside a heading annotates the name, rather than being
+/// part of it.
+///
+/// A heading can carry a footnote: the raised number that points at it, and the
+/// footnote text itself. Both sit inside `<heading>`, so text collected from the
+/// whole element reads as part of the container's name when it is not. One
+/// heading in the title 28 appendix runs to 313 characters this way.
+fn is_footnote(node: &roxmltree::Node) -> bool {
+    node.has_tag_name("note") || check_attr(node, "class", "footnoteRef")
+}
+
+/// The text of a node's `<heading>`, with any footnote left out.
+fn heading_text_without_footnotes(node: &roxmltree::Node) -> Option<String> {
+    fn collect(node: &roxmltree::Node, into: &mut String) {
+        for child in node.children() {
+            if child.is_text() {
+                into.push_str(child.text().unwrap_or_default());
+            } else if child.is_element() && !is_footnote(&child) {
+                collect(&child, into);
+            }
+        }
+    }
+
+    let heading = node.children().find(|n| n.has_tag_name("heading"))?;
+    let mut text = String::new();
+    collect(&heading, &mut text);
+    Some(text)
+}
+
+/// The number value for a container that carries no `<num>`.
+///
+/// A container that groups a body of law often has no number of its own: the
+/// Federal Rules sit in `courtRules`, and an unnumbered `level` gathers sections
+/// under a heading. Three sources are tried, best first (#115):
+///
+/// 1. The publisher's `identifier`, reduced to its last segment, so
+///    `/us/usc/t28a/courtRules/Civil` gives `Civil`.
+/// 2. The publisher's `<heading>`, reduced to a path segment, so `FEDERAL RULES
+///    OF BANKRUPTCY PROCEDURE` gives `federal-rules-of-bankruptcy-procedure`.
+/// 3. The XML `id`, which is a uuid no person can read or type. No container in
+///    the committed release points reaches this.
+///
+/// Numbering by position was rejected. It reads like a number the publisher
+/// gave, and every path below the container moves when the publisher inserts a
+/// sibling above it.
+fn numberless_container_value(node: &roxmltree::Node) -> Option<String> {
+    let from_identifier = node
+        .attribute("identifier")
+        .and_then(|identifier| identifier.rsplit('/').next())
+        .filter(|segment| !segment.is_empty())
+        .map(String::from);
+
+    from_identifier
+        .or_else(|| {
+            heading_text_without_footnotes(node)
+                .as_deref()
+                .and_then(path_segment_from_heading)
+        })
+        .or_else(|| node.attribute("id").map(String::from))
+}
+
 pub fn extract_number(element_type: ElementType, node: &roxmltree::Node) -> Result<Number> {
     // Extract <number> tag data
     match node.children().find(|n| n.has_tag_name("num")) {
@@ -790,13 +852,13 @@ pub fn extract_number(element_type: ElementType, node: &roxmltree::Node) -> Resu
                         display: String::new(),
                     })
                 }
-                ElementType::Level => match node.attribute("id") {
+                ElementType::Level => match numberless_container_value(node) {
                     None => Err(ParseError::UnableToParseElement(
-                        "<Level> element has neither a <num> or <id> field".to_string(),
+                        "<Level> element has no <num>, identifier, heading or id".to_string(),
                     )),
-                    Some(n) => Ok(Number {
-                        value: String::from(n),
-                        display: format!("Level {}", n),
+                    Some(value) => Ok(Number {
+                        display: format!("Level {}", value),
+                        value,
                     }),
                 },
                 _ => Err(ParseError::UnableToParseElement(format!(

--- a/src/uslm/path.rs
+++ b/src/uslm/path.rs
@@ -32,6 +32,52 @@ pub fn covers_path(prefix: &str, path: &str) -> bool {
     path == prefix || path.starts_with(&format!("{prefix}/"))
 }
 
+/// A path segment made from a container's heading.
+///
+/// Some containers carry no number and no `identifier`, and the only name the
+/// publisher gives them is their heading. The U.S. Code prints them that way
+/// too, so the heading is what a person would type (#115).
+///
+/// Keeps ASCII letters and digits, lowercases them, and writes every other run
+/// of characters as a single `-`, so that nothing outside `[a-z0-9-]` can reach
+/// a path. Returns `None` where the heading holds no letter or digit at all,
+/// because an empty segment would name the container's parent instead.
+///
+/// # Examples
+///
+/// ```
+/// use words_to_data::uslm::path::path_segment_from_heading;
+///
+/// assert_eq!(
+///     path_segment_from_heading("FEDERAL RULES OF BANKRUPTCY PROCEDURE").as_deref(),
+///     Some("federal-rules-of-bankruptcy-procedure")
+/// );
+///
+/// // Punctuation and repeated separators collapse to one dash.
+/// assert_eq!(
+///     path_segment_from_heading("Insolvency, Receivership, and Liquidation").as_deref(),
+///     Some("insolvency-receivership-and-liquidation")
+/// );
+///
+/// // A heading with nothing to name by.
+/// assert_eq!(path_segment_from_heading("  —  "), None);
+/// ```
+pub fn path_segment_from_heading(heading: &str) -> Option<String> {
+    let mut segment = String::new();
+    for character in heading.chars() {
+        if character.is_ascii_alphanumeric() {
+            segment.push(character.to_ascii_lowercase());
+        } else if !segment.ends_with('-') {
+            segment.push('-');
+        }
+    }
+    let segment = segment.trim_matches('-');
+    match segment.is_empty() {
+        true => None,
+        false => Some(segment.to_string()),
+    }
+}
+
 /// Determines if an element type should be included in the USLM path
 ///
 /// Returns true for elements that are part of the official USLM identifier scheme,

--- a/tests/appendix_container_tests.rs
+++ b/tests/appendix_container_tests.rs
@@ -9,6 +9,11 @@
 //!
 //! A dropped leaf is correct: a table of contents is not law. A dropped
 //! container is data loss, so the parser now reports it.
+//!
+//! A container that groups law carries no number of its own, and the path
+//! segment for it used to fall back to the element's XML uuid. It now comes from
+//! the publisher's `identifier`, or from the publisher's heading where there is
+//! no identifier (#115).
 
 use rstest::rstest;
 use words_to_data::dataset::{Dataset, DatasetMetadata};
@@ -27,8 +32,27 @@ const USC09: &str = "tests/test_data/usc/2025-07-18/usc09.xml";
 const RULE_1_TEXT: &str =
     "These rules govern the procedure in all civil actions and proceedings in the United States";
 
+/// Rule 401 of the Federal Rules of Evidence, which no dataset held while
+/// `<article>` was a name the parser did not know (#122).
+const RULE_401_TEXT: &str = "Evidence is relevant if";
+
 fn element_count(element: &USLMElement) -> usize {
     1 + element.children.iter().map(element_count).sum::<usize>()
+}
+
+fn collect_paths(element: &USLMElement, into: &mut Vec<String>) {
+    into.push(element.data.path.to_string());
+    for child in &element.children {
+        collect_paths(child, into);
+    }
+}
+
+fn paths_of(file: &str) -> Vec<String> {
+    let path = format!("tests/test_data/usc/{RELEASE}/{file}");
+    let root = parse(&path, RELEASE).unwrap_or_else(|e| panic!("{file} should parse: {e}"));
+    let mut paths = Vec::new();
+    collect_paths(&root, &mut paths);
+    paths
 }
 
 fn metadata() -> DatasetMetadata {
@@ -47,7 +71,7 @@ fn metadata() -> DatasetMetadata {
 /// the fix produces, so the test fails on a regression rather than on an edit
 /// to one rule.
 #[rstest]
-#[case("usc28a.xml", 2000)]
+#[case("usc28a.xml", 3000)]
 #[case("usc11a.xml", 2000)]
 #[case("usc18a.xml", 1000)]
 #[case("usc05A.xml", 100)]
@@ -81,31 +105,144 @@ fn should_find_federal_rules_of_civil_procedure_text_when_the_appendix_is_search
 }
 
 #[test]
-fn should_report_a_dropped_container_when_an_unknown_element_holds_structural_children() {
+fn should_find_federal_rules_of_evidence_text_when_the_appendix_is_searched() {
+    let mut dataset = Dataset::new(metadata());
+    dataset
+        .add_uslm_xml(USC28A, RELEASE, None)
+        .expect("the title 28 appendix should parse");
+
+    let hits = inspect::search(&dataset, RULE_401_TEXT).expect("search the dataset");
+
+    assert!(
+        !hits.is_empty(),
+        "Rule 401 of the Federal Rules of Evidence should be searchable"
+    );
+}
+
+/// `article` groups the rules of the Federal Rules of Evidence. While the parser
+/// did not know the name it dropped each article with the rules below it, and
+/// #113's report said so. The name is known now, so nothing is dropped and there
+/// is nothing to report (#122).
+#[test]
+fn should_report_no_dropped_container_when_the_appendix_holds_only_known_containers() {
     let (_root, report) = parse_with_report(USC28A, RELEASE).expect("the appendix should parse");
 
-    // `article` groups the Federal Rules of Evidence. The parser does not know
-    // the name, so it drops the article and the law below it — and now says so.
-    let article = report
-        .dropped_containers
-        .iter()
-        .find(|dropped| dropped.element_name == "article")
-        .unwrap_or_else(|| {
-            panic!(
-                "the dropped articles should be reported, got {:?}",
-                report.dropped_containers
-            )
-        });
+    assert!(
+        report.is_empty(),
+        "every container in the title 28 appendix should be known, got {:?}",
+        report.dropped_containers
+    );
+}
+
+/// The eleven articles of the Federal Rules of Evidence, each holding its rules.
+#[test]
+fn should_hold_the_articles_of_the_federal_rules_of_evidence_when_the_appendix_is_parsed() {
+    let root = parse(USC28A, RELEASE).expect("the appendix should parse");
+
+    let evidence = root
+        .find("uscode/appendix_28a/level_Evid")
+        .expect("the Federal Rules of Evidence should be in the tree");
+
+    assert_eq!(
+        evidence.children.len(),
+        11,
+        "the Federal Rules of Evidence hold eleven articles"
+    );
+    assert!(
+        root.find("uscode/appendix_28a/level_Evid/level_IV/level_401")
+            .is_some(),
+        "Rule 401 should sit under Article IV"
+    );
+}
+
+/// The publisher writes `identifier="/us/usc/t28a/courtRules/Civil"` on the
+/// container that holds the Federal Rules of Civil Procedure, and no `<num>`.
+/// Rule 1 used to sit under `level_id2e47c0a6-b17c-11ef-b971-e82c9e4f66ce`.
+#[test]
+fn should_name_a_container_from_the_publisher_identifier_when_it_carries_no_number() {
+    let root = parse(USC28A, RELEASE).expect("the appendix should parse");
+
+    let rule_1 = root
+        .find("uscode/appendix_28a/level_Civil/title_I/level_1")
+        .expect("Rule 1 of the Federal Rules of Civil Procedure should be at a typable path");
+
+    assert_eq!(
+        rule_1.data.heading.as_deref().map(str::trim),
+        Some("Scope and Purpose")
+    );
+}
+
+/// The container holding the Federal Rules of Bankruptcy Procedure carries no
+/// number and no `identifier`. Its heading is the only name the publisher gives
+/// it, and the U.S. Code prints it that way, so the path segment comes from
+/// there.
+#[test]
+fn should_name_a_container_from_its_heading_when_the_publisher_supplies_no_identifier() {
+    let root = parse(
+        &format!("tests/test_data/usc/{RELEASE}/usc11a.xml"),
+        RELEASE,
+    )
+    .expect("the title 11 appendix should parse");
 
     assert!(
-        article.structural_children > 0,
-        "a reported container should say how much law went with it"
+        root.find("uscode/appendix_11a/level_federal-rules-of-bankruptcy-procedure")
+            .is_some(),
+        "the Federal Rules of Bankruptcy Procedure should be at a typable path"
     );
+}
+
+/// A heading can carry a footnote, and the footnote is not part of the name. One
+/// heading in the title 28 appendix runs to 313 characters with its footnote
+/// attached, which is no more typable than the uuid it replaces.
+#[test]
+fn should_leave_a_footnote_out_of_a_segment_taken_from_a_heading() {
+    let root = parse(USC28A, RELEASE).expect("the appendix should parse");
+
     assert!(
-        article.parent_path.starts_with("uscode/appendix_28a"),
-        "a reported container should say where it sat, got {}",
-        article.parent_path
+        root.find(
+            "uscode/appendix_28a/level_Civil/\
+             level_supplemental-rules-for-admiralty-or-maritime-claims-and-asset-forfeiture-actions"
+        )
+        .is_some(),
+        "the supplemental admiralty rules should be named without their footnote"
     );
+}
+
+/// The four appendices carry most of the numberless containers, and nine
+/// ordinary titles carry the rest. Titles 12, 29 and 38 hold the largest share
+/// of the ordinary-title cases, and none of them is an obscure corner.
+#[rstest]
+#[case("usc28a.xml")]
+#[case("usc11a.xml")]
+#[case("usc18a.xml")]
+#[case("usc05A.xml")]
+#[case("usc12.xml")]
+#[case("usc29.xml")]
+#[case("usc38.xml")]
+fn should_hold_no_uuid_path_when_a_release_point_is_parsed(#[case] file: &str) {
+    let uuid_paths: Vec<String> = paths_of(file)
+        .into_iter()
+        .filter(|path| path.contains("level_id"))
+        .take(3)
+        .collect();
+
+    assert!(
+        uuid_paths.is_empty(),
+        "{file} should hold no uuid path, got {uuid_paths:?}"
+    );
+}
+
+/// Title 26 is the control. It holds no numberless container the parser reaches
+/// and no `<article>`, so neither change may touch it. 57,391 elements is the
+/// count the dataset holds at this release point.
+#[test]
+fn should_leave_a_title_with_no_numberless_container_unchanged() {
+    let root = parse(&format!("tests/test_data/usc/{RELEASE}/usc26.xml"), RELEASE)
+        .expect("title 26 should parse");
+
+    // The `uscode` container is not one of the title's own elements.
+    let count = element_count(&root) - 1;
+    assert_eq!(count, 57_391, "title 26 at {RELEASE} holds 57,391 elements");
 }
 
 #[test]

--- a/tests/path_tests.rs
+++ b/tests/path_tests.rs
@@ -1,5 +1,7 @@
 use words_to_data::uslm::ElementType;
-use words_to_data::uslm::path::{generate_structural_path, should_include_in_uslm_path};
+use words_to_data::uslm::path::{
+    generate_structural_path, path_segment_from_heading, should_include_in_uslm_path,
+};
 
 #[test]
 fn test_generate_structural_path_nested_element() {
@@ -20,4 +22,25 @@ fn test_should_include_in_uslm_path_level() {
 #[test]
 fn test_should_include_in_uslm_path_unknown() {
     assert!(!should_include_in_uslm_path(ElementType::Unknown));
+}
+
+/// A segment goes into a path, so nothing outside `[a-z0-9-]` may survive. The
+/// section symbol and the curly apostrophe both appear in real headings.
+#[test]
+fn should_keep_only_path_safe_characters_when_a_heading_becomes_a_segment() {
+    let segment = path_segment_from_heading(
+        "SUPPLEMENTAL RULES FOR SOCIAL SECURITY ACTIONS UNDER 42 U.S.C. \u{a7} 405(g)",
+    )
+    .expect("the heading names the container");
+
+    assert_eq!(
+        segment,
+        "supplemental-rules-for-social-security-actions-under-42-u-s-c-405-g"
+    );
+}
+
+/// An empty segment would name the container's parent, so there has to be none.
+#[test]
+fn should_give_no_segment_when_a_heading_holds_no_letter_or_digit() {
+    assert_eq!(path_segment_from_heading("\u{2014} \u{2014}"), None);
 }

--- a/tests/schema_version_tests.rs
+++ b/tests/schema_version_tests.rs
@@ -88,27 +88,28 @@ fn should_refuse_a_dataset_written_by_a_different_schema() {
     }
 }
 
-/// Dating a member's party changed a type written into every form of the file,
-/// so a dataset from the build before it must be refused by name (#105).
+/// Giving a numberless container a readable path segment changed the paths that
+/// `element_index` is keyed on, so a dataset from the build before it must be
+/// refused by name (#115).
 #[test]
 fn should_refuse_a_dataset_written_at_the_previous_schema() {
-    assert_eq!(SCHEMA_VERSION, 7, "the member party history is schema 7");
+    assert_eq!(SCHEMA_VERSION, 8, "readable container paths are schema 8");
 
-    let path = written_dataset("schema_six");
+    let path = written_dataset("schema_seven");
     let conn = Connection::open(&path).expect("the file should open directly");
-    conn.execute("UPDATE schema_version SET version = 6", [])
+    conn.execute("UPDATE schema_version SET version = 7", [])
         .expect("the version should update");
     drop(conn);
 
     match SqliteStorage::open(&path) {
         Err(DatasetError::SchemaVersionMismatch { found, expected }) => {
-            assert_eq!(found, 6);
-            assert_eq!(expected, 7);
+            assert_eq!(found, 7);
+            assert_eq!(expected, 8);
             let message = DatasetError::SchemaVersionMismatch { found, expected }.to_string();
             assert!(message.contains("regenerate"), "got: {message}");
         }
         Err(other) => panic!("the failure should name the schema, got {other}"),
-        Ok(_) => panic!("a dataset written before the party history must not open"),
+        Ok(_) => panic!("a dataset written with uuid paths must not open"),
     }
 }
 


### PR DESCRIPTION
Closes nothing on its own — #115 and #122 stay open until a maintainer closes them.

## What changed

A container that groups a body of law carries no number of its own. The structural-path segment for it fell back to the element's XML uuid, so `element_index` held 14,484 paths no person could read or type.

The segment now comes from the publisher, in this order:

1. The `identifier` attribute, reduced to its last segment. `/us/usc/t28a/courtRules/Civil` gives `Civil`.
2. The `<heading>`, reduced to a path segment. `FEDERAL RULES OF BANKRUPTCY PROCEDURE` gives `federal-rules-of-bankruptcy-procedure`. A footnote inside the heading is left out: one heading in the title 28 appendix runs to 313 characters with its footnote attached, which is no more typable than the uuid it replaces.
3. The XML `id`, as before. **No container in the committed release points reaches this.**

`<article>` is now a container, the same treatment #113 gave `courtRules`, `compiledAct` and `reorganizationPlans`. It groups the rules of the Federal Rules of Evidence, which were absent from every dataset while the name was unknown (#122).

`SCHEMA_VERSION` goes from 7 to 8. No column changes, but a path is what `element_index` is keyed on, so a dataset built with uuid paths read by this build would find nothing and say nothing.

`covers_path` is untouched. `DocumentType` is untouched. `ElementType` gains no variant — `article` maps to `Level`, like the other containers.

## The fallback, and how far it reaches

**The fallback is the heading, not numbering by position.** Numbering by position was rejected. It reads like a number the publisher gave, and it moves every path below a container when the publisher inserts a sibling above it. A heading does not move for that reason. It moves when the publisher rewords the heading, which is a change a reader can see, and it is the same class of movement `docs/adr/0001` already records for `Redesignate` and `Move`.

**This is not a handful.** Measured on both committed release points:

| | containers per release point | elements at or below one, per release point |
| --- | --- | --- |
| named by the publisher's `identifier` | 114 | 4,451 |
| **named by a heading (the fallback)** | **118** | **3,481** |

Across the two release points the fallback covers **6,962** paths, in thirteen works:

| Work | elements per release point |
| --- | --- |
| `uscode/appendix_11a` | 2,363 |
| `uscode/appendix_28a` | 240 |
| `uscode/appendix_5a` | 9 |
| `uscode/appendix_18a` | 1 |
| **appendix subtotal** | **2,613** |
| `uscode/title_29` | 396 |
| `uscode/title_38` | 143 |
| `uscode/title_25` | 132 |
| `uscode/title_19` | 99 |
| `uscode/title_12` | 77 |
| `uscode/title_7` | 8 |
| `uscode/title_21` | 7 |
| `uscode/title_22` | 4 |
| `uscode/title_42` | 2 |
| **ordinary-title subtotal** | **868** |

The ordinary-title subtotal is 1,736 across the two release points, which is exactly the ordinary-title figure the triage measured. **Not one of the 103 ordinary-title containers carries an `identifier`**, so option 2 fixes none of them and the fallback carries all of them. The whole Federal Rules of Bankruptcy Procedure also falls to it: its `courtRules` element supplies no identifier either.

Every one of the 118 containers carries a heading, and no two siblings produce the same segment anywhere in the corpus. Nothing falls past the heading to the uuid.

The brief said to stop and report rather than ship a scheme that churns paths silently. The scheme shipped here does not churn on insertion, which is the churn the brief named, so it is shipped — but the reach is stated above rather than buried, and the new dependence is written into `CONTEXT.md` and `docs/adr/0001` so the next reader meets it.

## Before and after: Rule 1 of the Federal Rules of Civil Procedure

Before (from the schema-7 dataset):

```
uscode/appendix_28a/level_id2e47c0a6-b17c-11ef-b971-e82c9e4f66ce/title_I/level_1
```

After:

```
uscode/appendix_28a/level_Civil/title_I/level_1
```

## Element counts for the four appendices, at 2025-07-18

| Appendix | before | after |
| --- | --- | --- |
| `appendix_28a` | 2,641 | **3,093** (+452) |
| `appendix_11a` | 2,364 | 2,364 |
| `appendix_18a` | 1,255 | 1,255 |
| `appendix_5a` | 118 | 118 |

**One correction to the brief.** It expected all four appendices to grow. Only the title 28 appendix does. `<article>` appears nowhere else in the committed corpus, and the +452 it adds is the Federal Rules of Evidence, which the brief predicted correctly.

## Paths holding a uuid

**Zero**, in every one of the 57 files at both release points. Before: 7,242 per release point, 14,484 in the dataset.

## No regression outside the affected works

Title 26 at 2025-07-18 is **57,391** elements, unchanged, with zero uuid paths. A test asserts the exact count. Every other work's element count matches the schema-7 dataset exactly, except `appendix_28a`.

## Test evidence

New and changed tests, all in `tests/`:

- `should_find_federal_rules_of_evidence_text_when_the_appendix_is_searched`
- `should_hold_the_articles_of_the_federal_rules_of_evidence_when_the_appendix_is_parsed`
- `should_name_a_container_from_the_publisher_identifier_when_it_carries_no_number`
- `should_name_a_container_from_its_heading_when_the_publisher_supplies_no_identifier`
- `should_leave_a_footnote_out_of_a_segment_taken_from_a_heading`
- `should_hold_no_uuid_path_when_a_release_point_is_parsed` (the four appendices plus titles 12, 29 and 38)
- `should_leave_a_title_with_no_numberless_container_unchanged` (title 26 at 57,391)
- `should_keep_only_path_safe_characters_when_a_heading_becomes_a_segment`, `should_give_no_segment_when_a_heading_holds_no_letter_or_digit`
- `should_report_a_dropped_container_...` became `should_report_no_dropped_container_when_the_appendix_holds_only_known_containers`. `<article>` was its subject and it is no longer dropped. **This removes the only positive test of #113's report**: no unknown container holding law remains anywhere in the committed US Code corpus. See the note below.
- `should_refuse_a_dataset_written_at_the_previous_schema` now pins schema 8 and refuses 7.

```
$ cargo test --no-fail-fast
passed 365 failed 0 ignored 7
exit 0
```

```
$ cargo test --test appendix_container_tests --test path_tests
running 20 tests
test should_stay_silent_when_an_unknown_element_holds_no_structural_children ... ok
test should_hold_no_uuid_path_when_a_release_point_is_parsed::case_1 ... ok
...
test should_leave_a_title_with_no_numberless_container_unchanged ... ok
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
running 6 tests
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
exit 0
```

```
$ cargo clippy --all-targets -- -D warnings
exit 0

$ cargo fmt --check
exit 0
```

The CLI, against a dataset built from `usc28a.xml` at 2025-07-18:

```
$ words_to_data search dataset.sqlite "Evidence is relevant if"
uscode/appendix_28a@2025-07-18  uscode/appendix_28a/level_Evid/level_IV/level_401  [chapeau]
    Evidence is relevant if:
1 match(es)

$ words_to_data search dataset.sqlite "These rules govern the procedure in all civil actions"
uscode/appendix_28a@2025-07-18  uscode/appendix_28a/level_Civil/title_I/level_1  [content]
    These rules govern the procedure in all civil actions and proceedings in the United States district courts, ...
1 match(es)
```

Note on the test suite: `tests/sqlite_tests.rs` writes to fixed `/tmp` paths and fails on a second run unless those files are removed first. That is pre-existing and unrelated.

## Docs

`CONTEXT.md`'s **Structural path** entry and the "A gap this ADR did not anticipate" section of `docs/adr/0001-structural-paths-locate-not-identify.md` both quoted 14,484 and the uuid example. Both now record what the code does, the new figure, and the new dependence on the publisher's wording. Every figure in them was re-measured, not carried over.

## Found on the way, out of scope

`parse` on a public law drops the whole body of the bill. The parser steps into `<main>` for a US Code document and not for a bill, so `<main>` reaches the unknown-element path and #113's report says so:

```
warning: unknown USLM element <main> in publiclawdocument_119-21 was dropped with 11 structural children below it
```

This is pre-existing and untouched here. It is worth its own issue.

## Rebuild

A rebuild is required: the schema goes to 8 and every affected path changes.
