### PR TITLE
feat: say what the citation extractor could not read, and read a lettered section (#135)

### DIFF
--- a/src/citation/usc.rs
+++ b/src/citation/usc.rs
@@ -10,23 +10,32 @@
 //! > <https://github.com/freelawproject/reporters-db>
 //!
 //! They are copied in rather than fetched, so a build needs no network and a
-//! reader of this file can see exactly what is matched. One change was needed to
-//! compile them with the Rust `regex` crate: Python writes a bounded repeat with
-//! an open lower bound, `{,3}`, and Rust requires `{0,3}`. Nothing else differs.
+//! reader of this file can see exactly what is matched. Every place this file
+//! departs from the published source is marked where it happens, with what the
+//! published pattern says and why we differ, because a silent divergence from an
+//! upstream pattern is a maintenance trap. [`LAW_SECTION`] carries three such
+//! notes.
 //!
-//! # Two limits this shares with eyecite
+//! # What is read, and what is declined
 //!
-//! Both follow from the vendored patterns, and both fail by finding nothing
-//! rather than by naming the wrong provision.
+//! Nothing fails quietly. [`find_with_report`] gives back the citations read
+//! **and** the citation-shaped text declined, each with a reason, and [`find`]
+//! writes the reasons to stderr. A reader can then tell "this text cites no
+//! statute" from "this citation form is not read", which is the difference
+//! `CONTEXT.md` draws between a Gap and an Exclusion.
 //!
-//! A citation with no section marker, `16 U.S.C. 1533`, is not matched: the
-//! pattern requires a `§` or a `Section`. The U.S. Code's own notes are written
-//! that way, so this is worth fixing, with its own fixtures.
+//! One form is declined on purpose: a citation with no section marker,
+//! `16 U.S.C. 1533`. The U.S. Code's own notes are written that way and there are
+//! 51,721 of them in the 2025-07-30 release, so this is the larger of the two
+//! limits by count. It is also the risky one. With no `§` and no `Section`, a
+//! number in that position cannot be told from a page or a year, which is
+//! presumably why the published pattern asks for a marker at all, and a wrong
+//! citation is worse than a missed one. So it is counted and named, not matched.
 //!
-//! A section number that ends in a letter, `21 U.S.C. § 355a`, is not matched
-//! either, because `law.section` allows no letters outside brackets. Reporting
-//! section 355 instead would be worse than reporting nothing: it names a
-//! different provision.
+//! A section number cut short is declined for the same reason, and that is the
+//! whole of the rest: `25 U.S.C. § 479a–1` is read as nothing rather than as
+//! section 479a, because the release holds both ([`ends_cleanly`]). Fourteen
+//! citations in the release land there.
 
 use std::sync::LazyLock;
 
@@ -56,10 +65,16 @@ const REPORTERS: [&str; 8] = [
 const SECTION_MARKER: &str = r"((§§?)|([Ss]((ec)(tion)?)?s?\.?))";
 
 /// `law.section` from `regexes.json`, with its group name removed so it can be
-/// used more than once in one pattern: a section number such as `1-2-3`, `1.2.3`
-/// or `981(a)(l)(C)`.
+/// used more than once in one pattern: a section number such as `1-2-3`, `1.2.3`,
+/// `981(a)(l)(C)` or `300gg-11`.
 ///
-/// Two changes from the published pattern.
+/// The published pattern is:
+///
+/// ```text
+/// (?:\d+(?:\((?:[a-zA-Z]{1}|\d{1,2})\))+)|(?:\d+(?:[\-.:]\d+){,3})
+/// ```
+///
+/// Three changes from it.
 ///
 /// `{,3}` is written `{0,3}`, because Python accepts an open lower bound and
 /// Rust does not. That is mechanical.
@@ -71,7 +86,60 @@ const SECTION_MARKER: &str = r"((§§?)|([Ss]((ec)(tion)?)?s?\.?))";
 /// `(g)(1)` of `18 U.S.C. § 922(g)(1)` falls outside the citation span
 /// (`docs/research/courtlistener-formats.md`, section 8.3). What the opinion
 /// named is what we keep.
-const LAW_SECTION: &str = r"(?:\d+(?:\((?:[a-zA-Z]{1}|\d{1,2})\))+)|(?:\d+(?:[\-.:]\d+){0,3})";
+///
+/// Every `\d+` may be followed by up to four letters, written `\d+[a-zA-Z]{0,4}`.
+/// The published pattern has both alternatives begin `\d+` and allows a letter
+/// only inside brackets, so `26 U.S.C. § 45X`, `21 U.S.C. § 355a` and
+/// `15 U.S.C. § 78aaa` are all unreadable to it. That is not a tail case: of the
+/// 29,592 section numbers in the 2025-07-30 release of the Code, 10,085 end in a
+/// letter, and the lettered ones are the heavily litigated ones (#135). The
+/// change is made in every `\d+` of a section number rather than only the first,
+/// because the Code writes `42 U.S.C. § 1395w-4a` as well as `42 U.S.C. §
+/// 300gg-11`.
+///
+/// Four letters, because four is the longest run the Code uses — `15 U.S.C. §
+/// 77bbbb`, `16 U.S.C. § 460dddd` — so a longer run is not a section number. The
+/// bound is what keeps [`ends_cleanly`] able to refuse `§ 78aaaaa` instead of
+/// reading a number that no section has.
+const LAW_SECTION: &str = r"(?:\d+[a-zA-Z]{0,4}(?:\((?:[a-zA-Z]{1}|\d{1,2})\))+)|(?:\d+[a-zA-Z]{0,4}(?:[\-.:]\d+[a-zA-Z]{0,4}){0,3})";
+
+/// Every dash the Code writes inside a section number.
+///
+/// `law.section` reads the ASCII hyphen of `[\-.:]` and nothing else, and the
+/// published Code prints `479a–1` with an en dash. The rest of the family is here
+/// so that a number written with one is not read cut short ([`ends_cleanly`]).
+const DASHES: [char; 6] = [
+    '-',        // HYPHEN-MINUS
+    '\u{2010}', // HYPHEN
+    '\u{2011}', // NON-BREAKING HYPHEN
+    '\u{2012}', // FIGURE DASH
+    '\u{2013}', // EN DASH
+    '\u{2014}', // EM DASH
+];
+
+/// A title, a reporter, and a number in the section position — whether or not the
+/// rest of it is a citation this module can read.
+///
+/// Not from `reporters_db`. It is the `U.S.C.` regex with the section marker made
+/// optional and the section number loosened to any run that starts with a digit,
+/// so that a citation form the reader declines can still be named and counted
+/// ([`find_with_report`]).
+///
+/// The run must start with a digit, because every section of the Code is numbered
+/// and a report about `5 U.S.C. Appendix` would be a report about prose rather
+/// than about a citation. It must end in a letter or a digit, so that the full
+/// stop of `16 U.S.C. 1533.` is not read as part of the number. A bracketed
+/// subsection is taken only as a whole group, so the closing bracket of
+/// `(16 U.S.C. 1533)` stays out as well. The skip is evidence a person reads, and
+/// evidence with punctuation in it invites a second look at nothing.
+static CANDIDATE: LazyLock<Regex> = LazyLock::new(|| {
+    let reporters = reporters_pattern();
+    let dashes = dash_class();
+    Regex::new(&format!(
+        r"\b(?P<title>\d+),?\s+(?P<reporter>{reporters}),?\s+(?:(?P<marker>{SECTION_MARKER})\s*)?(?P<section>\d(?:[0-9A-Za-z.:{dashes}]*[0-9A-Za-z])?(?:\([0-9A-Za-z]+\))*)"
+    ))
+    .expect("the candidate pattern must compile")
+});
 
 /// The `U.S.C.` regex of `laws.json`:
 /// `(?P<title>\d+),?\s+$reporter,?\s+$section_marker\s*$law_section`.
@@ -103,6 +171,15 @@ static ANOTHER_CITATION: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(r"^,?\s+(?:{reporters})"))
         .expect("the further-citation pattern must compile")
 });
+
+/// [`DASHES`] as the inside of a regex character class, so the list and the
+/// pattern cannot drift apart.
+fn dash_class() -> String {
+    DASHES
+        .iter()
+        .map(|dash| regex::escape(&dash.to_string()))
+        .collect()
+}
 
 /// Every spelling of the reporter, as one alternation.
 ///
@@ -178,7 +255,126 @@ pub fn section_number(section: &str) -> &str {
         .map_or(section, |(number, _)| number)
 }
 
+/// Why a piece of text that looks like a citation was not read as one.
+///
+/// A reason is part of the statement. A hole with no reason cannot be told apart
+/// from an oversight (`CONTEXT.md`, *Exclusion*), and "did not match" is no
+/// reason at all: it names the reader's behaviour rather than the text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// No `§` and no `Section` stands between the reporter and the number, as in
+    /// `16 U.S.C. 1533`.
+    ///
+    /// The form the Code's own notes use, and the one form left unread on
+    /// purpose. Without a marker a number in that position cannot be told from a
+    /// page or a year, which is why the published pattern asks for a marker, and
+    /// a wrong citation is worse than a missed one.
+    NoSectionMarker,
+    /// A marker is there, and the number beside it cannot be read whole, as in
+    /// `25 U.S.C. § 479a–1`.
+    ///
+    /// Reading the part of it that the pattern does read would name a different
+    /// provision — section 479a is not section 479a–1, and the release holds both
+    /// — so nothing is read. See [`ends_cleanly`].
+    SectionNumberNotRead,
+}
+
+impl std::fmt::Display for SkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let said = match self {
+            Self::NoSectionMarker => "no section marker",
+            Self::SectionNumberNotRead => "a section number that cannot be read whole",
+        };
+        f.write_str(said)
+    }
+}
+
+/// Text that looks like a U.S. Code citation and was not read as one.
+///
+/// Enough to act on: what the text says, where it is, and why it was declined.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkippedCitation {
+    /// The text that was declined, verbatim: `16 U.S.C. 1533`.
+    pub text: String,
+    /// Where `text` starts in the text it was found in, in bytes. The same
+    /// measure [`UscCitation::start`] uses, so the two can be read side by side.
+    pub start: usize,
+    pub reason: SkipReason,
+}
+
+impl SkippedCitation {
+    /// Where `text` ends, in bytes.
+    pub fn end(&self) -> usize {
+        self.start + self.text.len()
+    }
+}
+
+/// What one pass over a piece of text declined to read.
+///
+/// A skip happens before resolution: the citation was never read, so there is
+/// nothing to resolve and no [`Resolution`](super::resolve::Resolution) to give.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FindReport {
+    /// Every candidate declined, in the order they appear in the text.
+    pub skipped: Vec<SkippedCitation>,
+}
+
+impl FindReport {
+    /// True when every citation-shaped piece of text was read.
+    pub fn is_empty(&self) -> bool {
+        self.skipped.is_empty()
+    }
+
+    /// Write the report to stderr, so it reaches the person who ran the command.
+    ///
+    /// One line for each reason, not one for each skip. A title of the Code
+    /// writes the marker-less form thousands of times — title 42 alone holds over
+    /// ten thousand — and ten thousand lines is not a report anybody reads. The
+    /// count says how much was declined, the example says what it looked like,
+    /// and [`FindReport::skipped`] holds every one for a caller that wants them.
+    ///
+    /// The crate carries no logger, and the parser reports what it dropped the
+    /// same way (`uslm::parser::ParseReport::print_to_stderr`).
+    pub fn print_to_stderr(&self) {
+        for line in self.summary() {
+            eprintln!("{line}");
+        }
+    }
+
+    /// One line for each reason met, in the order the reasons were first met.
+    ///
+    /// The line names the reason, how many skips it accounts for, and the first
+    /// of them, so a reader can go and look at one.
+    pub fn summary(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+
+        for (at, skipped) in self.skipped.iter().enumerate() {
+            let met_before = self.skipped[..at]
+                .iter()
+                .any(|earlier| earlier.reason == skipped.reason);
+            if met_before {
+                continue;
+            }
+
+            let count = self
+                .skipped
+                .iter()
+                .filter(|other| other.reason == skipped.reason)
+                .count();
+            lines.push(format!(
+                "warning: {count} U.S.C. citation(s) were not read: {}. The first is {:?} at {}",
+                skipped.reason, skipped.text, skipped.start
+            ));
+        }
+
+        lines
+    }
+}
+
 /// Every U.S. Code citation in a piece of text, in the order they appear.
+///
+/// What the pass declined to read goes to stderr. Use [`find_with_report`] when
+/// the caller decides how a skip is shown.
 ///
 /// ```
 /// use words_to_data::citation::usc;
@@ -191,6 +387,36 @@ pub fn section_number(section: &str) -> &str {
 /// assert_eq!(found[1].sections, ["1983", "1988"]);
 /// ```
 pub fn find(text: &str) -> Vec<UscCitation> {
+    let (found, report) = find_with_report(text);
+    report.print_to_stderr();
+    found
+}
+
+/// Every citation read, and every citation-shaped piece of text declined.
+///
+/// The same pass as [`find`], except that the caller receives the [`FindReport`]
+/// instead of having it printed to stderr.
+///
+/// ```
+/// use words_to_data::citation::usc::{self, SkipReason};
+///
+/// let (found, report) = usc::find_with_report("under 16 U.S.C. 1533 and 26 U.S.C. § 45X");
+///
+/// // The lettered section is read; the one with no marker is named and declined.
+/// assert_eq!(found.len(), 1);
+/// assert_eq!(found[0].sections, ["45X"]);
+/// assert_eq!(report.skipped.len(), 1);
+/// assert_eq!(report.skipped[0].text, "16 U.S.C. 1533");
+/// assert_eq!(report.skipped[0].reason, SkipReason::NoSectionMarker);
+/// ```
+pub fn find_with_report(text: &str) -> (Vec<UscCitation>, FindReport) {
+    let found = read_citations(text);
+    let skipped = declined_candidates(text, &found);
+    (found, FindReport { skipped })
+}
+
+/// Every citation the vendored patterns read.
+fn read_citations(text: &str) -> Vec<UscCitation> {
     let mut found = Vec::new();
 
     for capture in CITATION.captures_iter(text) {
@@ -200,8 +426,8 @@ pub fn find(text: &str) -> Vec<UscCitation> {
             .expect("the pattern names a section")
             .as_str();
         if !ends_cleanly(text, whole.end()) {
-            // The section number runs on into letters, as in `§ 355a`. What we
-            // matched is a different provision from the one cited.
+            // The section number runs on, as in `§ 479a–1`. What we matched is a
+            // different provision from the one cited.
             continue;
         }
 
@@ -227,6 +453,36 @@ pub fn find(text: &str) -> Vec<UscCitation> {
     found
 }
 
+/// Every citation-shaped piece of text that no citation in `found` covers.
+///
+/// A candidate the reader took is not a skip, so the citations already read say
+/// which candidates to pass over. The two patterns agree on where a citation
+/// begins — same title, same reporter — so one starting offset is enough to pair
+/// them.
+fn declined_candidates(text: &str, found: &[UscCitation]) -> Vec<SkippedCitation> {
+    let mut skipped = Vec::new();
+
+    for candidate in CANDIDATE.captures_iter(text) {
+        let whole = candidate.get(0).expect("a match always has a whole");
+        if found.iter().any(|citation| citation.start == whole.start()) {
+            continue;
+        }
+
+        let reason = if candidate.name("marker").is_none() {
+            SkipReason::NoSectionMarker
+        } else {
+            SkipReason::SectionNumberNotRead
+        };
+        skipped.push(SkippedCitation {
+            text: text[whole.start()..whole.end()].to_string(),
+            start: whole.start(),
+            reason,
+        });
+    }
+
+    skipped
+}
+
 /// Where the next section of the citation that ends at `end` sits, if the text
 /// carries on with one.
 ///
@@ -249,9 +505,29 @@ fn further_section(text: &str, end: usize) -> Option<(usize, usize)> {
 ///
 /// A letter or a digit straight after it means the number was cut short, and a
 /// section number cut short names the wrong provision.
+///
+/// A dash and then a letter or a digit mean the same, when the number read ends
+/// in a letter. The Code numbers its lettered sections `479a–1`, `77z–1` and
+/// `2000e–5`, and prints the dash as an en dash, which the published separator
+/// class `[\-.:]` does not read. The 2025-07-30 release holds `25 U.S.C. § 479a`
+/// and `25 U.S.C. § 479a–1` both, so reading the first where the text names the
+/// second would name a real but different provision. A number that ends in a
+/// digit is left alone: there the dash is the range of `§§ 1961–63`, and the
+/// first section named is still one the text cited.
 fn ends_cleanly(text: &str, end: usize) -> bool {
-    !text[end..]
+    let mut after = text[end..].chars();
+    let Some(next) = after.next() else {
+        return true;
+    };
+    if next.is_alphanumeric() {
+        return false;
+    }
+
+    let ends_in_a_letter = text[..end]
         .chars()
-        .next()
-        .is_some_and(|next| next.is_alphanumeric())
+        .next_back()
+        .is_some_and(|last| last.is_ascii_alphabetic());
+    let carries_on = DASHES.contains(&next) && after.next().is_some_and(char::is_alphanumeric);
+
+    !(ends_in_a_letter && carries_on)
 }

--- a/tests/usc_citation_link_tests.rs
+++ b/tests/usc_citation_link_tests.rs
@@ -195,6 +195,39 @@ fn should_say_out_of_scope_when_the_dataset_does_not_carry_the_title() {
 }
 
 #[test]
+fn should_link_the_opinion_to_the_provision_when_the_section_number_ends_in_a_letter() {
+    let (dataset, paths) = dataset_holding(&[(TITLE_26, "uscode/title_26")]);
+    let scope = dataset.scope().expect("scope should derive");
+
+    // `26 U.S.C. § 45X`, the advanced manufacturing production credit. Until the
+    // section number was allowed a letter this citation read as nothing, so a
+    // third of the Code could not be linked to at all (#135). It is the section
+    // `docs/adr/0001-structural-paths-locate-not-identify.md` uses for its
+    // duplicate-path example, and H.R. 1 amended it.
+    let found = usc::find("the credit under 26 U.S.C. \u{a7} 45X(b)(1)(A)");
+    let citation = found.first().expect("one citation");
+    let cited = resolve(citation, &scope, &paths);
+
+    // The subsection travels as written, and the path stops at the section,
+    // because the citation cannot be trusted at that depth.
+    assert_eq!(cited[0].section, "45X(b)(1)(A)");
+    assert_eq!(cited[0].uslm_id, "/us/usc/t26/s45X");
+    assert_eq!(
+        cited[0].resolution,
+        Resolution::Provision {
+            paths: vec![
+                "uscode/title_26/subtitle_A/chapter_1/subchapter_A/part_IV/subpart_D/section_45X"
+                    .to_string()
+            ]
+        },
+        "the release publishes section 45X"
+    );
+
+    let links = cites_links(&obergefell(), citation, &cited);
+    assert_eq!(links.len(), 1, "one link, got {links:?}");
+}
+
+#[test]
 fn should_say_absent_when_the_dataset_holds_the_title_and_it_has_no_such_section() {
     let (dataset, paths) = dataset_holding(&[(TITLE_1, "uscode/title_1")]);
     let scope = dataset.scope().expect("scope should derive");

--- a/tests/usc_citation_report_tests.rs
+++ b/tests/usc_citation_report_tests.rs
@@ -1,0 +1,160 @@
+//! What the citation extractor says about the text it could not read (#135).
+//!
+//! A run that meets a citation form the patterns do not cover must say so. The
+//! alternative is silence, and silence cannot be told apart from "this text
+//! cites no statute". `CONTEXT.md` calls the first an Exclusion and the second a
+//! Gap, and the difference is the reason.
+//!
+//! The prose fixtures are real: the notes of the U.S. Code write a citation
+//! without a section marker throughout, and `tests/test_data/usc/2025-07-30`
+//! holds them.
+
+use words_to_data::citation::usc::{self, SkipReason};
+
+/// The notes to the Federal Rules of Criminal Procedure, which cite the Code both
+/// ways: with a section marker, and the way the Code's own notes write it.
+const RULES: &str = "tests/test_data/usc/2025-07-30/usc18a.xml";
+
+#[test]
+fn should_report_the_missing_marker_when_a_citation_has_no_section_mark() {
+    // The form the Code's own notes use. It stays unread on purpose: with no `§`
+    // and no "section", a number in that position cannot be told from a page or
+    // a year.
+    let text = "The Endangered Species Act, 16 U.S.C. 1533, applies.";
+
+    let (found, report) = usc::find_with_report(text);
+
+    assert!(found.is_empty(), "nothing is read, got {found:?}");
+    assert_eq!(report.skipped.len(), 1, "one skip, got {report:?}");
+    let skipped = &report.skipped[0];
+    assert_eq!(skipped.text, "16 U.S.C. 1533");
+    assert_eq!(skipped.start, text.find("16 U.S.C.").expect("the citation"));
+    assert_eq!(skipped.reason, SkipReason::NoSectionMarker);
+}
+
+#[test]
+fn should_read_nothing_and_say_so_when_a_dash_carries_a_lettered_number_on() {
+    // Real prose from the notes to the Federal Rules of Civil Procedure, in
+    // `tests/test_data/usc/2025-07-30/usc28a.xml`. The Code writes the dash part
+    // of a lettered section number with an en dash, which the published separator
+    // class `[\-.:]` does not read.
+    //
+    // Both `15 U.S.C. § 77z` and `15 U.S.C. § 77z-1` are sections of the release,
+    // so reading the first when the text names the second would name a real but
+    // different provision. Nothing is read, and the skip says why.
+    let text = "the Private Securities Litigation Reform Act, 15 U.S.C. \u{a7}\u{a7}\u{202f}77z\u{2013}1, and";
+
+    let (found, report) = usc::find_with_report(text);
+
+    assert!(found.is_empty(), "nothing is read, got {found:?}");
+    assert_eq!(report.skipped.len(), 1, "one skip, got {report:?}");
+    assert_eq!(
+        report.skipped[0].text, "15 U.S.C. \u{a7}\u{a7}\u{202f}77z\u{2013}1",
+        "the evidence covers the whole number, not the part that was read"
+    );
+    assert_eq!(
+        report.skipped[0].reason,
+        SkipReason::SectionNumberNotRead,
+        "a marker is there, so the missing marker is not the reason"
+    );
+}
+
+#[test]
+fn should_name_and_place_every_skip_when_real_prose_writes_the_marker_less_form() {
+    let rules = std::fs::read_to_string(RULES).expect("the criminal rules should be extracted");
+
+    let (found, report) = usc::find_with_report(&rules);
+
+    assert!(
+        report.skipped.len() > 80,
+        "the notes write the marker-less form throughout, got {}",
+        report.skipped.len()
+    );
+    for skipped in &report.skipped {
+        assert_eq!(
+            &rules[skipped.start..skipped.end()],
+            skipped.text,
+            "the recorded span must be where the text was found"
+        );
+        // A skip is a citation nobody read, so no citation may cover it. A skip
+        // that sits inside a citation would be double counting.
+        assert!(
+            !found
+                .iter()
+                .any(|citation| citation.start <= skipped.start && citation.end() > skipped.start),
+            "{skipped:?} sits inside a citation that was read"
+        );
+    }
+    // `42 U.S.C. 2014(y)`, in the notes to Rule 6. Marker-less, and it names a
+    // subsection, so a reason of "no section number" would be wrong too.
+    assert!(
+        report
+            .skipped
+            .iter()
+            .any(|skipped| skipped.text.contains("42 U.S.C. 2014(y)")
+                && skipped.reason == SkipReason::NoSectionMarker),
+        "the notes to Rule 6 cite 42 U.S.C. 2014(y) with no marker"
+    );
+}
+
+#[test]
+fn should_say_the_count_and_an_example_for_each_reason_when_the_report_is_summarised() {
+    let rules = std::fs::read_to_string(RULES).expect("the criminal rules should be extracted");
+
+    let (_found, report) = usc::find_with_report(&rules);
+    let summary = report.summary();
+
+    // One line for each reason met, not one for each skip. A title of the Code
+    // writes the marker-less form thousands of times.
+    assert_eq!(summary.len(), 2, "two reasons met, got {summary:?}");
+    assert!(summary.iter().all(|line| line.starts_with("warning: ")));
+    assert!(
+        summary[0].contains("no section marker"),
+        "the first reason met must be named: {summary:?}"
+    );
+    assert!(
+        summary[0].contains("89 U.S.C. citation"),
+        "the count must say how much was declined: {summary:?}"
+    );
+    assert!(
+        summary[1].contains("a section number that cannot be read whole"),
+        "the second reason met must be named: {summary:?}"
+    );
+    // The first skip of each reason, so a reader can go and look at one.
+    let first_not_read = report
+        .skipped
+        .iter()
+        .find(|skipped| skipped.reason == SkipReason::SectionNumberNotRead)
+        .expect("the notes to Rule 6 cite 25 U.S.C. \u{a7} 479a-1");
+    assert_eq!(
+        first_not_read.text, "25 U.S.C. \u{a7}\u{202f}479a\u{2013}1",
+        "the number, and not the full stop that ends the sentence"
+    );
+    assert!(
+        summary[1].contains(&format!(
+            "{:?} at {}",
+            first_not_read.text, first_not_read.start
+        )),
+        "the summary must point at a skip: {summary:?}"
+    );
+}
+
+#[test]
+fn should_report_nothing_when_every_citation_shaped_thing_was_read() {
+    let (found, report) = usc::find_with_report("See 26 U.S.C. § 174 and 21 U.S.C. § 355a.");
+
+    assert_eq!(found.len(), 2, "got {found:?}");
+    assert!(report.is_empty(), "nothing was declined, got {report:?}");
+    assert!(report.summary().is_empty());
+}
+
+#[test]
+fn should_report_nothing_when_the_text_names_no_statute() {
+    let (found, report) = usc::find_with_report("The Fourteenth Amendment requires no such thing.");
+
+    assert!(found.is_empty());
+    // The honest answer to "this text cites no statute". It is only worth
+    // anything because the other tests show that a declined citation is not
+    // silent.
+    assert!(report.is_empty());
+}

--- a/tests/usc_citation_tests.rs
+++ b/tests/usc_citation_tests.rs
@@ -74,6 +74,70 @@ fn should_cover_every_published_example_when_the_examples_come_from_laws_json() 
     );
 }
 
+/// Section numbers that end in a letter, with the title and the sections each
+/// citation names.
+///
+/// Every one of these is a real section of the Code held in
+/// `tests/test_data/usc`. A third of the Code is numbered this way — 10,085 of
+/// 29,592 section numbers in the 2025-07-30 release end in a letter — so a
+/// pattern that cannot name them cannot name a third of the law (#135).
+const LETTERED_SECTIONS: [(&str, &str, &[&str]); 6] = [
+    ("26 U.S.C. § 45X", "26", &["45X"]),
+    ("21 U.S.C. § 355a", "21", &["355a"]),
+    ("15 U.S.C. § 78aaa", "15", &["78aaa"]),
+    // Four letters is the longest run the Code uses: 15 U.S.C. § 77bbbb.
+    ("15 U.S.C. § 77bbbb", "15", &["77bbbb"]),
+    // A letter run in the middle, with a numbered part after it.
+    ("42 U.S.C. § 300gg-11", "42", &["300gg-11"]),
+    // A letter run on both parts: 42 U.S.C. § 1395w-4a.
+    ("42 U.S.C. § 1395w-4a", "42", &["1395w-4a"]),
+];
+
+#[test]
+fn should_read_the_whole_number_when_a_section_number_ends_in_a_letter() {
+    let mut missed = Vec::new();
+
+    for (citation, title, sections) in LETTERED_SECTIONS {
+        let found = usc::find(citation);
+        let matched = found.first().map(|read| {
+            (
+                read.title.as_str(),
+                read.sections.iter().map(String::as_str).collect(),
+                read.text.as_str(),
+            )
+        });
+        if matched != Some((title, sections.to_vec(), citation)) {
+            missed.push(format!("{citation:?} -> {found:?}"));
+        }
+    }
+
+    assert!(
+        missed.is_empty(),
+        "a lettered section number must be read whole:\n{}",
+        missed.join("\n")
+    );
+}
+
+#[test]
+fn should_keep_the_subsection_when_a_lettered_section_also_names_one() {
+    // `26 U.S.C. § 45X(b)(1)` is the shape a bill amends. Losing the letter would
+    // name section 45, and losing the brackets would lose what was cited.
+    let found = usc::find("credit under 26 U.S.C. § 45X(b)(1)(A)");
+
+    assert_eq!(found.len(), 1, "one citation, got {found:?}");
+    assert_eq!(found[0].sections, ["45X(b)(1)(A)"]);
+    assert_eq!(found[0].uslm_id("45X(b)(1)(A)"), "/us/usc/t26/s45X");
+}
+
+#[test]
+fn should_read_both_sections_when_a_list_mixes_a_lettered_number_with_a_plain_one() {
+    // A letter suffix must not break the list continuation logic.
+    let found = usc::find("see 21 U.S.C. §§ 355a, 360 and 355b");
+
+    assert_eq!(found.len(), 1, "one citation, got {found:?}");
+    assert_eq!(found[0].sections, ["355a", "360", "355b"]);
+}
+
 #[test]
 fn should_read_both_sections_when_a_citation_names_a_list_of_them() {
     // eyecite reads this as one citation to section 1983 and loses 1988
@@ -124,7 +188,7 @@ fn should_read_both_sections_when_real_prose_joins_them_with_and() {
 }
 
 #[test]
-fn should_find_every_citation_in_real_prose_except_a_section_ending_in_a_letter() {
+fn should_find_every_citation_in_real_prose_when_each_one_carries_a_section_marker() {
     // Real prose rather than a hand-written string: the notes of the Federal
     // Rules of Bankruptcy Procedure cite the U.S. Code throughout.
     let rules = std::fs::read_to_string("tests/test_data/usc/2025-07-30/usc11a.xml")
@@ -147,29 +211,33 @@ fn should_find_every_citation_in_real_prose_except_a_section_ending_in_a_letter(
         "`28 U.S.C. § 1334` is in the notes to Rule 9001"
     );
 
-    // Every mention in the document must be accounted for. The one kind that is
-    // allowed to be missed is a section number ending in a letter, such as
-    // `15 U.S.C. § 78aaa`: the published `law.section` pattern has no room for
-    // it, and naming section 78 instead would name a different provision.
-    let mention =
-        regex::Regex::new(r"\d+ U\.S\.C\. §\s*(?P<section>[0-9A-Za-z\-.:]+)").expect("a pattern");
+    // Every mention in the document must be read. Before the section number was
+    // allowed a letter, one of the 199 was missed: `15 U.S.C. § 78aaa`, in the
+    // notes to Rule 1002 (#135).
+    let mention = regex::Regex::new(r"\d+\s+U\.S\.C\.\s*§+\s*(?P<section>[0-9A-Za-z\-.:]+)")
+        .expect("a pattern");
     let mut mentions = 0;
+    let mut missed = Vec::new();
     for hit in mention.captures_iter(&rules) {
         mentions += 1;
         let at = hit.get(0).expect("a whole match").start();
-        if found
+        if !found
             .iter()
             .any(|citation| citation.start <= at && citation.end() > at)
         {
-            continue;
+            missed.push(format!(
+                "{:?} at {at}",
+                hit.get(0).expect("a whole").as_str()
+            ));
         }
-        let section = hit.name("section").expect("a section").as_str();
-        assert!(
-            section.ends_with(|last: char| last.is_ascii_alphabetic()),
-            "citation at {at} was missed and its section {section:?} does not end in a letter"
-        );
     }
-    assert!(mentions > 190, "the document should be full of mentions");
+    assert_eq!(mentions, 199, "the document holds 199 marked mentions");
+    assert!(
+        missed.is_empty(),
+        "every marked mention must be read, {} were not:\n{}",
+        missed.len(),
+        missed.join("\n")
+    );
 
     // Every citation must name a title and at least one section, or it is not a
     // citation and must not have been reported as one.
@@ -199,4 +267,47 @@ fn should_name_the_section_and_drop_the_subsection_when_asked_for_an_identifier(
 #[test]
 fn should_find_nothing_when_the_text_has_no_citation() {
     assert!(usc::find("The Fourteenth Amendment requires no such thing.").is_empty());
+}
+
+#[test]
+fn should_name_no_provision_the_opinion_did_not_cite_when_a_whole_opinion_is_read() {
+    // The false-positive gate (#135). *Obergefell v. Hodges*, CourtListener
+    // opinion 2812209, as the API returned it: 209,682 bytes of real judicial
+    // prose holding 27 section marks, most of them state statutes and none of
+    // them a U.S. Code citation. Widening the section number must not turn any of
+    // those 27 into a citation, because a wrong citation is worse than a missed
+    // one.
+    let record: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string("tests/test_data/courtlistener/opinion_2812209.json")
+            .expect("the cached opinion should read"),
+    )
+    .expect("the cached opinion should be JSON");
+    let opinion = record["results"][0]["plain_text"]
+        .as_str()
+        .expect("the opinion should carry plain text");
+
+    assert_eq!(opinion.len(), 209_682, "the cached opinion, unchanged");
+    assert_eq!(opinion.matches('\u{a7}').count(), 27, "27 section marks");
+
+    let (found, report) = usc::find_with_report(opinion);
+
+    // Exactly two, and both are in the opinion. The first is the section of the
+    // Defense of Marriage Act the case is about. The second reads only because a
+    // section number may now end in a letter: before that, `§2000bb` was silently
+    // nothing.
+    let read: Vec<_> = found
+        .iter()
+        .map(|citation| (citation.title.as_str(), citation.sections.clone()))
+        .collect();
+    assert_eq!(
+        read,
+        [
+            ("1", vec!["7".to_string()]),
+            ("42", vec!["2000bb".to_string()])
+        ],
+        "no provision the opinion did not cite, got {found:?}"
+    );
+    // Nothing citation-shaped is left over either, so the count above is the
+    // whole answer for this opinion.
+    assert!(report.is_empty(), "nothing was declined, got {report:?}");
 }


### PR DESCRIPTION
Closes nothing: #135 stays open for the maintainer.

## What changed

`src/citation/` only. No storage change, no `SCHEMA_VERSION` bump, no new `Resolution` variant, and `src/link.rs` is untouched.

### 1. The extractor says what it declined

`usc::find_with_report` sits beside `usc::find`, on the idiom `uslm::parser::parse_with_report` set in #113. It gives back the citations read **and** the citation-shaped text declined.

A skip record carries:

| field | what it says |
| --- | --- |
| `text` | the declined text, verbatim: `16 U.S.C. 1533` |
| `start` / `end()` | where it sits, in bytes, the same measure `UscCitation::start` uses |
| `reason` | `NoSectionMarker`, or `SectionNumberNotRead` |

`find` keeps its signature and writes the report to stderr, as `parse` does for a dropped container (#110). It writes **one line for each reason, not one for each skip**: title 42 alone declines 10,047 marker-less citations, and ten thousand lines is not a report a person reads. The line gives the count, the reason and the first example. `report.skipped` holds every one for a caller that wants them.

### 2. A section number may hold a letter

`law.section` now reads up to four letters after each digit run. `26 U.S.C. § 45X`, `21 U.S.C. § 355a`, `15 U.S.C. § 78aaa`, `15 U.S.C. § 77bbbb`, `42 U.S.C. § 300gg-11` and `42 U.S.C. § 1395w-4a` are all read whole.

Four letters, because four is the longest run the Code uses (`77bbbb`, `460dddd`). The bound keeps `ends_cleanly` able to refuse `§ 78aaaaa` rather than report a number no section has.

**Attribution.** This is the third deviation from the published `reporters_db` pattern and it is marked like the other two, in the `LAW_SECTION` doc comment: the published pattern is quoted in full, then each change with its reason.

### 3. The marker-less form stays unmatched, and is reported

`16 U.S.C. 1533` is counted and named, not matched. 51,721 of them in the release.

## The gate: false positives against Obergefell

| | before | after |
| --- | --- | --- |
| citations read | 1 | **2** |
| false positives | 0 | **0** |
| skips | — | 0 |

The cached opinion (`tests/test_data/courtlistener/opinion_2812209.json`, byte-identical plain text to `~/.cache/.../probe.json`): 209,682 bytes, 27 `§` marks. The second citation is real, not a false positive — `42 U. S. C. §2000bb`, the Religious Freedom Restoration Act, which the opinion cites and the old pattern read as nothing. Nothing citation-shaped is left over, so the count is the whole answer for that opinion. `tests/usc_citation_tests.rs::should_name_no_provision_the_opinion_did_not_cite_when_a_whole_opinion_is_read` is the gate, and it pins 209,682 and 27.

### One thing the brief did not anticipate: the widening did cost false positives, and they are closed

Widening alone read 7 truncated numbers on the committed corpus, each a real but **different** provision:

```
25 U.S.C. § 479a–1     -> would read 479a    (both are sections of the release)
15 U.S.C. § 80a–1      -> would read 80a
15 U.S.C. §§ 77z–1     -> would read 77z
42 U.S.C. § 2000e–5    -> would read 2000e
40 U.S.C. §§ 258a–258e -> would read 258a
```

The Code prints the dash of a lettered section number as an **en dash**, and the published separator class is `[\-.:]`, ASCII only. So `ends_cleanly` now refuses a number that ends in a letter when the text carries it on with any dash of the family. Those 14 occurrences across the release are declined and reported as `SectionNumberNotRead` instead. A number that ends in a digit is left as the published pattern leaves it, because there the dash is the range of `§§ 1961–63` and the first section named is still one the text cited.

## Real prose

**`usc11a.xml`, the measure the brief named:** 199 marked `N U.S.C. §` mentions, **199 read, 0 missed** — up from 198 of 199. The one miss was `15 U.S.C. § 78aaa`. Nothing is left; the test now asserts zero misses instead of asserting that a miss ends in a letter.

**Whole 2025-07-30 release, 57 titles, ~1.3 GB of real prose:**

| | |
| --- | --- |
| citations read | 1,305 |
| sections read | 1,394 |
| **sections only the widening can read** | **56** (39 distinct) |
| of those, resolving to a section the release holds | **40** (25 distinct); the other 16 are repealed or transferred numbers, so `Absent` |
| declined, no section marker | 51,721 |
| declined, section number not read whole | 14 |

`26 U.S.C. § 45X(b)(1)(A)` now resolves to `uscode/title_26/.../section_45X` and makes a link, which is the ADR 0001 example and a section H.R. 1 amended.

## Test evidence

Baseline on `vibes`, before any change:

```
$ rtk proxy cargo test --release   # exit 0
passed 416 failed 0 ignored 7
$ cargo clippy --all-targets -- -D warnings   # exit 0
$ cargo fmt --check                           # exit 0
```

After, in debug, which is what CI runs:

```
$ rtk proxy cargo test   # exit 0
passed 428 failed 0 ignored 7
$ cargo clippy --all-targets --all-features -- -D warnings   # exit 0
$ cargo fmt --check                                          # exit 0
```

+12 tests, no regression. The held behaviours all still pass: the 11 `laws.json` examples, `42 U.S.C. §§ 1983, 1988`, and `28 U.S.C. §§ 1475 and 1477`. A letter suffix does not break list continuation — `21 U.S.C. §§ 355a, 360 and 355b` reads all three.

Every RED step was run and shown to fail first: `find_with_report` missing (exit 101, no such function), the three lettered-section tests (exit 101, `-> []`), and the dash case (exit 101, read `77z`).

## Out of scope, as the brief asked

Storing the skips as `Exclusion`s in the `Declaration` is not built. The shape is now obvious, so it is filed: #140.

An ASCII-hyphen citation such as `42 U.S.C. § 300gg-11` is read whole but cannot resolve, because the release's own identifier is `/us/usc/t42/s300gg–11` with an en dash. That is a resolution question, not an extraction one: #141.
