### PR TITLE
feat: record a redesignation as a link, and answer continuity by walking them (#93)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -65,7 +65,11 @@ _Avoid_: Metadata, extra, blob
 **Provision**:
 A unit of law that stays the same thing across versions, even when its text changes or it moves to a new address. Its identity does not depend on its location. A Document node is how one is stored; a Provision is what one is.
 
-**The identity this definition needs does not exist yet.** Nothing in the code mints or carries one. A provision is reached by a Structural path plus a position within one Expression, which locates it and does not identify it, so "is this the same provision as last year" — the question a researcher actually asks — has no answer today. `docs/adr/0001-structural-paths-locate-not-identify.md` records the decision to mint an identity, and #93 is the work. Read this entry as what a Provision is meant to be, and Structural path as what the code has.
+**A provision has no identity of its own, and will not be given one.** Nothing in the code mints or carries one. A provision is reached by a Structural path plus a position within one Expression, which locates it and does not identify it.
+
+"Is this the same provision as last year" is answered another way: by walking Redesignations. A provision has nothing stable to hash — its text changes, which is the point of tracking it, and its location changes, which is why identity was wanted — so #93 recorded the movement as an edge instead of minting an id. `docs/adr/0001-structural-paths-locate-not-identify.md` records the identity it recommended and the note that replaced it.
+
+Read this entry as what a Provision is; read Structural path for how one is located, and Redesignation, under Statements about the law, for how two locations are known to be one provision.
 _Avoid_: Section, node, element
 
 **Structural path**:
@@ -90,7 +94,7 @@ The official identifier of a Document node, as published in the source document.
 _Avoid_: ID, identifier, reference
 
 **Diff**:
-The set of differences between two Expressions of one Work, in the shape of the document hierarchy.
+The set of differences between two Expressions of one Work, in the shape of the document hierarchy. A child is reported as changed, added, removed, or **moved**. Moved is what a Redesignation buys: where one is known the diff pairs across the renumbering, and where none is known it pairs by position, which is all two documents say on their own.
 _Avoid_: Delta, comparison, change set
 
 ## Bills
@@ -182,6 +186,18 @@ _Avoid_: Extra, metadata, blob
 **Change annotation**:
 The Link of kind `legislature.amended_by`. It connects one change in a Diff to the Amendment that caused it.
 _Avoid_: Match, mapping, label
+
+**Redesignation**:
+The Link of kind `legislature.redesignated_as`. It says a Provision was renumbered: the subject is the provision as it was, the object is the provision as it became, and each end names the change — a Work, a Structural path, and the two dates — so the edge says *when* the renumbering happened. A path is reused, so an edge with no dates would claim a renumbering held for all time.
+
+A Bill states it in words: "redesignating paragraph (3) as paragraph (2)". Nothing in the US Code records it, which is why a Diff that pairs by position alone reads a renumbering as a rewrite of whichever provision now holds the number, plus the disappearance of the one that moved.
+
+A redesignation a Bill states and the parser cannot resolve to two paths is **reported**, never dropped. The tool's silence must not read as the corpus's silence.
+_Avoid_: Rename, alias, move
+
+**Provision history**:
+The Redesignations one Provision ran through, walked out of the links, oldest first. A projection: nothing stores it, so a Bill added later adds an edge rather than rewriting an identity, and nothing that already points somewhere breaks (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`). An empty history is an answer — the provision has always been where it is — and not a failure.
+_Avoid_: Chain, lineage, ancestry
 
 **Extension**:
 A named set of facts that only some datasets carry, such as the legislature facts (Bill, Sponsor, Roll call) or the judicial facts (case name, opinion type). The core data model carries no extension concept, and no document class either. A Link's kind is an open namespaced string, a Document node's type is an open namespaced string, and in both cases the facts only one namespace understands sit in a payload the core stores and never reads (Kind payload, Class payload).

--- a/docs/adr/0001-structural-paths-locate-not-identify.md
+++ b/docs/adr/0001-structural-paths-locate-not-identify.md
@@ -1,14 +1,20 @@
 # Structural paths locate provisions; they do not identify them
 
-Status: accepted. **Partly implemented — see Implementation status.**
+Status: accepted. **The identity this ADR recommends was not built, and will not be — see Implementation status.**
 
 ## Implementation status
 
-The paragraph below says "we therefore give each provision a stable identity", in the settled tense. **We have not.** No provision identity is minted or carried anywhere in the code. `Target::Provision` names a provision by path, and `WorkId` holds a structural path for the same reason (`docs/adr/0003-storage-is-keyed-by-work.md` records that debt too).
+The paragraph below says "we therefore give each provision a stable identity", in the settled tense. **We have not, and #93 decided not to.** No provision identity is minted or carried anywhere in the code, and none is planned. `Target::Provision` names a provision by path, and `WorkId` holds a structural path for the same reason (`docs/adr/0003-storage-is-keyed-by-work.md` records that debt too).
 
-What is implemented is the second half: the path is treated as a locator, a path may name more than one provision, and the position is recorded explicitly rather than left implicit. The Consequences section below is accurate about that, and says so directly — "Position is what we have until then."
+**Do not build the identity this ADR recommends.** A provision has nothing stable to hash. Its text changes, which is the point of tracking it, and its location changes, which is why identity was wanted. A minted id would move whenever a newly added bill revealed an earlier redesignation, which is the exact defect `docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md` rejected UUIDs for: "it changes on every rebuild, so nothing outside the file can point at a link."
 
-So this ADR records an accepted decision and a partly-built one. #93 is the work, and it is queued for the release window after `SCHEMA_VERSION` 7. Until then, every statement here about identity should be read as intent, and every statement about position as fact.
+**What was built instead is an edge.** A redesignation is a record — one `Link` of kind `legislature.redesignated_as`, whose subject is the provision as it was and whose object is the provision as it became, each naming a change so the edge carries the dates it was observed between. Continuity is then a **projection**: "is this the same provision as last year" is answered by walking those links, forwards and backwards, and nothing stores the chain (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`, `LinkReader::provision_history`).
+
+An edge is preferred because it is additive. Adding a bill later adds an edge, where minting an identity would rewrite one, so nothing that already points somewhere breaks. #93 therefore needed no `SCHEMA_VERSION` bump and no rebuild, and `Target` did not change.
+
+What was already implemented is the second half of this ADR: the path is treated as a locator, a path may name more than one provision, and the position is recorded explicitly rather than left implicit. The Consequences section below is accurate about that, except where it says identity is the fix; see the note there.
+
+So this ADR records a problem statement that still holds and a remedy that was replaced. Read every statement about the path as a locator as fact, and every statement about a minted identity as a proposal that #93 answered another way.
 
 ### A gap this ADR did not anticipate
 
@@ -26,22 +32,34 @@ Legal sources often supply no usable identifier, so we derive a structural path 
 
 We therefore give each provision a stable identity that is carried across versions, and we treat the structural path as a locator at one point in time. Links point at the identity and record the locator beside it.
 
-> **Not built.** The identity in that paragraph does not exist in the code; a link points at a path. The second half — the path as a locator — is built. See Implementation status above, and #93.
+> **Not built, and superseded.** The identity in that paragraph does not exist in the code, and #93 decided against minting one; a link points at a path, and a *second* link says where that path moved to. The second half — the path as a locator — is built. See Implementation status above.
 
 ## Consequences
 
 Without this, three things break quietly. A `Move` reads as a delete plus an add, so the diff reports a change to law that did not change. Human-confirmed annotations, which point at path strings today (`ChangeAnnotation.paths`), silently attach to different text after a parser change, and the party who receives the file cannot detect it. And "is this the same provision as last year", which is the question a legal researcher actually asks, has no answer.
 
+> **The first and third are answered, by links rather than by identity.** A redesignation is stored as a `legislature.redesignated_as` link, the diff consults those links before it pairs by position, and "is this the same provision as last year" is walked out of them (#93). The second — an annotation attaching to different text after a parser change — is not: a link still names a path, and a parser change still moves it silently.
+
 A locator is not only stale across versions; it can be ambiguous within one. The law sometimes numbers two provisions alike — `26 U.S.C. § 45X(d)(4)` is two paragraphs (4), which the Code footnotes as "So in original" and the official site renders in full — so one path names both. Code that treats a path as unique within an expression does not fail loudly. It picks one and discards the other, which is the confident false statement this decision exists to avoid.
 
 Where a path names more than one provision, the document's order decides which is which. We inherit the order the source gives, pair provisions by position, and record the position explicitly rather than leaving it implicit in a parse. A parse keeps the order; a round trip through storage or a reserialized report is where it goes missing, and it goes missing silently. The alternatives to position are worse. Pairing by content similarity invents a judgement the source did not make, and treating a collision as an error refuses to hold law that genuinely exists.
 
-Position pairing has one limit, which we accept for now. When the number of provisions at a path falls, it assumes the survivors are the leading ones. If the source instead drops the first and keeps the second, the diff reports a large text change plus a removal, rather than the removal that happened. The corpus has not shown this yet: at `26 U.S.C. § 6724(d)(2)`, where two subparagraphs (JJ) became one between 2025-07-18 and 2025-07-30, the survivor is the first and position pairing is correct. That is luck rather than design, because nothing in the pairing can tell the two apart. A stable provision identity is what fixes this. Position is what we have until then.
+Position pairing has one limit. When the number of provisions at a path falls, it assumes the survivors are the leading ones. If the source instead drops the first and keeps the second, the diff reports a large text change plus a removal, rather than the removal that happened.
 
-The cost is one more identifier to mint and carry. We already do this for amendments, where `amendment_id` is a content hash, so the mechanism is not new.
+> **The corpus does show this, and this ADR looked for the wrong shape.** It searched for a swap of two provisions *sharing one path*, found none, and concluded the case was hypothetical. The real shape is a renumbering: `119-hr-1` struck `26 U.S.C. § 898(c)(2)` and renumbered (3) as (2), so paragraph (2) after the bill is paragraph (3) before it, and the diff reported (2) as rewritten and gaining children while (3) read as simply gone. Both statements are false. The corpus holds 57 `redesignate` actions.
+>
+> **What fixes it is the redesignation link, not an identity.** Where a link says a provision was renumbered, the diff pairs across the renumbering and reports the displaced provision as removed (`TreeDiff::from_nodes_with`, `TreeDiff::moved`). Where no link is known, position is still what we have, which is why the `§ 6724(d)(2)` case below keeps position pairing.
+
+The corpus's other example is genuinely unresolvable, and keeps position pairing. At `26 U.S.C. § 6724(d)(2)`, two subparagraphs (JJ) became one between 2025-07-18 and 2025-07-30. The survivor is the first, so position pairing happens to be right, and nothing in the source says which of the two it is — no bill states a redesignation there, so there is no link to consult and no honest answer beyond position.
+
+The cost of the edge, rather than an identifier, is that continuity has to be walked rather than read. That is a projection, computed on demand, and it is the price of the property that matters: adding a bill later adds an edge instead of rewriting an identity (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`).
 
 ## Considered and rejected
 
 **The path is the identity.** Simplest, and wrong in a way that produces confident false statements rather than errors.
 
 **The path is the identity, plus an alias table of renames.** This puts the truth in a side table. A reader that does not consult it gets the wrong answer, and no other implementation of the format is obliged to consult it.
+
+> **A redesignation link is not that table, and the difference is the point.** An alias table is a private index beside the data. A link is the data: `docs/adr/0002-links-live-in-the-core.md` requires every reader to see a link, read its subject and object, report its verification state and preserve it when it writes the file again, whether or not it understands the kind. So a reader that does not walk `legislature.redesignated_as` still *sees* it and can say a renumbering was recorded. It gets a coarser diff, not a confident wrong answer, and it can tell which it has.
+>
+> The link also carries provenance naming the bill that said so, which an alias table has no place for. A rename with no source is an assertion nobody can check.

--- a/src/bin/words_to_data/diff.rs
+++ b/src/bin/words_to_data/diff.rs
@@ -40,6 +40,17 @@ pub fn run(args: Args) {
     print_paths("Changed", &summary.changed_paths);
     print_paths("Added", &summary.added_paths);
     print_paths("Removed", &summary.removed_paths);
+
+    // A move is not a removal plus an addition, so it gets its own list. An
+    // empty one is not printed: every dataset has none until `redesignations`
+    // has run, and a heading saying "Moved (0)" reads as a claim that nothing
+    // moved (#93).
+    if !summary.moved_paths.is_empty() {
+        println!("\nMoved ({}):", summary.moved_paths.len());
+        for moved in &summary.moved_paths {
+            println!("  {} -> {}", moved.from, moved.to);
+        }
+    }
 }
 
 fn print_paths(label: &str, paths: &[String]) {

--- a/src/bin/words_to_data/main.rs
+++ b/src/bin/words_to_data/main.rs
@@ -16,6 +16,7 @@ mod info;
 mod load;
 mod match_amendments;
 mod path;
+mod redesignations;
 mod report;
 mod score_amendments;
 mod search;
@@ -44,6 +45,8 @@ enum Command {
     ScoreAmendments(score_amendments::Args),
     /// Match bill amendments to US Code changes via an LLM and annotate the dataset
     MatchAmendments(match_amendments::Args),
+    /// Record the provisions a bill renumbered, as links (deterministic, no LLM)
+    Redesignations(redesignations::Args),
 
     // --- Inspection (read-only) ---
     /// Show a dataset's metadata and headline counts
@@ -78,6 +81,7 @@ fn main() {
         Command::ExtractChanges(args) => extract_changes::run(args),
         Command::ScoreAmendments(args) => score_amendments::run(args),
         Command::MatchAmendments(args) => match_amendments::run(args),
+        Command::Redesignations(args) => redesignations::run(args),
         Command::Info(args) => info::run(args),
         Command::Expressions(args) => expressions::run(args),
         Command::Bills(args) => bills::run(args),

--- a/src/bin/words_to_data/redesignations.rs
+++ b/src/bin/words_to_data/redesignations.rs
@@ -1,0 +1,110 @@
+//! `words_to_data redesignations` — record the provisions a bill renumbered.
+//!
+//! Reads the `redesignate` clauses out of a bill's markup, resolves each one to
+//! the two paths it moved a provision between, and writes each as a
+//! `legislature.redesignated_as` link. The diff then pairs a renumbered provision
+//! with what it became instead of with whatever took its number (#93).
+//!
+//! Takes the bill's XML rather than the bill the dataset stores. Which provision
+//! a clause is about comes from where the words sat in the markup — a clause
+//! inside "in subsection (a)--" means something different from the same clause
+//! outside it — and a stored amendment keeps only the flattened text.
+//!
+//! **Every statement it cannot place is printed.** A run that resolved nothing
+//! and said nothing would read as a corpus with no redesignations in it, and the
+//! corpus is full of them.
+
+use clap::Args as ClapArgs;
+use words_to_data::dataset::{Dataset, Format};
+use words_to_data::legislature::redesignation::RedesignationReport;
+use words_to_data::storage::DocumentReader;
+use words_to_data::uslm::bill_redesignation::redesignations_stated_in_file;
+
+use crate::span::Span;
+
+#[derive(ClapArgs)]
+pub struct Args {
+    /// Path to a dataset (compact JSON) holding the works the bill amends
+    pub dataset: String,
+
+    /// The bill's USLM XML, such as a `public_law.xml` from the Congress cache
+    #[arg(long)]
+    pub bill_xml: String,
+
+    /// How the bill is named in links and reports, such as `119-hr-1`
+    #[arg(long)]
+    pub bill_id: String,
+
+    #[command(flatten)]
+    pub span: Span,
+
+    /// Where to write the dataset (defaults to overwriting the input)
+    #[arg(long)]
+    pub output: Option<String>,
+}
+
+pub fn run(args: Args) {
+    crate::load::refuse_sqlite(&args.dataset, "redesignations");
+    let mut dataset = crate::fail::or_exit(
+        Dataset::load(&args.dataset, Format::Compact),
+        "Error loading dataset",
+    );
+
+    let stated = crate::fail::or_exit(
+        redesignations_stated_in_file(&args.bill_id, &args.bill_xml),
+        "Error reading the bill",
+    );
+    println!("{} states {} redesignation(s).", args.bill_id, stated.len());
+
+    // One report per work. A statement resolves in the work that holds its
+    // section and fails in every other, so the reports are folded rather than
+    // concatenated (`RedesignationReport::across_works`).
+    let pairs = args.span.resolve(&dataset as &dyn DocumentReader);
+    let mut per_work = Vec::new();
+    for (from, to) in &pairs {
+        let report = crate::fail::or_exit(
+            dataset.record_redesignations(&args.bill_id, &stated, from, to),
+            "Error recording redesignations",
+        );
+        per_work.push(report);
+    }
+    let report = RedesignationReport::across_works(per_work);
+
+    println!(
+        "Recorded {} link(s) across {} work pair(s).",
+        report.resolved.len(),
+        pairs.len()
+    );
+    if report.unresolved.is_empty() {
+        println!("Every statement was placed.");
+    } else {
+        println!(
+            "\n{} statement(s) could not be placed. Each is a redesignation the \
+             corpus states and this build cannot turn into two paths:",
+            report.unresolved.len()
+        );
+        for unresolved in &report.unresolved {
+            println!("  {}", unresolved.reason);
+            println!("    {}", first_words(&unresolved.text));
+        }
+    }
+
+    let output = args.output.as_deref().unwrap_or(&args.dataset);
+    crate::fail::or_exit(
+        dataset.save(output, Format::Compact),
+        "Error saving dataset",
+    );
+    println!("\nWrote {output}");
+}
+
+/// The start of a clause, so one statement stays one line.
+///
+/// A clause that enacts new text carries the whole of it, which runs to
+/// thousands of characters and buries every other line of the report.
+fn first_words(text: &str) -> String {
+    const SHOWN: usize = 140;
+    match text.char_indices().nth(SHOWN) {
+        Some((end, _)) => format!("{}…", &text[..end]),
+        None => text.to_string(),
+    }
+}

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -23,10 +23,11 @@ use crate::annotation::ChangeAnnotation;
 use crate::congress::{
     BillDownload, BillVotes, CosponsorRecord, HouseRollCall, Member, SponsorInfo, VotePosition,
 };
-use crate::diff::TreeDiff;
+use crate::diff::{Redesignations, TreeDiff};
 use crate::document::DocumentNode;
 use crate::legislature::BillDiff;
-use crate::link::Link;
+use crate::legislature::redesignation::{self, RedesignationReport};
+use crate::link::{Link, ProvisionHistory};
 use crate::storage::{
     DocumentReader, DocumentWriter, EvidenceReader, EvidenceWriter, InMemoryStorage,
     LegislatureCounts, LegislatureReader, LegislatureWriter, LinkReader, LinkWriter, SqliteStorage,
@@ -183,12 +184,86 @@ impl<S: Storage> Dataset<S> {
         self.storage.get_annotations(from, to)
     }
 
+    /// The differences between two expressions of one work.
+    ///
+    /// Where a redesignation link says a provision was renumbered between these
+    /// two dates, the provision is paired with what it became, so the provision
+    /// it displaced reads as removed rather than as rewritten. Where none is
+    /// known, pairing is by position, exactly as before (#93).
+    ///
+    /// [`DocumentReader::compute_diff`] on a bare backend cannot do this, because
+    /// a document reader holds no links. A dataset holds both.
     pub fn compute_diff(
         &self,
         from: &ExpressionId,
         to: &ExpressionId,
     ) -> Result<TreeDiff, DatasetError> {
-        self.storage.compute_diff(from, to)
+        self.diff_over_links(from, to)
+    }
+
+    /// The diff, with a renumbered provision paired to what it became.
+    ///
+    /// Delegates to the backend when this dataset holds no redesignation for the
+    /// pair, which is every dataset until `record_redesignations` has run. That
+    /// keeps the ordinary path exactly as fast as it was, and keeps a backend
+    /// free to answer a diff its own way.
+    fn diff_over_links(
+        &self,
+        from: &ExpressionId,
+        to: &ExpressionId,
+    ) -> Result<TreeDiff, DatasetError> {
+        let known = Redesignations::from_links(&self.storage.links_for_pair(from, to)?);
+        if known.is_empty() {
+            return self.storage.compute_diff(from, to);
+        }
+        let (from_expression, to_expression) =
+            crate::storage::memory::require_same_work(&self.storage, from, to)?;
+        Ok(TreeDiff::from_nodes_with(
+            &from_expression.root,
+            &to_expression.root,
+            &known,
+        ))
+    }
+
+    /// Read the redesignations a bill states and record each one as a link.
+    ///
+    /// `from` must be the earlier expression: a redesignation moves a provision
+    /// *away* from a path, and that path only exists before the move, so the
+    /// earlier document is what a statement can be checked against.
+    ///
+    /// Takes statements the caller has already read, rather than the bill this
+    /// dataset stores. Which provision a clause is about comes from where the
+    /// words sat in the bill's markup — a clause inside "in subsection (a)--"
+    /// means something different from the same clause outside it — and a stored
+    /// amendment keeps only the flattened text. Read them with
+    /// [`crate::uslm::bill_redesignation::redesignations_stated`].
+    ///
+    /// Returns the report, including every statement it could not place. A
+    /// caller that drops the report turns this build's silence into the corpus's
+    /// silence.
+    pub fn record_redesignations(
+        &mut self,
+        bill_id: &str,
+        stated: &[redesignation::StatedRedesignation],
+        from: &ExpressionId,
+        to: &ExpressionId,
+    ) -> Result<RedesignationReport, DatasetError> {
+        let (from_expression, _) =
+            crate::storage::memory::require_same_work(&self.storage, from, to)?;
+        let report = redesignation::resolve(stated, &from_expression.root);
+        for resolved in &report.resolved {
+            self.storage
+                .add_link(resolved.link(&from.work, &from.at, &to.at, bill_id))?;
+        }
+        Ok(report)
+    }
+
+    /// The renumberings one provision ran through, oldest first.
+    ///
+    /// A projection over the redesignation links, walked on demand. See
+    /// [`LinkReader::provision_history`].
+    pub fn provision_history(&self, path: &str) -> Result<ProvisionHistory, DatasetError> {
+        self.storage.provision_history(path)
     }
 
     pub fn search_text(&self, query: &str) -> Result<Vec<SearchResult>, DatasetError> {
@@ -630,12 +705,17 @@ impl<S: Storage> DocumentReader for Dataset<S> {
         self.storage.prev_expression(id)
     }
 
+    /// The differences between two expressions, over the links as well as the
+    /// documents.
+    ///
+    /// A dataset holds both, so it answers the better question. See
+    /// [`Dataset::compute_diff`].
     fn compute_diff(
         &self,
         from: &ExpressionId,
         to: &ExpressionId,
     ) -> Result<TreeDiff, DatasetError> {
-        self.storage.compute_diff(from, to)
+        self.diff_over_links(from, to)
     }
 
     fn search_text(&self, query: &str) -> Result<Vec<SearchResult>, DatasetError> {

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -130,8 +130,120 @@ pub struct TreeDiff {
     /// Child elements that were removed from the old version
     pub removed: Vec<NodeData>,
 
+    /// Child elements renumbered between the two versions.
+    ///
+    /// Empty unless the caller supplied the redesignations that apply, which is
+    /// every diff computed straight from two trees
+    /// ([`TreeDiff::from_nodes_with`]).
+    ///
+    /// A projection, like the rest of this struct: it is computed from the two
+    /// documents and the links, and nothing stores it
+    /// (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub moved: Vec<NodeMove>,
+
     /// Recursive diffs for child elements present in both versions
     pub child_diffs: Vec<TreeDiff>,
+}
+
+/// A child element that changed its number: the same law, addressed differently.
+///
+/// Reported separately from a change, an addition and a removal, because it is
+/// none of those. Before this existed, a bill that struck paragraph (2) and
+/// renumbered (3) as (2) read as a rewrite of (2) plus the disappearance of (3) —
+/// two false statements about what the law did (#93).
+///
+/// The subtree below a moved element is **not** descended into. Every path inside
+/// it changed with its parent, so pairing it would need the whole subtree
+/// rebased, and the corpus's only case renumbered a provision whose words did
+/// not change. A moved element whose contents also changed is the next case to
+/// build, and there is no sample of it.
+// No `Eq` or `Hash`, for the reason `TreeDiff` has none.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct NodeMove {
+    /// The element as it was, at the path it had.
+    pub from: NodeData,
+
+    /// The element as it became, at the path it was given.
+    pub to: NodeData,
+
+    /// Text content changes at the element itself, when the same amendment
+    /// changed its words as well as its number. Usually empty: a redesignation
+    /// renumbers, and something else rewrites.
+    pub changes: Vec<FieldChangeEvent>,
+}
+
+/// The redesignations that apply between two versions of a document.
+///
+/// A lookup from the path a provision had to the path it was given. The diff asks
+/// this before it pairs by position, so a renumbered provision is paired with
+/// what it became rather than with whatever took its number.
+///
+/// Built from either side of the model: from the links a dataset holds
+/// ([`Redesignations::from_links`]), or from redesignations just read out of a
+/// bill ([`Redesignations::from_pairs`]). The diff therefore depends on neither
+/// storage nor a bill parser.
+#[derive(Debug, Clone, Default)]
+pub struct Redesignations {
+    /// Old path to new path. One old path moves to one new path: a provision
+    /// cannot become two.
+    by_old_path: HashMap<String, String>,
+}
+
+impl Redesignations {
+    /// Nothing known, so pairing is by position alone.
+    ///
+    /// The honest answer for a reader holding no links, and what
+    /// [`TreeDiff::from_nodes`] uses.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Build from pairs of old path and new path.
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (String, String)>) -> Self {
+        Self {
+            by_old_path: pairs.into_iter().collect(),
+        }
+    }
+
+    /// Build from the `legislature.redesignated_as` links among those given.
+    ///
+    /// A link of any other kind is skipped. Both ends of a redesignation link
+    /// name a change — a provision as it read across two dates — so a link whose
+    /// ends are shaped otherwise is not one of ours and is left alone.
+    pub fn from_links(links: &[crate::link::Link]) -> Self {
+        use crate::link::{LinkKind, Target};
+
+        let redesignated_as = LinkKind::new(LinkKind::REDESIGNATED_AS);
+        let path_of = |target: &Target| match target {
+            Target::Change { path, .. } => Some(path.clone()),
+            Target::Provision(path) => Some(path.clone()),
+            _ => None,
+        };
+        Self::from_pairs(
+            links
+                .iter()
+                .filter(|link| link.kind == redesignated_as)
+                .filter_map(|link| Some((path_of(&link.subject)?, path_of(&link.object)?))),
+        )
+    }
+
+    /// True when nothing is known, so the diff behaves exactly as it did before
+    /// redesignations existed.
+    pub fn is_empty(&self) -> bool {
+        self.by_old_path.is_empty()
+    }
+
+    /// How many redesignations are known.
+    pub fn len(&self) -> usize {
+        self.by_old_path.len()
+    }
+
+    /// The path a provision was given, when one is known.
+    fn new_path_of(&self, old_path: &str) -> Option<&str> {
+        self.by_old_path.get(old_path).map(String::as_str)
+    }
 }
 
 impl TreeDiff {
@@ -262,37 +374,67 @@ impl TreeDiff {
         self.changes.is_empty()
             && self.added.is_empty()
             && self.removed.is_empty()
+            && self.moved.is_empty()
             && self.child_diffs.is_empty()
     }
 
-    /// Group an element's children by path, keeping document order within each.
+    /// Group children by path, keeping document order within each.
     ///
     /// A path can name more than one child, so the value is every child that
     /// carries it rather than one of them.
-    fn children_by_path(element: &DocumentNode) -> HashMap<&str, Vec<&DocumentNode>> {
+    fn children_by_path<'a>(
+        children: &[&'a DocumentNode],
+    ) -> HashMap<&'a str, Vec<&'a DocumentNode>> {
         let mut by_path: HashMap<&str, Vec<&DocumentNode>> = HashMap::new();
-        for child in &element.children {
+        for child in children {
             by_path.entry(&child.data.path).or_default().push(child);
         }
         by_path
     }
 
+    /// Diff two versions of one element, pairing its children by position.
+    ///
+    /// Position is all a pair of documents says on its own. Where a bill
+    /// renumbered a provision, pairing by position reads the renumbering as a
+    /// rewrite; give the redesignations to [`TreeDiff::from_nodes_with`] and it
+    /// pairs across them instead.
     pub fn from_nodes(from_element: &DocumentNode, to_element: &DocumentNode) -> TreeDiff {
+        Self::from_nodes_with(from_element, to_element, &Redesignations::none())
+    }
+
+    /// Diff two versions of one element, pairing a renumbered provision with
+    /// what it became.
+    ///
+    /// A redesignation takes precedence over position; where none is known,
+    /// position is what we have (`docs/adr/0001-structural-paths-locate-not-identify.md`).
+    pub fn from_nodes_with(
+        from_element: &DocumentNode,
+        to_element: &DocumentNode,
+        known: &Redesignations,
+    ) -> TreeDiff {
         assert!(from_element.data.path == to_element.data.path);
         let root_path = from_element.data.path.clone();
         // 1. Diff the root element's fields
         let changes = diff_nodes(from_element, to_element);
 
-        // 2. Build HashMaps of children by path
+        // 2. Pair off the children a bill renumbered, and take them out of the
+        // position pairing below. A renumbered child holds a number that was
+        // somebody else's, so leaving it in would make the two fight over it.
+        let renumbered = plan_moves(from_element, to_element, known);
+        let moved = renumbered.moves(from_element, to_element);
+        let children_left_a = renumbered.remaining(&from_element.children, Side::Old);
+        let children_left_b = renumbered.remaining(&to_element.children, Side::New);
+
+        // 3. Build HashMaps of children by path
         // A path can name more than one child: the law sometimes numbers two
         // provisions alike and the document records both (`docs/adr/0001`). So
         // each path maps to the children that carry it, in document order,
         // rather than to a single element. Keying by path alone made the second
         // provision invisible — a change to it could not be reported at all.
-        let children_a = Self::children_by_path(from_element);
-        let children_b = Self::children_by_path(to_element);
+        let children_a = Self::children_by_path(&children_left_a);
+        let children_b = Self::children_by_path(&children_left_b);
 
-        // 3. Find added, removed, matched
+        // 4. Find added, removed, matched
         let mut added = vec![];
         let mut removed = vec![];
         let mut child_diffs = vec![];
@@ -305,7 +447,7 @@ impl TreeDiff {
         // first on one side answers to the first on the other. Order therefore
         // carries meaning, and a swap in the source is a real change.
         let mut seen: HashMap<&str, usize> = HashMap::new();
-        for child_a in &from_element.children {
+        for child_a in &children_left_a {
             let path = &*child_a.data.path;
             let occurrence = seen.entry(path).or_insert(0);
             let index = *occurrence;
@@ -318,7 +460,7 @@ impl TreeDiff {
                     // `changes` and `child_diffs` here dropped a child whose
                     // sole content was an added or removed element, which lost
                     // every pure insertion in the tree (#54).
-                    let child_diff = TreeDiff::from_nodes(child_a, child_b);
+                    let child_diff = TreeDiff::from_nodes_with(child_a, child_b, known);
                     if !child_diff.is_empty() {
                         child_diffs.push(child_diff);
                     }
@@ -332,7 +474,7 @@ impl TreeDiff {
 
         // Iterate through B for added only, again in document order.
         let mut seen = HashMap::new();
-        for child_b in &to_element.children {
+        for child_b in &children_left_b {
             let path = &*child_b.data.path;
             let occurrence = seen.entry(path).or_insert(0);
             let index = *occurrence;
@@ -354,6 +496,7 @@ impl TreeDiff {
             to_element: to_element.data.clone(),
             added,
             removed,
+            moved,
             child_diffs,
         }
     }
@@ -644,6 +787,7 @@ impl TreeDiff {
             to_element: self.to_element.clone(),
             added: self.added.clone(),
             removed: self.removed.clone(),
+            moved: self.moved.clone(),
             child_diffs: vec![],
         }
     }
@@ -702,6 +846,92 @@ pub struct MentionMatch {
     pub matched_text: String,
 }
 
+/// Which of an element's children paired across a renumbering.
+///
+/// Held as index pairs into the two child lists, because both sides need to be
+/// taken out of the position pairing and a path cannot say which occurrence.
+#[derive(Debug, Default)]
+struct MovePlan {
+    /// One old child's index against the new child's index it became.
+    pairs: Vec<(usize, usize)>,
+}
+
+/// Which side of a diff a child list belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Side {
+    Old,
+    New,
+}
+
+/// Pair off the children a bill renumbered.
+///
+/// Old-document order, so the answer does not depend on a hash. A new child is
+/// claimed once: two old provisions renumbered to one path would be a statement
+/// the bill did not make, and the second is left to position pairing rather than
+/// paired over the first.
+fn plan_moves(
+    from_element: &DocumentNode,
+    to_element: &DocumentNode,
+    known: &Redesignations,
+) -> MovePlan {
+    if known.is_empty() {
+        return MovePlan::default();
+    }
+    let mut pairs = Vec::new();
+    let mut claimed: HashSet<usize> = HashSet::new();
+    for (old_index, child_a) in from_element.children.iter().enumerate() {
+        let Some(new_path) = known.new_path_of(&child_a.data.path) else {
+            continue;
+        };
+        let found = to_element
+            .children
+            .iter()
+            .enumerate()
+            .find(|(new_index, child_b)| {
+                *child_b.data.path == *new_path && !claimed.contains(new_index)
+            });
+        if let Some((new_index, _)) = found {
+            claimed.insert(new_index);
+            pairs.push((old_index, new_index));
+        }
+    }
+    MovePlan { pairs }
+}
+
+impl MovePlan {
+    /// The moves themselves, with any change to the moved element's own words.
+    fn moves(&self, from_element: &DocumentNode, to_element: &DocumentNode) -> Vec<NodeMove> {
+        self.pairs
+            .iter()
+            .filter_map(|(old_index, new_index)| {
+                let child_a = from_element.children.get(*old_index)?;
+                let child_b = to_element.children.get(*new_index)?;
+                Some(NodeMove {
+                    from: child_a.data.clone(),
+                    to: child_b.data.clone(),
+                    changes: field_changes(child_a, child_b),
+                })
+            })
+            .collect()
+    }
+
+    /// The children on one side that no move claimed, in document order.
+    fn remaining<'a>(&self, children: &'a [DocumentNode], side: Side) -> Vec<&'a DocumentNode> {
+        let claimed = |index: usize| {
+            self.pairs.iter().any(|(old_index, new_index)| match side {
+                Side::Old => *old_index == index,
+                Side::New => *new_index == index,
+            })
+        };
+        children
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| !claimed(*index))
+            .map(|(_, child)| child)
+            .collect()
+    }
+}
+
 /// Check if a word is a stop word (case-insensitive)
 fn is_stop_word(word: &str) -> bool {
     let lower = word.to_lowercase();
@@ -733,6 +963,16 @@ pub fn diff_nodes(element_a: &DocumentNode, element_b: &DocumentNode) -> Vec<Fie
     // across two dates. The type is an open string, so this compares what the
     // producer wrote rather than a vocabulary the core owns (#129).
     assert!(element_a.data.node_type == element_b.data.node_type);
+    field_changes(element_a, element_b)
+}
+
+/// Compute field-level changes between two elements that need not share a path.
+///
+/// What [`diff_nodes`] does, without its two checks. A renumbered provision sits
+/// at a different path on each side, by definition, and a bill can renumber it to
+/// another level as well — `redesignating paragraph (1) as subparagraph (A)` — so
+/// neither the path nor the type can be required to match.
+fn field_changes(element_a: &DocumentNode, element_b: &DocumentNode) -> Vec<FieldChangeEvent> {
     let mut changes: Vec<FieldChangeEvent> = Vec::new();
     for field_name in [
         TextContentField::Heading,

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -679,9 +679,24 @@ pub struct DiffSummary {
     pub added_paths: Vec<String>,
     /// Paths of elements removed from the older version.
     pub removed_paths: Vec<String>,
+    /// Elements a bill renumbered: where each was, and where it went.
+    ///
+    /// Empty unless the dataset holds redesignation links for the pair. Reported
+    /// beside the other three rather than folded into them, because a move is
+    /// none of them: reading it as a removal plus an addition is the false
+    /// statement the links exist to remove (#93).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub moved_paths: Vec<MovedPath>,
 }
 
-/// Recursively collect changed/added/removed paths from a diff tree.
+/// One element that changed its number, for a report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MovedPath {
+    pub from: String,
+    pub to: String,
+}
+
+/// Recursively collect changed/added/removed/moved paths from a diff tree.
 fn collect_diff_paths(diff: &TreeDiff, summary: &mut DiffSummary) {
     if !diff.changes.is_empty() {
         summary.changed_paths.push(diff.root_path.clone());
@@ -692,6 +707,12 @@ fn collect_diff_paths(diff: &TreeDiff, summary: &mut DiffSummary) {
     summary
         .removed_paths
         .extend(diff.removed.iter().map(|e| e.path.to_string()));
+    summary
+        .moved_paths
+        .extend(diff.moved.iter().map(|m| MovedPath {
+            from: m.from.path.to_string(),
+            to: m.to.path.to_string(),
+        }));
     for child in &diff.child_diffs {
         collect_diff_paths(child, summary);
     }
@@ -713,6 +734,7 @@ pub fn diff<S: Storage>(
         changed_paths: Vec::new(),
         added_paths: Vec::new(),
         removed_paths: Vec::new(),
+        moved_paths: Vec::new(),
     };
     collect_diff_paths(&tree, &mut summary);
     Ok(summary)

--- a/src/legislature/mod.rs
+++ b/src/legislature/mod.rs
@@ -10,6 +10,8 @@
 //! needs these types and has no USLM to speak of, and a court opinion needs
 //! none of them at all.
 
+pub mod redesignation;
+
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};

--- a/src/legislature/redesignation.rs
+++ b/src/legislature/redesignation.rs
@@ -1,0 +1,1035 @@
+//! A redesignation: a provision that a bill renumbered.
+//!
+//! A bill says "redesignating paragraph (3) as paragraph (2)", and the provision
+//! stays the same law under a new number. Nothing in the US Code records that.
+//! Two release points later, the diff sees a paragraph (2) whose text is
+//! unrecognisable and a paragraph (3) that is gone, and reports a rewrite plus a
+//! removal — a confident false statement about what the law did.
+//!
+//! # Why this is a link and not an identity
+//!
+//! `docs/adr/0001-structural-paths-locate-not-identify.md` recommended giving
+//! each provision a stable identity. A provision has nothing stable to hash: its
+//! text changes, which is the point of tracking it, and its location changes,
+//! which is why identity was wanted. A minted id would move whenever a newly
+//! added bill revealed an earlier redesignation, which is the defect
+//! `docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md` rejected
+//! UUIDs for.
+//!
+//! A redesignation is therefore a **record**: one `Link` of kind
+//! `legislature.redesignated_as`, whose subject is the provision as it was and
+//! whose object is the provision as it became. A provision's continuity is a
+//! **projection** over those links, computed on demand and never stored
+//! (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`).
+//!
+//! # Reading and resolving are separate
+//!
+//! [`read_clause`] reads the words. It needs no US Code, because the words are
+//! the same whatever format the bill arrived in.
+//!
+//! [`resolve`] turns the words into paths. That needs the section under
+//! amendment and the document as it read before the bill, so a path can be
+//! checked against law that is really there.
+//!
+//! A redesignation the text states and this module cannot resolve is
+//! **reported**, never dropped: [`RedesignationReport::unresolved`] names each
+//! one and says why. Silence is the failure mode here, and it is the rule #110
+//! set for unknown elements.
+//!
+//! # What this does not handle
+//!
+//! [`crate::legislature::AmendingAction::Move`] — a provision relocated rather
+//! than renumbered, such as a section transferred to another title. Nothing in
+//! the committed corpus carries one, so there is no real fixture to build
+//! against and `CLAUDE.md` forbids inventing one. The model already permits it:
+//! a link's two ends carry a work each, so an edge may cross from one work to
+//! another. **A sample is needed before this is built.**
+//!
+//! A redesignation stated against a *container* rather than a section is not
+//! handled either. `Part VII of subchapter B of chapter 1 is amended by
+//! redesignating section 224 as section 225` renumbers a whole section, and the
+//! container under amendment is a part. [`resolve`] starts from a section, so
+//! these are reported with [`Reason::NoSectionNamed`]. Three statements in the
+//! corpus take that form.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::document::DocumentNode;
+use crate::link::{
+    Evidence, KindPayload, Link, LinkKind, Provenance, Target, VerificationState,
+    amendment_reference,
+};
+use crate::uslm::ElementType;
+
+/// One step of a provision's address below a section, as a bill writes it.
+///
+/// `paragraph (3)` is a level and a number. Both halves are needed: the number
+/// alone cannot say whether `(A)` is a subparagraph or an item, and a structural
+/// path spells the level out.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Designation {
+    /// The level the bill named: `paragraph` in `paragraph (3)`.
+    pub level: ElementType,
+    /// The number inside the parentheses: `3`, `c`, `A`, `iii`, `AA`.
+    pub number: String,
+}
+
+impl Designation {
+    pub fn new(level: ElementType, number: impl Into<String>) -> Self {
+        Self {
+            level,
+            number: number.into(),
+        }
+    }
+
+    /// The path segment this designation writes: `paragraph_3`.
+    ///
+    /// Built from [`ElementType::path_segment_name`], which is the same frozen
+    /// spelling the parser uses, so a path built here and a path read from a
+    /// document cannot disagree about what a level is called.
+    pub fn path_segment(&self) -> String {
+        format!("{}_{}", self.level.path_segment_name(), self.number)
+    }
+}
+
+impl fmt::Display for Designation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.path_segment())
+    }
+}
+
+/// One provision renumbered: what it was called, and what it became.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Renumbering {
+    pub from: Designation,
+    pub to: Designation,
+}
+
+impl fmt::Display for Renumbering {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {}", self.from, self.to)
+    }
+}
+
+/// Why a redesignation the text states could not be turned into two paths.
+///
+/// Each variant names something a reader can act on. "Could not parse" alone
+/// would tell a maintainer nothing about which bills to look at.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Reason {
+    /// The clause names a level this build does not know as a unit of law, such
+    /// as `the item relating to section 224`, which is a table-of-sections entry
+    /// rather than a provision.
+    NotAProvisionLevel(String),
+    /// The clause named a level but no designations followed it.
+    NoDesignations,
+    /// The clause named what a provision was, and not what it became.
+    NoNewDesignation,
+    /// A range such as `(R) through (Z)` could not be enumerated, because the
+    /// numbers at that level do not run in a series this build knows.
+    UnknownSeries(String),
+    /// Both sides read, and they name different numbers of provisions. Pairing
+    /// them would invent a correspondence the bill did not state.
+    CountsDiffer { from: usize, to: usize },
+    /// No section under amendment was named anywhere above the clause.
+    NoSectionNamed,
+    /// The amendment changes a table of sections, which is an index of the law
+    /// rather than law.
+    TableOfSections,
+    /// A section was named and nothing said which title of the Code it is in.
+    ///
+    /// A bare `Section 898` relies on the bill's own "Amendment of 1986 Code"
+    /// convention. This build resolves it only where the publisher's own
+    /// reference confirms the title, and reports it otherwise, rather than
+    /// asserting a title nobody told us.
+    NoTitleForSection(String),
+    /// The dataset does not hold the section under amendment, so nothing here
+    /// can be checked against law that is really there.
+    SectionNotHeld(String),
+    /// The container the clause sits in is not in the document at that path.
+    ContainerNotHeld(String),
+    /// One path names more than one provision here, so which one was renumbered
+    /// cannot be told apart (`docs/adr/0001-structural-paths-locate-not-identify.md`).
+    ContainerIsAmbiguous(String),
+    /// The provision the clause renumbers is not at that path in the document
+    /// as it read before the bill. Usually an amendment that acts on an earlier
+    /// amendment's result, a state no release point holds.
+    ProvisionNotHeld(String),
+}
+
+impl Reason {
+    /// Whether this reason says only "the section belongs to another work".
+    ///
+    /// The answer every work but one gives when a corpus is swept, and the least
+    /// informative one, so it is the one a fold gives up first
+    /// ([`RedesignationReport::across_works`]).
+    pub fn is_another_title(&self) -> bool {
+        matches!(self, Self::SectionNotHeld(_))
+    }
+}
+
+impl fmt::Display for Reason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotAProvisionLevel(word) => write!(f, "`{word}` is not a level of a provision"),
+            Self::NoDesignations => write!(f, "no designations followed the level"),
+            Self::NoNewDesignation => {
+                write!(f, "the clause does not say what the provision became")
+            }
+            Self::UnknownSeries(level) => {
+                write!(f, "the numbers of a {level} do not run in a known series")
+            }
+            Self::CountsDiffer { from, to } => {
+                write!(f, "{from} old designations against {to} new ones")
+            }
+            Self::NoSectionNamed => write!(f, "no section under amendment was named"),
+            Self::TableOfSections => write!(f, "a table of sections, not a provision"),
+            Self::NoTitleForSection(section) => {
+                write!(f, "nothing says which title holds section {section}")
+            }
+            Self::SectionNotHeld(id) => write!(f, "the dataset does not hold {id}"),
+            Self::ContainerNotHeld(path) => write!(f, "no provision at {path}"),
+            Self::ContainerIsAmbiguous(path) => write!(f, "{path} names more than one provision"),
+            Self::ProvisionNotHeld(path) => write!(f, "no provision at {path} before the bill"),
+        }
+    }
+}
+
+/// A redesignation as a bill stated it, before any path is resolved.
+///
+/// The reader of a bill produces these. It knows where in the bill the words
+/// sat, which is what supplies the section under amendment and the container,
+/// and it knows nothing about the US Code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatedRedesignation {
+    /// The amendment this was read out of, by its content hash.
+    pub amendment_id: String,
+    /// The clause as the bill wrote it, so a reviewer can read the words.
+    pub text: String,
+    /// The section under amendment, as a USLM identifier: `/us/usc/t26/s898`.
+    ///
+    /// `None` when the bill named no section this reader could find, which is
+    /// reported rather than guessed at.
+    pub section: Option<String>,
+    /// The steps from that section down to the container, outermost first.
+    ///
+    /// A citation such as `898(c)` gives a number and no level, so a step's
+    /// level is optional and is read from the document when it is absent.
+    pub container: Vec<Step>,
+    /// What the clause said, when it could be read.
+    pub renumberings: Vec<Renumbering>,
+    /// Why the clause could not be read, when it could not.
+    pub unreadable: Option<Reason>,
+}
+
+/// One step down from a section, as a bill named it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Step {
+    /// The number: `c`, `3`, `A`, `iii`.
+    pub number: String,
+    /// The level, when the bill named one. `Section 898(c)` names none;
+    /// `in subsection (c)` names one.
+    pub level: Option<ElementType>,
+}
+
+impl Step {
+    pub fn numbered(number: impl Into<String>) -> Self {
+        Self {
+            number: number.into(),
+            level: None,
+        }
+    }
+
+    pub fn named(level: ElementType, number: impl Into<String>) -> Self {
+        Self {
+            number: number.into(),
+            level: Some(level),
+        }
+    }
+}
+
+/// A redesignation resolved to the two paths it moved a provision between.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Redesignation {
+    /// Where the provision was before the bill.
+    pub from_path: String,
+    /// Where the bill put it.
+    pub to_path: String,
+    /// The amendment that said so.
+    pub amendment_id: String,
+    /// The clause, as the bill wrote it.
+    pub text: String,
+}
+
+/// A redesignation the text states and this build could not resolve.
+///
+/// Reported rather than dropped. A reader must be able to see that the corpus
+/// said something the tool could not place, because otherwise the tool's silence
+/// reads as the law's silence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Unresolved {
+    pub amendment_id: String,
+    /// The clause, as the bill wrote it.
+    pub text: String,
+    pub reason: Reason,
+}
+
+impl fmt::Display for Unresolved {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "warning: redesignation not resolved ({}): {}",
+            self.reason, self.text
+        )
+    }
+}
+
+/// What one sweep for redesignations found, and what it could not place.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedesignationReport {
+    pub resolved: Vec<Redesignation>,
+    pub unresolved: Vec<Unresolved>,
+}
+
+impl RedesignationReport {
+    /// How many statements were looked at: resolved plus unresolved.
+    pub fn stated(&self) -> usize {
+        self.resolved.len() + self.unresolved.len()
+    }
+
+    /// Write every unresolved statement to stderr, so it reaches the person who
+    /// ran the command.
+    ///
+    /// The crate carries no logger and the CLI writes its own warnings with
+    /// `eprintln!`, so this does the same (`crate::uslm::parser::ParseReport`).
+    pub fn warn(&self) {
+        for unresolved in &self.unresolved {
+            eprintln!("{unresolved}");
+        }
+    }
+
+    /// Fold another sweep's findings into this one.
+    pub fn absorb(&mut self, other: RedesignationReport) {
+        self.resolved.extend(other.resolved);
+        self.unresolved.extend(other.unresolved);
+    }
+
+    /// One view of a corpus, from one report per work.
+    ///
+    /// A statement resolves in the one work that holds its section and fails in
+    /// every other, so concatenating the reports would say the same statement was
+    /// unresolved fifty times over. A statement that resolved in any work is
+    /// resolved; only one that resolved nowhere is reported, once.
+    ///
+    /// The reason kept is the most telling one. Every work but one answers
+    /// [`Reason::SectionNotHeld`], which says only "this is not my title", and
+    /// keeping that would hide the one work that had the section and still could
+    /// not place the statement.
+    pub fn across_works(reports: impl IntoIterator<Item = RedesignationReport>) -> Self {
+        let mut folded = Self::default();
+        for report in reports {
+            folded.absorb(report);
+        }
+        // A statement is named by the amendment it came from and the words it
+        // was read out of. Two statements in one amendment are different
+        // statements, and their words differ, so the pair tells them apart.
+        let name_of = |amendment_id: &str, text: &str| (amendment_id.to_string(), text.to_string());
+        let placed: std::collections::HashSet<(String, String)> = folded
+            .resolved
+            .iter()
+            .map(|resolved| name_of(&resolved.amendment_id, &resolved.text))
+            .collect();
+
+        let mut best: std::collections::BTreeMap<(String, String), Unresolved> =
+            std::collections::BTreeMap::new();
+        for unresolved in &folded.unresolved {
+            let name = name_of(&unresolved.amendment_id, &unresolved.text);
+            if placed.contains(&name) {
+                continue;
+            }
+            let keep = match best.get(&name) {
+                None => true,
+                Some(held) => {
+                    held.reason.is_another_title() && !unresolved.reason.is_another_title()
+                }
+            };
+            if keep {
+                best.insert(name, unresolved.clone());
+            }
+        }
+        Self {
+            resolved: folded.resolved,
+            unresolved: best.into_values().collect(),
+        }
+    }
+}
+
+// --- Reading the words ---
+
+/// Every renumbering one redesignating clause states.
+///
+/// The clause is the amending text around a `redesignate` action. Reading stops
+/// at the first thing that is not part of a designation list, so the rest of the
+/// sentence — "and by inserting after paragraph (6) the following" — is ignored
+/// rather than mistaken for part of the statement.
+///
+/// # Examples
+///
+/// ```
+/// use words_to_data::legislature::redesignation::read_clause;
+///
+/// let one = read_clause("by redesignating paragraph (3) as paragraph (2).").unwrap();
+/// assert_eq!(one.len(), 1);
+/// assert_eq!(one[0].from.path_segment(), "paragraph_3");
+/// assert_eq!(one[0].to.path_segment(), "paragraph_2");
+///
+/// // A list pairs off in the order the clause named them.
+/// let two = read_clause(
+///     "by redesignating subsections (c) and (d) as subsections (d) and (e), respectively",
+/// )
+/// .unwrap();
+/// assert_eq!(two.len(), 2);
+/// assert_eq!(two[1].from.path_segment(), "subsection_d");
+/// assert_eq!(two[1].to.path_segment(), "subsection_e");
+///
+/// // A range is enumerated through the series that level's numbers run in.
+/// let range = read_clause(
+///     "by redesignating subparagraphs (R) through (Z) as subparagraphs (S) through (AA), respectively",
+/// )
+/// .unwrap();
+/// assert_eq!(range.len(), 9);
+/// assert_eq!(range[8].from.path_segment(), "subparagraph_Z");
+/// assert_eq!(range[8].to.path_segment(), "subparagraph_AA");
+/// ```
+pub fn read_clause(clause: &str) -> Result<Vec<Renumbering>, Reason> {
+    let rest = after_redesignating(clause).ok_or(Reason::NoDesignations)?;
+    let (from_level, rest) = read_level(rest)?;
+    let (from_numbers, rest) = read_designations(rest, from_level);
+    if from_numbers.is_empty() {
+        return Err(Reason::NoDesignations);
+    }
+
+    let rest = skip_to_new_designation(rest).ok_or(Reason::NoNewDesignation)?;
+    let (to_level, rest) = read_level(rest)?;
+    let (to_numbers, _) = read_designations(rest, to_level);
+    if to_numbers.is_empty() {
+        return Err(Reason::NoNewDesignation);
+    }
+
+    let from = expand(&from_numbers, from_level)?;
+    let to = expand(&to_numbers, to_level)?;
+    if from.len() != to.len() {
+        return Err(Reason::CountsDiffer {
+            from: from.len(),
+            to: to.len(),
+        });
+    }
+
+    Ok(from
+        .into_iter()
+        .zip(to)
+        .map(|(from, to)| Renumbering {
+            from: Designation::new(from_level, from),
+            to: Designation::new(to_level, to),
+        })
+        .collect())
+}
+
+/// The text after the word the bill uses to redesignate, with a leading `the`
+/// dropped.
+fn after_redesignating(clause: &str) -> Option<&str> {
+    let lower = clause.to_lowercase();
+    let at = lower.find("redesignat")?;
+    let rest = clause[at..].split_once(char::is_whitespace)?.1;
+    Some(
+        rest.trim_start()
+            .strip_prefix("the ")
+            .unwrap_or(rest.trim_start()),
+    )
+}
+
+/// The level word at the front of `text`, and what follows it.
+///
+/// A plural is what a list is written with — `subsections (c) and (d)` — so the
+/// trailing `s` comes off before the word is looked up.
+fn read_level(text: &str) -> Result<(ElementType, &str), Reason> {
+    let text = text.trim_start();
+    let end = text
+        .find(|c: char| !c.is_ascii_alphabetic())
+        .unwrap_or(text.len());
+    let word = &text[..end];
+    let singular = word.strip_suffix('s').unwrap_or(word);
+    match ElementType::from_str(singular) {
+        Ok(ElementType::Unknown) | Err(_) => Err(Reason::NotAProvisionLevel(word.to_string())),
+        Ok(level) if !is_provision_level(level) => {
+            Err(Reason::NotAProvisionLevel(word.to_string()))
+        }
+        Ok(level) => Ok((level, &text[end..])),
+    }
+}
+
+/// Whether a level names a unit of law a redesignation can move.
+///
+/// A `level` is the parser's container for a hierarchy it could not name, and a
+/// bill never redesignates one. Listing what is allowed, rather than what is
+/// not, keeps a new `ElementType` from silently joining the set.
+fn is_provision_level(level: ElementType) -> bool {
+    matches!(
+        level,
+        ElementType::Section
+            | ElementType::Subsection
+            | ElementType::Paragraph
+            | ElementType::Subparagraph
+            | ElementType::Clause
+            | ElementType::Subclause
+            | ElementType::Item
+            | ElementType::Subitem
+            | ElementType::Subsubitem
+    )
+}
+
+/// One side of a clause, as the bill wrote it.
+#[derive(Debug, PartialEq, Eq)]
+enum Written {
+    /// `(c) and (d)`, or one designation on its own.
+    Listed(Vec<String>),
+    /// `(R) through (Z)`.
+    Range { first: String, last: String },
+}
+
+impl Written {
+    /// True when no designation was read at all.
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Listed(numbers) if numbers.is_empty())
+    }
+}
+
+/// The designations at the front of `text`, and what follows them.
+///
+/// Reading stops at the first token that is not a designation or a word that
+/// joins two of them, so the remainder of the sentence is left alone.
+fn read_designations(text: &str, level: ElementType) -> (Written, &str) {
+    let mut numbers: Vec<String> = Vec::new();
+    let mut range = false;
+    let mut rest = text;
+
+    loop {
+        let trimmed = rest.trim_start_matches([' ', ',']);
+        if let Some(after) = strip_word(trimmed, "and") {
+            rest = after;
+            continue;
+        }
+        if let Some(after) = strip_word(trimmed, "through") {
+            range = true;
+            rest = after;
+            continue;
+        }
+        match read_number(trimmed, level) {
+            Some((number, after)) => {
+                numbers.push(number);
+                rest = after;
+            }
+            None => break,
+        }
+    }
+
+    match (range, numbers.first(), numbers.last()) {
+        (true, Some(first), Some(last)) if numbers.len() == 2 => (
+            Written::Range {
+                first: first.clone(),
+                last: last.clone(),
+            },
+            rest,
+        ),
+        _ => (Written::Listed(numbers), rest),
+    }
+}
+
+/// `text` with `word` removed from the front, when it starts with that whole
+/// word.
+fn strip_word<'a>(text: &'a str, word: &str) -> Option<&'a str> {
+    let rest = text.strip_prefix(word)?;
+    match rest.chars().next() {
+        None => Some(rest),
+        Some(next) if !next.is_ascii_alphanumeric() => Some(rest),
+        Some(_) => None,
+    }
+}
+
+/// One designation at the front of `text`, and what follows it.
+///
+/// A section is written bare — `redesignating section 224 as section 225` —
+/// and every level below it is written in parentheses.
+fn read_number(text: &str, level: ElementType) -> Option<(String, &str)> {
+    if let Some(inside) = text.strip_prefix('(') {
+        let (number, after) = inside.split_once(')')?;
+        let number = number.trim();
+        let plausible = !number.is_empty()
+            && number.len() <= 6
+            && number.chars().all(|c| c.is_ascii_alphanumeric());
+        return plausible.then(|| (number.to_string(), after));
+    }
+    if level != ElementType::Section {
+        return None;
+    }
+    let end = text
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+        .unwrap_or(text.len());
+    let number = &text[..end];
+    let starts_with_digit = number.starts_with(|c: char| c.is_ascii_digit());
+    starts_with_digit.then(|| (number.to_string(), &text[end..]))
+}
+
+/// The text after the `as` that introduces the new designation.
+///
+/// A clause can carry an aside between the two halves — "redesignating
+/// subsection (g), as amended by this section, as subsection (h)" — so the
+/// first `as` is not always the right one. The one that counts is followed by a
+/// level word.
+fn skip_to_new_designation(text: &str) -> Option<&str> {
+    let mut rest = text;
+    loop {
+        let at = rest.to_lowercase().find(" as ")?;
+        let after = &rest[at + " as ".len()..];
+        let after = strip_article(after);
+        if read_level(after).is_ok() {
+            return Some(after);
+        }
+        rest = &rest[at + " as ".len()..];
+    }
+}
+
+/// `text` with a leading `a`, `an` or `the` removed.
+fn strip_article(text: &str) -> &str {
+    for article in ["an ", "a ", "the "] {
+        if let Some(rest) = text.strip_prefix(article) {
+            return rest;
+        }
+    }
+    text
+}
+
+/// Every designation one side of a clause names, in order.
+fn expand(written: &Written, level: ElementType) -> Result<Vec<String>, Reason> {
+    match written {
+        Written::Listed(numbers) => Ok(numbers.clone()),
+        Written::Range { first, last } => {
+            let series = Series::of(level)
+                .ok_or_else(|| Reason::UnknownSeries(level.path_segment_name().to_string()))?;
+            series
+                .between(first, last)
+                .ok_or_else(|| Reason::UnknownSeries(level.path_segment_name().to_string()))
+        }
+    }
+}
+
+/// How the numbers at one level run on.
+///
+/// The drafting convention, which is what a range such as `(R) through (Z) as
+/// (S) through (AA)` relies on: the Code doubles a letter after `(z)`, and
+/// numbers a clause in lower-case roman.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Series {
+    /// `1`, `2`, `3`.
+    Arabic,
+    /// `a` … `z`, then `aa`, `bb`.
+    LowerLetter,
+    /// `A` … `Z`, then `AA`, `BB`.
+    UpperLetter,
+    /// `i`, `ii`, `iii`.
+    LowerRoman,
+    /// `I`, `II`, `III`.
+    UpperRoman,
+}
+
+impl Series {
+    /// The series a level's numbers run in, or `None` where this build does not
+    /// know.
+    ///
+    /// Only a range needs this. A list names every designation, so it is read
+    /// without any convention at all.
+    fn of(level: ElementType) -> Option<Self> {
+        match level {
+            ElementType::Section | ElementType::Paragraph => Some(Self::Arabic),
+            ElementType::Subsection | ElementType::Item => Some(Self::LowerLetter),
+            ElementType::Subparagraph => Some(Self::UpperLetter),
+            ElementType::Clause => Some(Self::LowerRoman),
+            ElementType::Subclause => Some(Self::UpperRoman),
+            _ => None,
+        }
+    }
+
+    /// Every designation from `first` to `last`, both ends included.
+    ///
+    /// `None` when `last` is not reached: a range that runs away is a range this
+    /// build has misread, and a long list of invented designations would be
+    /// worse than saying so.
+    fn between(self, first: &str, last: &str) -> Option<Vec<String>> {
+        /// Long enough for any range the Code writes, short enough that a
+        /// misread range stops rather than filling memory.
+        const LIMIT: usize = 64;
+
+        let mut run = vec![first.to_string()];
+        while run.last().is_some_and(|current| current != last) {
+            if run.len() >= LIMIT {
+                return None;
+            }
+            let next = self.next(run.last()?)?;
+            run.push(next);
+        }
+        Some(run)
+    }
+
+    /// The designation after this one in the series.
+    fn next(self, current: &str) -> Option<String> {
+        match self {
+            Self::Arabic => Some((current.parse::<u32>().ok()? + 1).to_string()),
+            Self::LowerLetter => next_letter_run(current, 'a', 'z'),
+            Self::UpperLetter => next_letter_run(current, 'A', 'Z'),
+            Self::LowerRoman => Some(roman(from_roman(current)? + 1).to_lowercase()),
+            Self::UpperRoman => Some(roman(from_roman(current)? + 1)),
+        }
+    }
+}
+
+/// The letter run after this one: `c` to `d`, `z` to `aa`, `aa` to `bb`.
+///
+/// The Code repeats one letter rather than counting in base 26, so `(z)` is
+/// followed by `(aa)` and never by `(ab)`.
+fn next_letter_run(current: &str, first: char, last: char) -> Option<String> {
+    let mut letters = current.chars();
+    let letter = letters.next()?;
+    if !(first..=last).contains(&letter) || letters.any(|other| other != letter) {
+        return None;
+    }
+    match letter == last {
+        true => Some(first.to_string().repeat(current.chars().count() + 1)),
+        false => Some(
+            char::from_u32(letter as u32 + 1)?
+                .to_string()
+                .repeat(current.chars().count()),
+        ),
+    }
+}
+
+/// A roman numeral as a number, or `None` when it is not one.
+fn from_roman(text: &str) -> Option<u32> {
+    let digit = |c: char| match c.to_ascii_uppercase() {
+        'I' => Some(1),
+        'V' => Some(5),
+        'X' => Some(10),
+        'L' => Some(50),
+        'C' => Some(100),
+        'D' => Some(500),
+        'M' => Some(1000),
+        _ => None,
+    };
+    if text.is_empty() {
+        return None;
+    }
+    let values: Option<Vec<u32>> = text.chars().map(digit).collect();
+    let values = values?;
+    let mut total = 0;
+    for (index, value) in values.iter().enumerate() {
+        match values[index + 1..].iter().any(|later| later > value) {
+            true => total -= *value as i64,
+            false => total += *value as i64,
+        }
+    }
+    u32::try_from(total).ok()
+}
+
+/// A number as an upper-case roman numeral.
+fn roman(mut value: u32) -> String {
+    const DIGITS: [(u32, &str); 13] = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ];
+    let mut written = String::new();
+    for (amount, digit) in DIGITS {
+        while value >= amount {
+            written.push_str(digit);
+            value -= amount;
+        }
+    }
+    written
+}
+
+// --- Resolving the words to paths ---
+
+/// Every section of a document, by USLM identifier, with the node itself.
+///
+/// [`crate::citation::resolve::SectionPaths`] answers the same question with a
+/// path. A redesignation needs the node as well, because a citation such as
+/// `898(c)` names a number and not a level, and only the document can say that
+/// `(c)` is a subsection.
+#[derive(Debug, Default)]
+pub struct SectionIndex<'a> {
+    sections: std::collections::BTreeMap<String, Vec<&'a DocumentNode>>,
+}
+
+impl<'a> SectionIndex<'a> {
+    /// Index every section of one parsed work.
+    pub fn of(work: &'a DocumentNode) -> Self {
+        let mut index = Self::default();
+        index.add(work);
+        index
+    }
+
+    fn add(&mut self, node: &'a DocumentNode) {
+        let is_section = node.data.node_type.local() == ElementType::Section.type_name();
+        if is_section
+            && let Some(id) = crate::uslm::UslmFacts::of(&node.data).and_then(|facts| facts.uslm_id)
+        {
+            self.sections
+                .entry(plain_dashes(&id))
+                .or_default()
+                .push(node);
+        }
+        for child in &node.children {
+            self.add(child);
+        }
+    }
+
+    /// The sections one USLM identifier names, in document order.
+    pub fn get(&self, uslm_id: &str) -> &[&'a DocumentNode] {
+        self.sections
+            .get(&plain_dashes(uslm_id))
+            .map_or(&[], Vec::as_slice)
+    }
+
+    /// How many identifiers are indexed.
+    pub fn len(&self) -> usize {
+        self.sections.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sections.is_empty()
+    }
+}
+
+/// Every dash written as a plain hyphen.
+///
+/// The publisher sets a section number with an en dash — `/us/usc/t26/s1400Z–1` —
+/// and a bill's text types a hyphen. The two name one section, and comparing them
+/// byte for byte reported § 1400Z-1 as a section the Code does not hold.
+fn plain_dashes(text: &str) -> String {
+    text.replace(
+        ['\u{2010}', '\u{2011}', '\u{2012}', '\u{2013}', '\u{2014}'],
+        "-",
+    )
+}
+
+/// Turn stated redesignations into paths, against the document as it read
+/// before the bill.
+///
+/// `document` must be the earlier expression. A redesignation moves a provision
+/// *from* a path, and that path exists only before the move; checking it there
+/// is what keeps a misread clause from becoming a link that points at nothing.
+pub fn resolve(stated: &[StatedRedesignation], document: &DocumentNode) -> RedesignationReport {
+    let index = SectionIndex::of(document);
+    let mut report = RedesignationReport::default();
+    for statement in stated {
+        resolve_one(statement, &index, &mut report);
+    }
+    report
+}
+
+fn resolve_one(
+    statement: &StatedRedesignation,
+    index: &SectionIndex,
+    report: &mut RedesignationReport,
+) {
+    let mut reject = |reason: Reason| {
+        report.unresolved.push(Unresolved {
+            amendment_id: statement.amendment_id.clone(),
+            text: statement.text.clone(),
+            reason,
+        });
+    };
+
+    if let Some(reason) = &statement.unreadable {
+        reject(reason.clone());
+        return;
+    }
+    let Some(section_id) = &statement.section else {
+        reject(Reason::NoSectionNamed);
+        return;
+    };
+    let section = match index.get(section_id) {
+        [] => {
+            reject(Reason::SectionNotHeld(section_id.clone()));
+            return;
+        }
+        [only] => *only,
+        _ => {
+            reject(Reason::ContainerIsAmbiguous(section_id.clone()));
+            return;
+        }
+    };
+
+    let container = match walk_down(section, &statement.container) {
+        Ok(container) => container,
+        Err(reason) => {
+            reject(reason);
+            return;
+        }
+    };
+
+    for renumbering in &statement.renumberings {
+        let from_path = format!(
+            "{}/{}",
+            container.data.path,
+            renumbering.from.path_segment()
+        );
+        // The provision must be where the bill says it was. A link built from a
+        // path no document holds cannot be checked by the party reading it.
+        let held = container
+            .children
+            .iter()
+            .filter(|child| *child.data.path == *from_path)
+            .count();
+        match held {
+            0 => reject(Reason::ProvisionNotHeld(from_path)),
+            1 => report.resolved.push(Redesignation {
+                to_path: format!("{}/{}", container.data.path, renumbering.to.path_segment()),
+                from_path,
+                amendment_id: statement.amendment_id.clone(),
+                text: statement.text.clone(),
+            }),
+            _ => reject(Reason::ContainerIsAmbiguous(from_path)),
+        }
+    }
+}
+
+/// The node the steps lead to, below `section`.
+fn walk_down<'a>(section: &'a DocumentNode, steps: &[Step]) -> Result<&'a DocumentNode, Reason> {
+    let mut current = section;
+    for step in steps {
+        let matches: Vec<&DocumentNode> = current
+            .children
+            .iter()
+            .filter(|child| step_names(step, &child.data.path))
+            .collect();
+        current = match matches.as_slice() {
+            [only] => only,
+            [] => {
+                return Err(Reason::ContainerNotHeld(format!(
+                    "{}/…_{}",
+                    current.data.path, step.number
+                )));
+            }
+            _ => {
+                return Err(Reason::ContainerIsAmbiguous(format!(
+                    "{}/…_{}",
+                    current.data.path, step.number
+                )));
+            }
+        };
+    }
+    Ok(current)
+}
+
+/// Whether a step names the provision at this path.
+///
+/// A step from a citation carries a number and no level, so the number is what
+/// is compared; where the bill did name a level, it must agree.
+fn step_names(step: &Step, path: &str) -> bool {
+    let Some(segment) = path.rsplit('/').next() else {
+        return false;
+    };
+    let Some((level, number)) = segment.split_once('_') else {
+        return false;
+    };
+    if number != step.number {
+        return false;
+    }
+    match step.level {
+        Some(named) => level == named.path_segment_name(),
+        None => true,
+    }
+}
+
+// --- The link a redesignation becomes ---
+
+impl Redesignation {
+    /// The link that records this redesignation.
+    ///
+    /// Subject and object are both [`Target::Change`]: the provision as it was,
+    /// and the provision as it became, each with the two dates it was observed
+    /// between. A bare provision could not say *when* it moved, and a path is
+    /// reused — a paragraph (3) struck today can be added again later — so a
+    /// dateless edge would claim a renumbering held for all time
+    /// (`docs/adr/0004-links-are-stored-and-identified-by-what-they-say.md`).
+    ///
+    /// Both ends carry the same work and the same dates. An edge whose two ends
+    /// sit in different works is permitted by the model, because a section can
+    /// be transferred between titles, and the corpus has none; nothing is built
+    /// for it here.
+    pub fn link(
+        &self,
+        work: &crate::dataset::WorkId,
+        from_date: &str,
+        to_date: &str,
+        bill_id: &str,
+    ) -> Link {
+        let kind = LinkKind::new(LinkKind::REDESIGNATED_AS);
+        Link {
+            subject: Target::Change {
+                work: work.clone(),
+                path: self.from_path.clone(),
+                from_date: from_date.to_string(),
+                to_date: to_date.to_string(),
+            },
+            object: Target::Change {
+                work: work.clone(),
+                path: self.to_path.clone(),
+                from_date: from_date.to_string(),
+                to_date: to_date.to_string(),
+            },
+            provenance: Provenance {
+                source: "rule:bill_redesignation".to_string(),
+                method: Some("amendingAction type=redesignate".to_string()),
+                // A rule read a sentence a source wrote. The bill asserts the
+                // renumbering; the reading of it is a machine's, and no person
+                // has confirmed it.
+                verification: VerificationState::MachineSuggested,
+                evidence: Some(Evidence {
+                    // The words the statement was read out of, so a reviewer can
+                    // check the reading against them.
+                    reasoning: Some(self.text.clone()),
+                    ..Evidence::default()
+                }),
+                raw_score: None,
+                // No clock reading. The same bill gives the same answer on any
+                // day, so a timestamp would only record when the build ran.
+                timestamp: None,
+                corroboration: None,
+            },
+            payload: Some(KindPayload {
+                namespace: kind.namespace().to_string(),
+                value: serde_json::json!({
+                    "bill_id": bill_id,
+                    "amendment_id": self.amendment_id,
+                    "amendment": amendment_reference(bill_id, &self.amendment_id),
+                }),
+            }),
+            kind,
+        }
+    }
+}

--- a/src/link.rs
+++ b/src/link.rs
@@ -39,6 +39,14 @@ impl LinkKind {
     /// An opinion citing a provision.
     pub const CITES: &'static str = "judicial.cites";
 
+    /// A provision renumbered by a bill: the subject became the object.
+    ///
+    /// This is the record that answers "is this the same provision as last
+    /// year". The chain through it is computed on demand and never stored
+    /// (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`,
+    /// `crate::legislature::redesignation`).
+    pub const REDESIGNATED_AS: &'static str = "legislature.redesignated_as";
+
     pub fn new(kind: impl Into<String>) -> Self {
         Self(kind.into())
     }
@@ -474,6 +482,149 @@ pub fn annotations_from_links(links: &[Link]) -> Vec<ChangeAnnotation> {
     }
 
     grouped.into_values().collect()
+}
+
+/// One renumbering in a provision's history.
+///
+/// Read out of a `legislature.redesignated_as` link: the provision sat at
+/// `from_path` in the expression of `from_date`, and at `to_path` in the
+/// expression of `to_date`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedesignationStep {
+    pub from_path: String,
+    pub to_path: String,
+    pub from_date: String,
+    pub to_date: String,
+}
+
+/// The renumberings one provision ran through, oldest first.
+///
+/// A **projection**. Nothing stores it: it is walked out of the links each time
+/// it is asked for, so a bill added later adds an edge rather than rewriting an
+/// identity, and nothing that already points somewhere breaks
+/// (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`).
+///
+/// This is the answer to "is this the same provision as last year", which
+/// `docs/adr/0001-structural-paths-locate-not-identify.md` says has none.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProvisionHistory {
+    /// The path that was asked about.
+    pub path: String,
+    /// Every renumbering, oldest first. Empty when this dataset knows of none,
+    /// which is the ordinary case: most provisions keep their number.
+    pub steps: Vec<RedesignationStep>,
+}
+
+impl ProvisionHistory {
+    /// Every path the provision has held, oldest first, ending at the newest.
+    pub fn paths(&self) -> Vec<&str> {
+        let mut paths: Vec<&str> = self
+            .steps
+            .iter()
+            .map(|step| step.from_path.as_str())
+            .collect();
+        match self.steps.last() {
+            Some(last) => paths.push(&last.to_path),
+            None => paths.push(&self.path),
+        }
+        paths
+    }
+
+    /// The earliest path this dataset knows for the provision.
+    ///
+    /// The path itself when no renumbering is known, which is an answer and not
+    /// a failure: the provision has always been where it is.
+    pub fn earliest(&self) -> &str {
+        self.steps
+            .first()
+            .map_or(self.path.as_str(), |step| step.from_path.as_str())
+    }
+
+    /// The newest path this dataset knows for the provision.
+    pub fn latest(&self) -> &str {
+        self.steps
+            .last()
+            .map_or(self.path.as_str(), |step| step.to_path.as_str())
+    }
+
+    /// Whether the two paths name one provision across the renumberings known.
+    pub fn covers(&self, path: &str) -> bool {
+        self.paths().contains(&path)
+    }
+}
+
+/// Walk the redesignation links to a provision's history.
+///
+/// Both directions from `path`: backwards to the earliest name the links give it,
+/// and forwards to the latest. A link of another kind is skipped.
+///
+/// Walking a list rather than querying twice per step is deliberate. The links
+/// table is indexed on the subject's path, which answers the forward direction,
+/// and on the kind, which is enough to fetch every redesignation in a dataset —
+/// there are tens of them, not millions. The backward direction would need an
+/// index on the *object's* path, and adding one would change the stored shape for
+/// a query that is already fast.
+///
+/// A cycle cannot happen in the law, and a misread bill could still write one, so
+/// a path already seen stops the walk instead of looping for ever.
+pub fn history_from_links(path: &str, links: &[Link]) -> ProvisionHistory {
+    let redesignated_as = LinkKind::new(LinkKind::REDESIGNATED_AS);
+    let steps: Vec<RedesignationStep> = links
+        .iter()
+        .filter(|link| link.kind == redesignated_as)
+        .filter_map(step_of)
+        .collect();
+
+    let mut history = ProvisionHistory {
+        path: path.to_string(),
+        steps: Vec::new(),
+    };
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    seen.insert(path.to_string());
+
+    // Backwards: what this provision used to be called.
+    let mut earliest = path.to_string();
+    while let Some(step) = steps.iter().find(|step| step.to_path == earliest) {
+        if !seen.insert(step.from_path.clone()) {
+            break;
+        }
+        earliest = step.from_path.clone();
+        history.steps.insert(0, step.clone());
+    }
+
+    // Forwards: what it became.
+    let mut latest = path.to_string();
+    while let Some(step) = steps.iter().find(|step| step.from_path == latest) {
+        if !seen.insert(step.to_path.clone()) {
+            break;
+        }
+        latest = step.to_path.clone();
+        history.steps.push(step.clone());
+    }
+
+    history
+}
+
+/// One step, read out of a link whose two ends name changes.
+fn step_of(link: &Link) -> Option<RedesignationStep> {
+    let (
+        Target::Change {
+            path: from_path,
+            from_date,
+            to_date,
+            ..
+        },
+        Target::Change { path: to_path, .. },
+    ) = (&link.subject, &link.object)
+    else {
+        return None;
+    };
+    Some(RedesignationStep {
+        from_path: from_path.clone(),
+        to_path: to_path.clone(),
+        from_date: from_date.clone(),
+        to_date: to_date.clone(),
+    })
 }
 
 /// Map a verification state back onto a stored status.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -234,6 +234,25 @@ pub trait LinkReader {
     fn annotation_pairs(&self) -> Result<Vec<crate::dataset::ExpressionPair>, DatasetError> {
         self.link_pairs()
     }
+
+    /// The renumberings one provision ran through, oldest first.
+    ///
+    /// This is how "is this the same provision as last year" is answered: by
+    /// walking the `legislature.redesignated_as` links, forwards and backwards.
+    /// No identity is minted and nothing is stored, so a bill added later adds an
+    /// edge instead of rewriting an identity
+    /// (`docs/adr/0007-a-record-is-what-was-said-everything-else-is-derived.md`,
+    /// #93).
+    ///
+    /// Answered from `links_by_kind`, which the backends index. A dataset holds
+    /// tens of redesignations rather than millions, so the walk happens in
+    /// memory; the backward direction would otherwise need an index on the
+    /// object's path, and adding a column for a query this cheap would change the
+    /// stored shape for nothing.
+    fn provision_history(&self, path: &str) -> Result<crate::link::ProvisionHistory, DatasetError> {
+        let links = self.links_by_kind(crate::link::LinkKind::REDESIGNATED_AS)?;
+        Ok(crate::link::history_from_links(path, &links))
+    }
 }
 
 /// Reading the legislature facts a dataset holds.

--- a/src/uslm/bill_parser.rs
+++ b/src/uslm/bill_parser.rs
@@ -128,7 +128,7 @@ pub fn parse_bill_amendments(bill_id: &str, path: &str) -> Result<Bill> {
 /// The ID is a SHA256 hash of "{bill_id}:{amending_text}", providing a stable,
 /// deterministic identifier that works regardless of the source format (USLM XML,
 /// plaintext, etc.).
-fn compute_amendment_id(bill_id: &str, amending_text: &str) -> String {
+pub(crate) fn compute_amendment_id(bill_id: &str, amending_text: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(format!("{}:{}", bill_id, amending_text));
     let result = hasher.finalize();
@@ -201,7 +201,7 @@ fn get_amendment_data(node: &Node, bill_id: &str) -> BillAmendment {
     }
 }
 
-fn node_text(node: &Node) -> String {
+pub(crate) fn node_text(node: &Node) -> String {
     let raw: String = node
         .descendants()
         .filter(|n| n.is_text())

--- a/src/uslm/bill_redesignation.rs
+++ b/src/uslm/bill_redesignation.rs
@@ -1,0 +1,470 @@
+//! Reading the redesignations a bill states, out of USLM markup.
+//!
+//! The words of a redesignation are domain, and
+//! [`crate::legislature::redesignation`] reads them. What lives here is the part
+//! that belongs to one publisher's markup: *where in the bill* the words sat, and
+//! therefore which provision they are about.
+//!
+//! # Why the markup and not the flat text
+//!
+//! A bill nests its instructions:
+//!
+//! ```text
+//! Section 163(h)(3)(F) is amended--
+//!   (1) in clause (i)--
+//!         (B) by redesignating subclauses (III) and (IV) as subclauses (IV) and (V)
+//!   (2) by striking clause (ii) and redesignating clauses (iii) and (iv) as ...
+//! ```
+//!
+//! The first redesignation is inside clause (i); the second is not, because
+//! item (2) closed that scope. Flattened to one string the two read alike, and a
+//! scan backwards for the nearest "in clause (i)" attaches the second one to the
+//! wrong provision. The markup says which is which, so the markup is what is
+//! read.
+//!
+//! # What is resolved here and what is not
+//!
+//! This module answers "which section, and which container inside it". It does
+//! not touch the US Code, so it cannot say whether that provision exists;
+//! [`crate::legislature::redesignation::resolve`] does that against a document.
+//!
+//! A statement whose section this module cannot name still comes back, carrying
+//! the reason. Dropping it would make the tool's silence read as the corpus's
+//! silence, which is the rule #110 set for unknown elements.
+
+use std::str::FromStr;
+use std::sync::LazyLock;
+
+use regex::Regex;
+use roxmltree::{Document, Node};
+
+use crate::io::load_xml_file;
+use crate::legislature::redesignation::{Reason, StatedRedesignation, Step, read_clause};
+use crate::uslm::ElementType;
+use crate::uslm::parser::{ParseError, normalize_quotes};
+
+pub type Result<T> = std::result::Result<T, ParseError>;
+
+/// Every redesignation a bill states, in document order.
+///
+/// One entry per `redesignate` action in the markup, whether or not it could be
+/// placed. `bill_id` travels through to the links the statements become.
+///
+/// # Examples
+///
+/// ```
+/// use words_to_data::uslm::bill_redesignation::redesignations_stated_in_file;
+///
+/// let stated = redesignations_stated_in_file(
+///     "119-hr-1",
+///     "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml",
+/// )
+/// .unwrap();
+/// assert_eq!(stated.len(), 57);
+/// ```
+pub fn redesignations_stated_in_file(
+    bill_id: &str,
+    path: &str,
+) -> Result<Vec<StatedRedesignation>> {
+    let xml = load_xml_file(path)?;
+    redesignations_stated(bill_id, &xml)
+}
+
+/// Every redesignation a bill states, read from markup already in memory.
+pub fn redesignations_stated(bill_id: &str, xml: &str) -> Result<Vec<StatedRedesignation>> {
+    let document = Document::parse(xml)?;
+    let code_of_1986 = titles_declaring_the_1986_code(&document);
+    Ok(document
+        .root()
+        .descendants()
+        .filter(is_redesignate_action)
+        .map(|action| read_action(bill_id, action, &code_of_1986))
+        .collect())
+}
+
+/// The bill titles that declare a bare section reference to mean the Internal
+/// Revenue Code, by their USLM identifier.
+///
+/// A tax bill opens with a References clause: "whenever in this title, an
+/// amendment … is expressed in terms of an amendment to … a section …, the
+/// reference shall be considered to be made to a section … of the Internal
+/// Revenue Code of 1986". That is the bill telling the reader which title of the
+/// Code a bare `Section 898` means, so it is read from the bill rather than
+/// assumed. `119-hr-1` declares it once, for its title VII.
+///
+/// The clause scopes itself — "in this title" — so the declaration is recorded
+/// against the title that holds it and reaches no further. The same bill
+/// declares the Immigration and Nationality Act for another subtitle, which is
+/// not the US Code at all, and a rule that ignored scope would read one as the
+/// other.
+fn titles_declaring_the_1986_code(document: &Document) -> Vec<String> {
+    document
+        .root()
+        .descendants()
+        .filter(|node| {
+            node.tag_name().name().eq_ignore_ascii_case("title")
+                && node.attribute("identifier").is_some()
+        })
+        .filter(|title| declares_the_1986_code(title))
+        .filter_map(|title| title.attribute("identifier").map(str::to_string))
+        .collect()
+}
+
+/// Whether a bill title carries the References clause, in its own words.
+fn declares_the_1986_code(title: &Node) -> bool {
+    title
+        .descendants()
+        .filter(|node| node.tag_name().name().eq_ignore_ascii_case("content"))
+        .any(|content| {
+            let text = collapse_spaces(
+                &content
+                    .descendants()
+                    .filter(Node::is_text)
+                    .filter_map(|node| node.text())
+                    .collect::<String>(),
+            );
+            text.contains("whenever in this title")
+                && text.contains("Internal Revenue Code of 1986")
+        })
+}
+
+/// Whether a node is an `<amendingAction type="redesignate">`.
+fn is_redesignate_action(node: &Node) -> bool {
+    node.tag_name()
+        .name()
+        .eq_ignore_ascii_case("amendingAction")
+        && node.attribute("type") == Some("redesignate")
+}
+
+/// One statement, read from the action and the structure around it.
+fn read_action(bill_id: &str, action: Node, code_of_1986: &[String]) -> StatedRedesignation {
+    let levels: Vec<Node> = action.ancestors().filter(is_level).collect();
+    let clause = levels.first().map(own_text).unwrap_or_default();
+
+    // The container, from `in subsection (a)` phrases. Read innermost-first,
+    // because the ancestors are, and turned round at the end so the steps read
+    // outermost-first like a path.
+    let mut container: Vec<Step> = Vec::new();
+    let mut amending_line = None;
+    for (depth, level) in levels.iter().enumerate() {
+        let text = match depth {
+            0 => clause.clone(),
+            _ => own_text(level),
+        };
+        // The clause's own `in clause (i),` prefix counts as well: a bill writes
+        // a one-line instruction either way.
+        if let Some(step) = leading_in_phrase(&text) {
+            container.push(step);
+        }
+        if let Some(line) = amending_line_of(&text) {
+            amending_line = Some((line, *level));
+            break;
+        }
+    }
+    container.reverse();
+
+    let mut statement = StatedRedesignation {
+        amendment_id: amendment_id_around(bill_id, action),
+        text: clause.clone(),
+        section: None,
+        container,
+        renumberings: Vec::new(),
+        unreadable: None,
+    };
+
+    // A table of sections is an index of the law rather than law, so the whole
+    // statement is out of scope. Said before the clause is read, because the
+    // clause reads as nonsense — "the item relating to section 224" — and the
+    // reason a reader needs is the one about the table.
+    if amending_line
+        .as_ref()
+        .is_some_and(|(line, _)| line.contains("table of sections"))
+    {
+        statement.unreadable = Some(Reason::TableOfSections);
+        return statement;
+    }
+
+    match read_clause(&clause) {
+        Ok(renumberings) => statement.renumberings = renumberings,
+        Err(reason) => {
+            statement.unreadable = Some(reason);
+            return statement;
+        }
+    }
+
+    let Some((line, holder)) = amending_line else {
+        statement.unreadable = Some(Reason::NoSectionNamed);
+        return statement;
+    };
+
+    match section_under_amendment(&line, holder, code_of_1986) {
+        Ok((section, trail)) => {
+            statement.section = Some(section);
+            // The citation's own trail sits above anything the `in` phrases
+            // named: `Section 898(c)` reaches the subsection, and `in
+            // paragraph (2)` below it reaches further down.
+            let mut steps: Vec<Step> = trail.into_iter().map(Step::numbered).collect();
+            steps.append(&mut statement.container);
+            statement.container = steps;
+        }
+        Err(reason) => statement.unreadable = Some(reason),
+    }
+    statement
+}
+
+// --- Reading the markup ---
+
+/// The id of the amendment this action belongs to.
+///
+/// The same content hash [`crate::uslm::bill_parser`] mints, over the same text:
+/// the innermost enclosing `role="instruction"` element. That is what makes the
+/// link's payload point at an amendment the dataset actually holds, rather than
+/// at a hash of a sentence nothing else knows.
+///
+/// A bill nests instructions, so the innermost one is the tightest amendment the
+/// parser extracted around this action.
+fn amendment_id_around(bill_id: &str, action: Node) -> String {
+    let instruction = action
+        .ancestors()
+        .find(|node| node.attribute("role") == Some("instruction"));
+    let text = instruction
+        .map(|node| crate::uslm::bill_parser::node_text(&node))
+        .unwrap_or_default();
+    crate::uslm::bill_parser::compute_amendment_id(bill_id, &text)
+}
+
+/// The element type a USLM tag name names, or `Unknown`.
+///
+/// [`ElementType::from_str`] never fails — an unknown name is `Unknown` — and
+/// naming that here keeps the `unwrap` out of the readers below.
+fn element_type_of(tag_name: &str) -> ElementType {
+    ElementType::from_str(tag_name).unwrap_or(ElementType::Unknown)
+}
+
+/// Whether a node is a level of the bill's own hierarchy.
+///
+/// These are the elements that carry a number and hold others, so they are the
+/// ones whose text can open a scope. Anything else — a heading, a sidenote, a
+/// `<ref>` — is part of its level's own words.
+fn is_level(node: &Node) -> bool {
+    if !node.is_element() {
+        return false;
+    }
+    !matches!(
+        element_type_of(node.tag_name().name()),
+        ElementType::Unknown | ElementType::Level
+    )
+}
+
+/// The words of one level, without the levels nested inside it.
+///
+/// A level's own text is the instruction it gives. Its children give their own,
+/// and reading them here would fold a whole subtree of instructions into one
+/// sentence. Quoted content is skipped for the same reason it is skipped
+/// everywhere else: it is the text the bill enacts, not law in force, and it is
+/// full of sentences that look like citations.
+fn own_text(level: &Node) -> String {
+    let mut text = String::new();
+    for child in level.children() {
+        if child.is_text() {
+            text.push_str(child.text().unwrap_or_default());
+            continue;
+        }
+        if is_level(&child)
+            || child
+                .tag_name()
+                .name()
+                .eq_ignore_ascii_case("quotedContent")
+        {
+            continue;
+        }
+        for descendant in child.descendants().filter(Node::is_text) {
+            text.push_str(descendant.text().unwrap_or_default());
+        }
+    }
+    normalize_quotes(&collapse_spaces(&text))
+}
+
+/// One run of whitespace as one space, so a pattern does not have to allow for
+/// the line breaks in the markup.
+fn collapse_spaces(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// The part of a level's text before `is amended`, when it says that.
+///
+/// This is where a bill names what it is about to change. Everything after it is
+/// the instruction, which can mention any number of other provisions.
+fn amending_line_of(text: &str) -> Option<String> {
+    static AMENDED: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\b(?:is|are)\s+amended").unwrap());
+    let found = AMENDED.find(text)?;
+    Some(text[..found.start()].to_string())
+}
+
+/// The step a leading `in subsection (a)` phrase names.
+///
+/// Only at the front of the text, and only with the level spelt out, so a
+/// mention further along the instruction — "by inserting after paragraph (6)" —
+/// cannot be read as a scope.
+fn leading_in_phrase(text: &str) -> Option<Step> {
+    static IN_PHRASE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^\s*(?:\([0-9A-Za-z]{1,6}\)\s*)?in\s+([a-z]+)\s+\(([0-9A-Za-z]{1,6})\)")
+            .unwrap()
+    });
+    let found = IN_PHRASE.captures(text)?;
+    let level = match element_type_of(&found[1]) {
+        ElementType::Unknown | ElementType::Level => return None,
+        level => level,
+    };
+    Some(Step::named(level, &found[2]))
+}
+
+/// The section a level's amending line names, as a USLM identifier, and the
+/// designations the citation gives below it.
+///
+/// Three forms, in the order they are trusted.
+///
+/// 1. `Section 2881a of title 10, United States Code` — the bill says which
+///    title, so nothing has to be inferred.
+/// 2. `Section 6(o) of the Food and Nutrition Act of 2008 (7 U.S.C. 2015(o))` —
+///    the citation numbers a section of an Act, and the publisher's own `<ref>`
+///    beside it gives the place in the Code. The reference is the authority, so
+///    the trail comes from it and not from the Act's numbering. A reference whose
+///    text says `note` is refused: the Act is *not* codified at that section,
+///    and treating the note's home as the provision would point a link at
+///    somebody else's law.
+/// 3. A bare `Section 898(c)`, first against the publisher's own marginal
+///    reference to the same section number — `26 USC 898` — and then against the
+///    bill's References clause, which declares for a whole bill title that a
+///    bare section means the Internal Revenue Code
+///    ([`titles_declaring_the_1986_code`]).
+///
+/// Where none of the three answers, the statement is reported with
+/// [`Reason::NoTitleForSection`]. A title nobody told us is a confident guess,
+/// and this is the one place a wrong guess would silently move a provision
+/// between titles of the Code.
+fn section_under_amendment(
+    line: &str,
+    holder: Node,
+    code_of_1986: &[String],
+) -> std::result::Result<(String, Vec<String>), Reason> {
+    static CITATION: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)section\s+([0-9][0-9A-Za-z\-]*)\s*((?:\([0-9A-Za-z]{1,6}\))*)").unwrap()
+    });
+    static OF_TITLE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)of\s+title\s+([0-9]+[A-Za-z]?)\b").unwrap());
+
+    let cited = CITATION.captures(line).ok_or(Reason::NoSectionNamed)?;
+    let number = cited[1].to_string();
+    let trail = designations_in(&cited[2]);
+
+    if let Some(titled) = OF_TITLE.captures(line) {
+        return Ok((uslm_section_id(&titled[1], &number), trail));
+    }
+
+    let names_an_act = line.contains(" of the ");
+    if names_an_act && let Some(reference) = codified_reference(holder, line) {
+        return Ok((
+            uslm_section_id(&reference.title, &reference.section),
+            reference.trail,
+        ));
+    }
+
+    // A bare section: the title must come from the publisher, not from us.
+    let mut scope = Some(holder);
+    while let Some(node) = scope {
+        let confirming = usc_references(node)
+            .into_iter()
+            .find(|reference| reference.section == number);
+        if let Some(reference) = confirming {
+            return Ok((uslm_section_id(&reference.title, &number), trail));
+        }
+        if node.tag_name().name().eq_ignore_ascii_case("section") {
+            break;
+        }
+        scope = node.parent().filter(|parent| is_level(parent));
+    }
+
+    // The bill's own References clause, which says for a whole title of the bill
+    // that a bare section means the Internal Revenue Code of 1986 — title 26.
+    let in_a_declaring_title = holder.ancestors().any(|ancestor| {
+        ancestor.tag_name().name().eq_ignore_ascii_case("title")
+            && ancestor
+                .attribute("identifier")
+                .is_some_and(|id| code_of_1986.iter().any(|declared| declared == id))
+    });
+    if in_a_declaring_title {
+        return Ok((uslm_section_id(INTERNAL_REVENUE_CODE, &number), trail));
+    }
+
+    Err(Reason::NoTitleForSection(number))
+}
+
+/// The title of the US Code the Internal Revenue Code of 1986 is.
+const INTERNAL_REVENUE_CODE: &str = "26";
+
+/// `/us/usc/t26/s898`, the identifier a parsed section carries.
+fn uslm_section_id(title: &str, section: &str) -> String {
+    format!("/us/usc/t{title}/s{section}")
+}
+
+/// The numbers in a run of parentheses: `(c)(1)(A)` becomes `c`, `1`, `A`.
+fn designations_in(parenthesised: &str) -> Vec<String> {
+    parenthesised
+        .split(['(', ')'])
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// A reference into the US Code, as the publisher wrote it.
+struct UscReference {
+    title: String,
+    section: String,
+    /// The designations below the section, from the reference's own path.
+    trail: Vec<String>,
+    /// The words on the page, which say whether the reference is to the section
+    /// or to the notes under it.
+    display: String,
+}
+
+/// The reference in an amending line that gives the codified home of the Act it
+/// names.
+///
+/// Taken from the line's own words rather than from the whole element: an
+/// instruction quotes the text it enacts, and that text cites other statutes.
+fn codified_reference(holder: Node, line: &str) -> Option<UscReference> {
+    usc_references(holder).into_iter().find(|reference| {
+        line.contains(reference.display.trim()) && !reference.display.contains("note")
+    })
+}
+
+/// Every US Code reference in a subtree.
+fn usc_references(node: Node) -> Vec<UscReference> {
+    node.descendants()
+        .filter(|child| child.tag_name().name().eq_ignore_ascii_case("ref"))
+        .filter_map(|child| {
+            let href = child.attribute("href")?;
+            let rest = href.strip_prefix("/us/usc/t")?;
+            let (title, rest) = rest.split_once("/s")?;
+            let mut parts = rest.split('/');
+            let section = parts.next()?.to_string();
+            let display: String = child
+                .descendants()
+                .filter(Node::is_text)
+                .filter_map(|text| text.text())
+                .collect();
+            Some(UscReference {
+                title: title.to_string(),
+                section,
+                trail: parts
+                    .filter(|part| !part.is_empty())
+                    .map(str::to_string)
+                    .collect(),
+                display: collapse_spaces(&display),
+            })
+        })
+        .collect()
+}

--- a/src/uslm/mod.rs
+++ b/src/uslm/mod.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 use crate::document::{ClassPayload, NodeData, NodeType};
 
 pub mod bill_parser;
+pub mod bill_redesignation;
 pub mod parser;
 pub mod path;
 

--- a/tests/redesignation_tests.rs
+++ b/tests/redesignation_tests.rs
@@ -1,0 +1,463 @@
+//! Redesignations: a provision a bill renumbered, and the link that records it.
+//!
+//! Every case here is read out of the committed corpus. The motivating one is
+//! `119-hr-1`: "Section 898(c) is amended by striking paragraph (2) and
+//! redesignating paragraph (3) as paragraph (2)."
+
+use std::process::Command;
+
+use words_to_data::dataset::{
+    Dataset, DatasetMetadata, Expression, ExpressionId, Format, WorkId, work_roots,
+};
+use words_to_data::diff::{Redesignations, TreeDiff};
+use words_to_data::legislature::redesignation::{RedesignationReport, Step, read_clause, resolve};
+use words_to_data::link::{LinkKind, Target, VerificationState};
+use words_to_data::storage::{InMemoryStorage, LinkReader};
+use words_to_data::uslm::bill_redesignation::redesignations_stated_in_file;
+use words_to_data::uslm::parser::parse;
+
+/// The committed public law, which holds every redesignation in the corpus.
+const BILL: &str = "tests/test_data/congress_client_cache/bill/119/hr/1/public_law.xml";
+const BILL_ID: &str = "119-hr-1";
+
+/// Title 26 before and after `119-hr-1` reached the Code.
+const TITLE_26_BEFORE: &str = "tests/test_data/usc/2025-07-18/usc26.xml";
+const TITLE_26_AFTER: &str = "tests/test_data/usc/2025-07-30/usc26.xml";
+const BEFORE: &str = "2025-07-18";
+const AFTER: &str = "2025-07-30";
+
+/// § 898(c), the provision the diff reported wrongly before this existed.
+const SUBSECTION_898_C: &str =
+    "uscode/title_26/subtitle_A/chapter_1/subchapter_N/part_II/subpart_D/section_898/subsection_c";
+
+#[test]
+fn should_read_one_renumbering_when_the_clause_names_one_paragraph() {
+    // 119-hr-1, § 70352(a). The motivating case.
+    let clause = "Section 898(c) is amended by striking paragraph (2) and \
+                  redesignating paragraph (3) as paragraph (2).";
+
+    let renumberings = read_clause(clause).expect("the clause should be readable");
+
+    let written: Vec<String> = renumberings.iter().map(ToString::to_string).collect();
+    assert_eq!(written, vec!["paragraph_3 -> paragraph_2"]);
+}
+
+#[test]
+fn should_name_the_section_under_amendment_when_the_bill_states_a_redesignation() {
+    let stated = redesignations_stated_in_file(BILL_ID, BILL).expect("the bill should parse");
+
+    let found = stated
+        .iter()
+        .find(|s| s.text.contains("Section 898(c)"))
+        .expect("the bill states a redesignation in section 898(c)");
+
+    assert_eq!(found.section.as_deref(), Some("/us/usc/t26/s898"));
+    assert_eq!(found.container, vec![Step::numbered("c")]);
+    let written: Vec<String> = found.renumberings.iter().map(ToString::to_string).collect();
+    assert_eq!(written, vec!["paragraph_3 -> paragraph_2"]);
+}
+
+#[test]
+fn should_resolve_the_paragraph_898_c_renumbered_when_title_26_is_in_hand() {
+    let stated = redesignations_stated_in_file(BILL_ID, BILL).expect("the bill should parse");
+    let before = parse(TITLE_26_BEFORE, BEFORE).expect("title 26 should parse");
+
+    let report = resolve(&stated, &before);
+
+    let moved = report
+        .resolved
+        .iter()
+        .find(|r| r.from_path == format!("{SUBSECTION_898_C}/paragraph_3"))
+        .expect("paragraph (3) of § 898(c) should resolve");
+    assert_eq!(moved.to_path, format!("{SUBSECTION_898_C}/paragraph_2"));
+}
+
+/// The paths of the children one diff node reports as removed.
+fn removed_paths(at: &words_to_data::diff::TreeDiff) -> Vec<String> {
+    at.removed
+        .iter()
+        .map(|node| node.path.to_string())
+        .collect()
+}
+
+#[test]
+fn should_report_a_renumbered_paragraph_as_rewritten_when_no_redesignation_is_known() {
+    // What the diff said before this existed, and what it still says with no
+    // redesignation in hand. Old (2) was struck and old (3) took its number, so
+    // pairing by position reads old (2) against a paragraph that is really old
+    // (3): a large rewrite, plus children appearing out of nowhere.
+    let before = parse(TITLE_26_BEFORE, BEFORE).expect("title 26 should parse");
+    let after = parse(TITLE_26_AFTER, AFTER).expect("title 26 should parse");
+
+    let diff = TreeDiff::from_nodes(&before, &after);
+    let at = diff.find(SUBSECTION_898_C).expect("§ 898(c) changed");
+
+    let rewritten = at
+        .child_diffs
+        .iter()
+        .find(|child| child.root_path.ends_with("/paragraph_2"))
+        .expect("paragraph (2) reads as rewritten");
+    assert!(!rewritten.changes.is_empty(), "its words read as changed");
+    assert!(
+        !rewritten.added.is_empty(),
+        "and it reads as gaining children"
+    );
+    assert_eq!(
+        removed_paths(at),
+        vec![format!("{SUBSECTION_898_C}/paragraph_3")],
+        "and paragraph (3) reads as simply gone"
+    );
+    assert!(at.moved.is_empty(), "nothing is reported as moved");
+}
+
+#[test]
+fn should_report_a_renumbered_paragraph_as_moved_when_the_bill_said_so() {
+    let stated = redesignations_stated_in_file(BILL_ID, BILL).expect("the bill should parse");
+    let before = parse(TITLE_26_BEFORE, BEFORE).expect("title 26 should parse");
+    let after = parse(TITLE_26_AFTER, AFTER).expect("title 26 should parse");
+    let known = Redesignations::from_pairs(
+        resolve(&stated, &before)
+            .resolved
+            .iter()
+            .map(|r| (r.from_path.clone(), r.to_path.clone())),
+    );
+
+    let diff = TreeDiff::from_nodes_with(&before, &after, &known);
+    let at = diff.find(SUBSECTION_898_C).expect("§ 898(c) changed");
+
+    // Paragraph (2) was struck.
+    assert_eq!(
+        removed_paths(at),
+        vec![format!("{SUBSECTION_898_C}/paragraph_2")]
+    );
+    // Paragraph (3) became paragraph (2), with its words untouched.
+    let moved: Vec<(String, String)> = at
+        .moved
+        .iter()
+        .map(|m| (m.from.path.to_string(), m.to.path.to_string()))
+        .collect();
+    assert_eq!(
+        moved,
+        vec![(
+            format!("{SUBSECTION_898_C}/paragraph_3"),
+            format!("{SUBSECTION_898_C}/paragraph_2"),
+        )]
+    );
+    assert!(
+        at.moved[0].changes.is_empty(),
+        "the renumbering changed no words"
+    );
+    // And nothing reads as a rewrite of paragraph (2), which is the false
+    // statement this whole change exists to remove.
+    assert!(at.child_diffs.is_empty(), "no child reads as changed");
+    assert!(at.added.is_empty(), "no child reads as added");
+}
+
+#[test]
+fn should_pair_by_position_when_no_bill_redesignated_the_path() {
+    // § 6724(d)(2), where two subparagraphs (JJ) became one between these two
+    // release points and no bill in the corpus redesignated anything in the
+    // section. Its pairing must be untouched, whether or not redesignations are
+    // known elsewhere in the title
+    // (`docs/adr/0001-structural-paths-locate-not-identify.md`).
+    let stated = redesignations_stated_in_file(BILL_ID, BILL).expect("the bill should parse");
+    let before = parse(TITLE_26_BEFORE, BEFORE).expect("title 26 should parse");
+    let after = parse(TITLE_26_AFTER, AFTER).expect("title 26 should parse");
+    let known = Redesignations::from_pairs(
+        resolve(&stated, &before)
+            .resolved
+            .iter()
+            .map(|r| (r.from_path.clone(), r.to_path.clone())),
+    );
+
+    let by_position = TreeDiff::from_nodes(&before, &after);
+    let over_links = TreeDiff::from_nodes_with(&before, &after, &known);
+
+    let by_position_at = find_section(&by_position, "section_6724");
+    let over_links_at = find_section(&over_links, "section_6724");
+    assert!(
+        !by_position_at.is_empty(),
+        "§ 6724 changed between these release points"
+    );
+    assert_eq!(by_position_at, over_links_at);
+}
+
+/// One section's diff, as JSON, found by the last segment of its path.
+///
+/// By segment rather than by whole path, so a test does not have to spell out
+/// every subtitle, chapter and part above the section.
+fn find_section(diff: &TreeDiff, segment: &str) -> String {
+    if diff.root_path.ends_with(segment) {
+        return serde_json::to_string(diff).expect("a diff serializes");
+    }
+    diff.child_diffs
+        .iter()
+        .map(|child| find_section(child, segment))
+        .find(|found| !found.is_empty())
+        .unwrap_or_default()
+}
+
+/// Title 26 at both release points, in a dataset, with `119-hr-1`'s
+/// redesignations recorded as links.
+fn dataset_with_redesignations() -> (
+    Dataset<InMemoryStorage>,
+    ExpressionId,
+    ExpressionId,
+    RedesignationReport,
+) {
+    let work = WorkId::new("uscode/title_26");
+    let mut dataset = Dataset::new(DatasetMetadata::default());
+    for (path, date) in [(TITLE_26_BEFORE, BEFORE), (TITLE_26_AFTER, AFTER)] {
+        let parsed = parse(path, date).expect("title 26 should parse");
+        let root = work_roots(parsed).pop().expect("the file holds one title");
+        dataset
+            .add_expression(Expression {
+                id: ExpressionId::new(work.clone(), date),
+                label: None,
+                root,
+            })
+            .expect("the expression should store");
+    }
+    let from = ExpressionId::new(work.clone(), BEFORE);
+    let to = ExpressionId::new(work, AFTER);
+
+    let stated = redesignations_stated_in_file(BILL_ID, BILL).expect("the bill should parse");
+    let report = dataset
+        .record_redesignations(BILL_ID, &stated, &from, &to)
+        .expect("the redesignations should record");
+    (dataset, from, to, report)
+}
+
+#[test]
+fn should_record_a_link_naming_the_bill_when_a_redesignation_resolves() {
+    let (dataset, _, _, _) = dataset_with_redesignations();
+
+    let links = dataset
+        .links_for_path(&format!("{SUBSECTION_898_C}/paragraph_3"))
+        .expect("links should read");
+    let redesignation = links
+        .iter()
+        .find(|link| link.kind.0 == LinkKind::REDESIGNATED_AS)
+        .expect("paragraph (3) carries a redesignation link");
+
+    // The object names where the provision went, and carries the dates, so the
+    // statement is not read as holding for all time.
+    assert_eq!(
+        redesignation.object,
+        Target::Change {
+            work: WorkId::new("uscode/title_26"),
+            path: format!("{SUBSECTION_898_C}/paragraph_2"),
+            from_date: BEFORE.to_string(),
+            to_date: AFTER.to_string(),
+        }
+    );
+    // And the provenance names the bill that said so.
+    let payload = redesignation.payload.as_ref().expect("a payload");
+    assert_eq!(payload.value["bill_id"], BILL_ID);
+    assert_eq!(
+        redesignation.provenance.verification,
+        VerificationState::MachineSuggested
+    );
+    assert!(
+        redesignation
+            .provenance
+            .evidence
+            .as_ref()
+            .and_then(|e| e.reasoning.as_deref())
+            .is_some_and(|words| words.contains("redesignating paragraph (3)")),
+        "the words the statement was read out of travel with it"
+    );
+}
+
+#[test]
+fn should_report_that_paragraph_2_was_formerly_paragraph_3_when_asked_for_its_history() {
+    let (dataset, _, _, _) = dataset_with_redesignations();
+
+    let history = dataset
+        .provision_history(&format!("{SUBSECTION_898_C}/paragraph_2"))
+        .expect("a history should read");
+
+    assert_eq!(
+        history.earliest(),
+        format!("{SUBSECTION_898_C}/paragraph_3")
+    );
+    assert_eq!(history.latest(), format!("{SUBSECTION_898_C}/paragraph_2"));
+    assert!(history.covers(&format!("{SUBSECTION_898_C}/paragraph_3")));
+    assert_eq!(history.steps.len(), 1);
+    assert_eq!(history.steps[0].from_date, BEFORE);
+    assert_eq!(history.steps[0].to_date, AFTER);
+}
+
+#[test]
+fn should_report_no_renumbering_when_a_provision_kept_its_number() {
+    let (dataset, _, _, _) = dataset_with_redesignations();
+    let untouched = "uscode/title_26/subtitle_F/chapter_61/subchapter_A/part_III/subpart_B/section_6041/subsection_d";
+
+    let history = dataset
+        .provision_history(untouched)
+        .expect("a history should read");
+
+    // An answer, not a failure: the provision has always been where it is.
+    assert!(history.steps.is_empty());
+    assert_eq!(history.earliest(), untouched);
+    assert_eq!(history.paths(), vec![untouched]);
+}
+
+#[test]
+fn should_diff_over_the_links_when_a_dataset_holds_redesignations() {
+    let (dataset, from, to, _) = dataset_with_redesignations();
+
+    let diff = dataset.compute_diff(&from, &to).expect("a diff");
+    let at = diff.find(SUBSECTION_898_C).expect("§ 898(c) changed");
+
+    assert_eq!(
+        removed_paths(at),
+        vec![format!("{SUBSECTION_898_C}/paragraph_2")]
+    );
+    assert_eq!(at.moved.len(), 1);
+    assert_eq!(
+        at.moved[0].to.path.to_string(),
+        format!("{SUBSECTION_898_C}/paragraph_2")
+    );
+    assert!(at.child_diffs.is_empty());
+}
+
+#[test]
+fn should_print_the_statements_it_could_not_place_when_the_command_runs() {
+    // Silence is the failure mode: a run that resolved nothing and said nothing
+    // would read as a corpus with no redesignations in it (#110).
+    let path = format!("{}/redesignations.json", env!("CARGO_TARGET_TMPDIR"));
+    let mut dataset = Dataset::new(DatasetMetadata::default());
+    for (file, date) in [(TITLE_26_BEFORE, BEFORE), (TITLE_26_AFTER, AFTER)] {
+        dataset
+            .add_uslm_xml(file, date, None)
+            .expect("title 26 should load");
+    }
+    dataset
+        .save(&path, Format::Compact)
+        .expect("the fixture should save");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_words_to_data"))
+        .args([
+            "redesignations",
+            &path,
+            "--bill-xml",
+            BILL,
+            "--bill-id",
+            BILL_ID,
+            "--between",
+            BEFORE,
+            AFTER,
+            // Beside the input, not over it, so the fixture stays free of links
+            // and the run can be repeated.
+            "--output",
+            &format!("{}/redesignations_linked.json", env!("CARGO_TARGET_TMPDIR")),
+        ])
+        .output()
+        .expect("the binary should run");
+
+    assert!(output.status.success(), "the command should succeed");
+    let said = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        said.contains("states 57 redesignation(s)"),
+        "it says how many the bill states: {said}"
+    );
+    assert!(
+        said.contains("could not be placed"),
+        "it says which it could not place: {said}"
+    );
+    assert!(
+        said.contains("a table of sections, not a provision"),
+        "and why, in words: {said}"
+    );
+}
+
+/// The titles the corpus's redesignations name, as release-point file names.
+///
+/// Only the titles needed. Sweeping all fifty-seven files to place fifty-seven
+/// statements would spend minutes proving the same thing.
+const TITLES_NAMED: [&str; 7] = [
+    "usc05.xml",
+    "usc07.xml",
+    "usc10.xml",
+    "usc15.xml",
+    "usc20.xml",
+    "usc26.xml",
+    "usc42.xml",
+];
+
+/// The whole corpus's redesignations, resolved against every title they name.
+///
+/// This is the number the issue asks for: how many of the statements in the
+/// corpus become links, and how many are reported instead.
+#[test]
+fn should_resolve_most_of_the_corpus_and_report_the_rest() {
+    let stated = redesignations_stated_in_file(BILL_ID, BILL).expect("the bill should parse");
+
+    let per_work: Vec<RedesignationReport> = TITLES_NAMED
+        .iter()
+        .map(|file| {
+            let path = format!("tests/test_data/usc/{BEFORE}/{file}");
+            let root = parse(&path, BEFORE).unwrap_or_else(|e| panic!("{path} should parse: {e}"));
+            resolve(&stated, &root)
+        })
+        .collect();
+    let report = RedesignationReport::across_works(per_work);
+
+    // What the sweep found, printed so the numbers in the pull request can be
+    // read straight off a run.
+    println!(
+        "stated={} resolved={} unresolved={}",
+        stated.len(),
+        report.resolved.len(),
+        report.unresolved.len()
+    );
+    for unresolved in &report.unresolved {
+        println!("  {}: {}", unresolved.reason, unresolved.text);
+    }
+
+    // Every statement is accounted for: one that resolved nowhere carries a
+    // reason. This is the assertion that keeps a silent parse from passing.
+    let placed: std::collections::HashSet<(&str, &str)> = report
+        .resolved
+        .iter()
+        .map(|r| (r.amendment_id.as_str(), r.text.as_str()))
+        .collect();
+    let named: std::collections::HashSet<(&str, &str)> = report
+        .unresolved
+        .iter()
+        .map(|u| (u.amendment_id.as_str(), u.text.as_str()))
+        .collect();
+    for statement in &stated {
+        let key = (statement.amendment_id.as_str(), statement.text.as_str());
+        assert!(
+            placed.contains(&key) || named.contains(&key),
+            "every statement is either resolved or reported: {}",
+            statement.text
+        );
+    }
+
+    // A run that resolves nothing is the failure this test exists to catch.
+    assert!(
+        report.resolved.len() >= 60,
+        "the corpus's redesignations should mostly resolve, and {} did",
+        report.resolved.len()
+    );
+}
+
+#[test]
+fn should_report_every_redesignation_the_corpus_states() {
+    let stated = redesignations_stated_in_file(BILL_ID, BILL).expect("the bill should parse");
+
+    // 57 `redesignate` actions sit in the committed public law. Each one is a
+    // statement, and none may be dropped: a statement this build cannot place
+    // carries the reason instead.
+    assert_eq!(stated.len(), 57);
+    assert!(stated.iter().all(|s| !s.text.is_empty()));
+    assert!(
+        stated
+            .iter()
+            .all(|s| s.unreadable.is_some() || !s.renumberings.is_empty()),
+        "a statement says what it found or why it found nothing"
+    );
+}


### PR DESCRIPTION
Closes nothing — #93 stays open for the maintainer.

## What this does

A bill says "redesignating paragraph (3) as paragraph (2)". Nothing in the US Code records it, so the diff pairs old (2) against new (2) — which is really old (3) — and reports a rewrite plus a removal. Both statements are false, and both are in the shipped dataset for `26 U.S.C. § 898(c)` today.

A redesignation now becomes a **`legislature.redesignated_as` link**. The subject is the provision as it was, the object is the provision as it became, and both ends are a `Target::Change`, so the edge carries the two dates it was observed between. A path is reused, so a dateless edge would claim a renumbering held for all time.

**No provision identity is minted**, and `docs/adr/0001` is corrected so the next reader does not build the one it recommends. **Nothing stored changes shape:** `SCHEMA_VERSION` stays at 9, `Target` is untouched, and no dataset is rebuilt.

## The before and after for § 898(c)

`words_to_data diff uscode/title_26@2025-07-18 -> @2025-07-30`, the two committed release points.

**Before** — a rewrite of (2), two children out of nowhere, and (3) simply gone:

```
Changed:  .../section_898/subsection_c/paragraph_2
Added:    .../section_898/subsection_c/paragraph_2/subparagraph_A
          .../section_898/subsection_c/paragraph_2/subparagraph_B
Removed:  .../section_898/subsection_c/paragraph_3
```

**After** — (2) struck, (3) renumbered, its words untouched:

```
Changed:  (nothing under § 898(c))
Added:    (nothing under § 898(c))
Removed:  .../section_898/subsection_c/paragraph_2
Moved:    .../section_898/subsection_c/paragraph_3
       -> .../section_898/subsection_c/paragraph_2
```

`TreeDiff` gains a fourth list, `moved`, beside changed, added and removed. A move is none of the three, and folding it into them is the false statement this change removes. `DiffSummary` and the `diff` command report it as well; the list is left out when empty, because "Moved (0)" reads as a claim that nothing moved.

## Resolution rate

The committed corpus holds **57 `redesignate` actions** in one bill (`119-hr-1`, committed twice as `tests/test_data/bills/hr-119-21.xml` and `.../bill/119/hr/1/public_law.xml` — the same file). The issue says 59, which is the count in the maintainer's larger dataset; 57 is what the committed corpus holds and what the tests assert.

Resolved against the seven titles those statements name, at 2025-07-18:

| | |
| --- | --- |
| Statements read out of the bill | **57** |
| Statements resolved to two paths | **44** |
| Links written (a statement can name a list or a range) | **89** |
| Statements reported as unresolvable | **13** |

Every one of the 13 carries a reason, and **none is dropped**. Each reason is a statement about the corpus, not a shrug:

| Count | Reason | Is it a defect? |
| --- | --- | --- |
| 3 | a table of sections, not a provision | No. A table of sections is an index of the law, not law. |
| 3 | no section under amendment was named | Yes, a gap. `Part VII of subchapter B of chapter 1 is amended by redesignating section 224 as section 225` renumbers a whole section inside a *part*. `resolve` starts from a section. Noted in the module docs. |
| 3 | nothing says which title holds section 4 | No. The Radiation Exposure Compensation Act is not codified — its reference reads `42 U.S.C. 2210 note`. Refusing a `note` reference is deliberate; treating the note's home as the provision would point a link at somebody else's law. |
| 1 | nothing says which title holds section 101 | No. Same shape: `7 U.S.C. 1621 note`. |
| 2 | no provision at *path* before the bill | No. `§ 48E(j)` and `§ 16517(c)(3)` are created by an earlier amendment in the same bill, so they exist in no release point. A link built from a path no document holds cannot be checked. |
| 1 | the numbers of a paragraph do not run in a known series | No — it is a drafting error in the law: `redesignating subparagraphs (R) through (V) as paragraphs (S) through (W)`. Letters at the paragraph level. Reported rather than guessed at. |

So of the 13, **three are a real gap in this build** and ten are the corpus saying something a link cannot honestly record.

### How a section is resolved

The hard part was the section under amendment, and the answer is three rules, in order of how far each is trusted — each one a fact read from the bill, never a convention this build invents:

1. `Section 2881a of title 10, United States Code` — the bill says which title.
2. `Section 6(o) of the Food and Nutrition Act of 2008 (7 U.S.C. 2015(o))` — the publisher's own `<ref>` gives the place in the Code, including the trail below the section. A `note` reference is refused.
3. A bare `Section 898(c)` — first against the publisher's marginal reference to the same section number (`26 USC 898`), then against the bill's own References clause: *"whenever in this title, an amendment … is expressed in terms of an amendment to … a section …, the reference shall be considered to be made to … the Internal Revenue Code of 1986."* That clause scopes itself to one title of the bill, and it is recorded against that title only — the same bill declares the Immigration and Nationality Act for another subtitle, which is not the US Code at all.

Where none of the three answers, the statement is reported. A title nobody told us is a guess, and this is the one place a wrong guess would silently move a provision between titles of the Code.

### Why the markup and not the flat text

A bill nests its instructions:

```
Section 163(h)(3)(F) is amended--
  (1) in clause (i)--
        (B) by redesignating subclauses (III) and (IV) as subclauses (IV) and (V)
  (2) by striking clause (ii) and redesignating clauses (iii) and (iv) as ...
```

The first is inside clause (i); the second is not, because item (2) closed that scope. Flattened to one string the two read alike. So `src/uslm/bill_redesignation.rs` walks the markup, and `BillAmendment` — which keeps only the flattened text — is untouched. That is also why nothing stored had to change.

## Continuity is a projection

`LinkReader::provision_history(path)` walks the links both ways and returns the chain, oldest first. Nothing stores it, so a bill added later adds an edge instead of rewriting an identity, and nothing that already points somewhere breaks (`docs/adr/0007`).

Asking for `.../section_898/subsection_c/paragraph_2` reports that it was formerly paragraph (3), with the dates. An empty history is an answer — the provision has always been where it is — and not a failure.

**No new index was needed, and the issue's note on this is slightly wrong.** ADR 0004 promoted the link's *object reference* to a column, but that column is only filled for a `Target::External`, so the backward direction is not indexed today. It does not need to be: the walk fetches every redesignation link through the indexed `kind` column — tens of rows, not millions — and walks them in memory. Adding a column for a query this cheap would change the stored shape for nothing.

## Test evidence

Baseline on `vibes` (`98d0678`), release: **416 passed, 0 failed, 7 ignored**, exit 0. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` both exit 0.

After, release: **431 passed, 0 failed, 7 ignored**, exit 0 (47 binaries). Clippy and fmt both still exit 0.

`tests/redesignation_tests.rs`, 13 tests, every one against the committed corpus and no mocked data:

- `should_read_one_renumbering_when_the_clause_names_one_paragraph` — the motivating clause.
- `should_name_the_section_under_amendment_when_the_bill_states_a_redesignation` — § 898(c) resolves to `/us/usc/t26/s898` and subsection (c).
- `should_report_every_redesignation_the_corpus_states` — all 57, each with a finding or a reason.
- `should_resolve_the_paragraph_898_c_renumbered_when_title_26_is_in_hand`.
- **`should_report_a_renumbered_paragraph_as_rewritten_when_no_redesignation_is_known`** — pins the old, wrong behaviour, so the fix cannot be mistaken for something that was always true.
- **`should_report_a_renumbered_paragraph_as_moved_when_the_bill_said_so`** — the acceptance criterion, asserted directly.
- **`should_pair_by_position_when_no_bill_redesignated_the_path`** — § 6724(d)(2), where two subparagraphs (JJ) became one and no bill redesignated anything. Its diff must be byte-identical with and without links.
- `should_record_a_link_naming_the_bill_when_a_redesignation_resolves` — the link's object, its dates, `bill_id: 119-hr-1`, `MachineSuggested`, and the words the statement was read out of as evidence.
- `should_report_that_paragraph_2_was_formerly_paragraph_3_when_asked_for_its_history`.
- `should_report_no_renumbering_when_a_provision_kept_its_number`.
- `should_diff_over_the_links_when_a_dataset_holds_redesignations` — end to end through a `Dataset`.
- `should_resolve_most_of_the_corpus_and_report_the_rest` — the table above, asserted and printed.
- `should_print_the_statements_it_could_not_place_when_the_command_runs` — drives the binary, and fails if the report is silent.

Plus a doc test on `read_clause` covering a single, a list, and a range.

**One gate could not be run here.** `cargo test` in debug does not fit: the host disk is 100% full (1.7 TB of 1.8 TB used by material that is not this repo), and a debug build of the 47 test binaries runs out of space at about 3.5 GB free even after `cargo clean`. That is an environment limit, not a code one. Release is green and CI runs debug, so please watch the CI result on this PR.

## Out of scope, deliberately

- **`AmendingAction::Move`.** No instance in the committed corpus, so there is no real fixture and `CLAUDE.md` forbids inventing one. The model already permits it — a link's two ends carry a work each, so an edge may cross titles — and **a sample is needed** before it is built. Noted in the module docs; a follow-up issue asks for one.
- **A redesignation stated against a container rather than a section.** The three `Part VII … redesignating section 224 as section 225` statements. Reported, not built.
- **The duplicate-path cases.** `§ 6724(d)(2)` keeps position pairing, and the test above proves it.

## Docs

- `docs/adr/0001` — the Implementation status now says the identity was not built **and will not be**, names the edge that replaced it, and corrects the Consequences claim that the corpus had not shown position pairing's limit. It had: this ADR searched for a swap of two provisions sharing one path and the real shape is a renumbering. The Considered-and-rejected entry on an "alias table of renames" gets a note on why a link is not that table — a reader must carry and report a link it does not understand, so it gets a coarser diff rather than a confident wrong answer, and the link carries provenance naming the bill.
- `CONTEXT.md` — **Provision** no longer promises an identity; **Redesignation** and **Provision history** are new entries beside **Change annotation**; **Diff** gains the fourth verdict.

## New surface

- `legislature::redesignation` — `read_clause`, `resolve`, `Designation`, `Renumbering`, `Reason`, `RedesignationReport`.
- `uslm::bill_redesignation::redesignations_stated{,_in_file}`.
- `diff::Redesignations`, `diff::NodeMove`, `TreeDiff::from_nodes_with`, `TreeDiff::moved`.
- `link::ProvisionHistory`, `link::history_from_links`, `LinkKind::REDESIGNATED_AS`.
- `LinkReader::provision_history`, `Dataset::record_redesignations`.
- `words_to_data redesignations <dataset> --bill-xml … --bill-id … --between FROM TO` — deterministic, no LLM, and it prints every statement it could not place.
